### PR TITLE
Fixing search path for lupdate/lrelease

### DIFF
--- a/ugene.pro
+++ b/ugene.pro
@@ -144,13 +144,14 @@ win32 : UGENE_DEV_NULL = nul
 unix : UGENE_DEV_NULL = /dev/null
 
 UGENE_LRELEASE =
-UGENE_LUPDATE = 
-system(lrelease-qt5 -version > $$UGENE_DEV_NULL 2> $$UGENE_DEV_NULL) {
-    UGENE_LRELEASE = lrelease-qt5
-    UGENE_LUPDATE = lupdate-qt5
-} else : system(lrelease -version > $$UGENE_DEV_NULL 2> $$UGENE_DEV_NULL) {
-    UGENE_LRELEASE = lrelease
-    UGENE_LUPDATE = lupdate
+UGENE_LUPDATE =
+message(Using QT from $$[QT_INSTALL_BINS])
+system($$[QT_INSTALL_BINS]/lrelease-qt5 -version > $$UGENE_DEV_NULL 2> $$UGENE_DEV_NULL) {
+    UGENE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease-qt5
+    UGENE_LUPDATE = $$[QT_INSTALL_BINS]/lupdate-qt5
+} else : system($$[QT_INSTALL_BINS]/lrelease -version > $$UGENE_DEV_NULL 2> $$UGENE_DEV_NULL) {
+    UGENE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease
+    UGENE_LUPDATE = $$[QT_INSTALL_BINS]/lupdate
 }
 
 #foreach 'language'


### PR DESCRIPTION
The only way to build UGENE today is to have all QT tools in path. However the good practice for QT projects is to rely on qmake environment. 

This patch fixes the way UGENE build looks for additional tools like lupdate and lrelease.

After this patch applied QT tools are detected from qmake environment and there is no use of $PATH. So a developer may have multiple QT versions in the same system and rely on qmake only to build UGENE.

Checked Windows & Linux builds
