### PR TITLE
SeqView on Retina

### DIFF
--- a/src/corelibs/U2View/src/ov_msa/MSAEditor.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditor.cpp
@@ -32,7 +32,6 @@
 #include <QSvgGenerator>
 #include <QToolBar>
 #include <QVBoxLayout>
-#include <QWindow>
 
 #include <U2Algorithm/MSADistanceAlgorithm.h>
 #include <U2Algorithm/MSADistanceAlgorithmRegistry.h>
@@ -1031,12 +1030,6 @@ MSAEditorUI::MSAEditorUI(MSAEditor* _editor)
     connect(delSelectionAction, SIGNAL(triggered()), seqArea, SLOT(sl_delCurrentSelection()));
 
     nameList->addAction(delSelectionAction);
-
-    // All pixmap-based views must be updated when you drag'n'dron between high DPI and usual displays
-    QWindow *window = AppContext::getMainWindow()->getQMainWindow()->windowHandle();
-    connect(window, SIGNAL(screenChanged(QScreen*)), nameList, SLOT(sl_onScreenChanged()));
-    connect(window, SIGNAL(screenChanged(QScreen*)), seqArea, SLOT(sl_onScreenChanged()));
-    connect(window, SIGNAL(screenChanged(QScreen*)), consArea, SLOT(sl_onScreenChanged()));
 }
 
 QWidget* MSAEditorUI::createLabelWidget(const QString& text, Qt::Alignment ali){

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusArea.cpp
@@ -246,10 +246,10 @@ void MSAEditorConsensusArea::paintEvent(QPaintEvent *e) {
     assert(s.width() == sas.width());
 
     if (cachedView->size() != s) {
-        assert(completeRedraw);
         delete cachedView;
         cachedView = new QPixmap(s);
         cachedView->setDevicePixelRatio(devicePixelRatio());
+        completeRedraw = true;
     }
 
     if (completeRedraw) {
@@ -522,11 +522,6 @@ void MSAEditorConsensusArea::sl_zoomOperationPerformed( bool resizeModeChanged )
     } else {
         setupFontAndHeight();
     }
-}
-
-void MSAEditorConsensusArea::sl_onScreenChanged() {
-    completeRedraw = true;
-    update();
 }
 
 void MSAEditorConsensusArea::sl_selectionChanged(const MSAEditorSelection& current, const MSAEditorSelection& prev) {

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusArea.h
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusArea.h
@@ -101,7 +101,6 @@ private slots:
     void sl_copyConsensusSequenceWithGaps();
     void sl_configureConsensusAction();
     void sl_zoomOperationPerformed(bool resizeModeChanged);
-    void sl_onScreenChanged(); // For high DPI displays
 
 public:
     void drawContent(QPainter& painter);

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorNameList.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorNameList.cpp
@@ -597,11 +597,6 @@ void MSAEditorNameList::sl_onGroupColorsChanged(const GroupColorSchema& colors) 
     update();
 }
 
-void MSAEditorNameList::sl_onScreenChanged() {
-    completeRedraw = true;
-    update();
-}
-
 //////////////////////////////////////////////////////////////////////////
 // draw methods
 QFont MSAEditorNameList::getFont(bool selected) const {
@@ -636,10 +631,10 @@ QRect MSAEditorNameList::calculateButtonRect(const QRect& itemRect) const {
 void MSAEditorNameList::drawAll() {
     QSize s = size() * devicePixelRatio();
     if (cachedView->size() != s) {
-        assert(completeRedraw);
         delete cachedView;
         cachedView = new QPixmap(s);
         cachedView->setDevicePixelRatio(devicePixelRatio());
+        completeRedraw = true;
     }
     if (completeRedraw) {
         QPainter pCached(cachedView);

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorNameList.h
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorNameList.h
@@ -79,7 +79,6 @@ private slots:
     void sl_modelChanged();
 
     void sl_onGroupColorsChanged(const GroupColorSchema&);
-    void sl_onScreenChanged(); // For high DPI displays
 protected:
     void updateContent();
     virtual void updateScrollBar();

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.cpp
@@ -628,10 +628,10 @@ void MSAEditorSequenceArea::paintEvent(QPaintEvent *e) {
 void MSAEditorSequenceArea::drawAll() {
     QSize s = size() * devicePixelRatio();
     if (cachedView->size() != s) {
-        assert(completeRedraw);
         delete cachedView;
         cachedView = new QPixmap(s);
         cachedView->setDevicePixelRatio(devicePixelRatio());
+        completeRedraw = true;
     }
     if (completeRedraw) {
         QPainter pCached(cachedView);
@@ -2919,11 +2919,6 @@ void MSAEditorSequenceArea::sl_setCollapsingRegions(const QList<QStringList>& co
 void MSAEditorSequenceArea::sl_changeSelectionColor() {
     QColor black(Qt::black);
     selectionColor = (black == selectionColor) ? Qt::darkGray : Qt::black;
-    update();
-}
-
-void MSAEditorSequenceArea::sl_onScreenChanged() {
-    completeRedraw = true;
     update();
 }
 

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.h
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.h
@@ -403,7 +403,6 @@ private slots:
     void sl_alphabetChanged(const MAlignmentModInfo &mi, const DNAAlphabet *prevAlphabet);
 
     void sl_changeSelectionColor();
-    void sl_onScreenChanged(); // For high DPI displays
 
 
 protected:

--- a/src/corelibs/U2View/src/ov_sequence/GSequenceLineView.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/GSequenceLineView.cpp
@@ -536,12 +536,13 @@ void GSequenceLineViewRenderArea::drawFrame(QPainter& p) {
 
 
 void GSequenceLineViewRenderArea::paintEvent(QPaintEvent *e) {
-    QSize cachedViewSize = cachedView->size();
-    QSize currentSize = size();
+    QSize cachedViewSize = cachedView->size() * devicePixelRatio();
+    QSize currentSize = size() * devicePixelRatio();
     if (cachedViewSize != currentSize) {
         view->addUpdateFlags(GSLV_UF_NeedCompleteRedraw);
         delete cachedView;
         cachedView = new QPixmap(currentSize);
+        cachedView->setDevicePixelRatio(devicePixelRatio());
     }
 
     drawAll(this);


### PR DESCRIPTION
Added support of high DPI display for Sequence View and simplified processing of screen changes for MSA Editor.

Before:
<img width="1280" alt="before" src="https://cloud.githubusercontent.com/assets/1551618/20033237/7cc53da8-a39c-11e6-9c97-2957dbc38bfe.png">
After:
<img width="1280" alt="after" src="https://cloud.githubusercontent.com/assets/1551618/20033236/7cc2c140-a39c-11e6-8b85-5ac405146ac4.png">