### PR TITLE
Fix build against Qt 5.10

### DIFF
--- a/src/plugins/external_tool_support/src/bowtie2/Bowtie2Settings.ui
+++ b/src/plugins/external_tool_support/src/bowtie2/Bowtie2Settings.ui
@@ -254,9 +254,6 @@
             <property name="text">
              <string>Disallow gaps (--gbar)</string>
             </property>
-            <property name="shortcut">
-             <string notr="true"/>
-            </property>
            </widget>
           </item>
          </layout>


### PR DESCRIPTION
src/plugins/external_tool_support/src/bowtie2/Bowtie2Settings.ui: Remove
shortcut setting that breaks the build with Qt 5.10.

UGENE can be built with Qt ≥ 5.6 and a separate QtWebKit. With Qt 5.10,
we were hitting a build error: uic was producing code that did not
compile.