### PR TITLE
Avoid clash with extern tgkill declaration

### DIFF
--- a/src/libs_3rdparty/breakpad/src/client/linux/handler/exception_handler.cc
+++ b/src/libs_3rdparty/breakpad/src/client/linux/handler/exception_handler.cc
@@ -109,7 +109,6 @@ namespace {
   // A wrapper for the tgkill syscall: send a signal to a specific thread.
   int tgkill(pid_t tgid, pid_t tid, int sig) {
     return syscall(__NR_tgkill, tgid, tid, sig);
-    return 0;
   }
 }
 

--- a/src/libs_3rdparty/breakpad/src/client/linux/handler/exception_handler.cc
+++ b/src/libs_3rdparty/breakpad/src/client/linux/handler/exception_handler.cc
@@ -105,10 +105,12 @@
 #define PR_SET_PTRACER 0x59616d61
 #endif
 
-// A wrapper for the tgkill syscall: send a signal to a specific thread.
-static int tgkill(pid_t tgid, pid_t tid, int sig) {
-  return syscall(__NR_tgkill, tgid, tid, sig);
-  return 0;
+namespace {
+  // A wrapper for the tgkill syscall: send a signal to a specific thread.
+  int tgkill(pid_t tgid, pid_t tid, int sig) {
+    return syscall(__NR_tgkill, tgid, tid, sig);
+    return 0;
+  }
 }
 
 namespace google_breakpad {
@@ -371,7 +373,7 @@ void ExceptionHandler::SignalHandler(int sig, siginfo_t* info, void* uc) {
     // In order to retrigger it, we have to queue a new signal by calling
     // kill() ourselves.  The special case (si_pid == 0 && sig == SIGABRT) is
     // due to the kernel sending a SIGABRT from a user request via SysRQ.
-    if (tgkill(getpid(), syscall(__NR_gettid), sig) < 0) {
+    if (::tgkill(getpid(), syscall(__NR_gettid), sig) < 0) {
       // If we failed to kill ourselves (e.g. because a sandbox disallows us
       // to do so), we instead resort to terminating our process. This will
       // result in an incorrect exit code.


### PR DESCRIPTION
Putting tgkill wrapper into an unnamed namespace to avoid clash with extern declaration of tgkill in /usr/include/bits/signal_ext.h.

Without this fix compilation gives:
`
/home/alex/build/ugene/src/libs_3rdparty/breakpad/src/client/linux/handler/exception_handler.cc:109:12: error: ‘int tgkill(pid_t, pid_t, int)’ was declared ‘extern’ and later ‘static’ [-fpermissive]
  109 | static int tgkill(pid_t tgid, pid_t tid, int sig) {
      |            ^~~~~~
In file included from /usr/include/signal.h:374,
                 from /home/alex/build/ugene/src/libs_3rdparty/breakpad/src/client/linux/handler/exception_handler.h:33,
                 from /home/alex/build/ugene/src/libs_3rdparty/breakpad/src/client/linux/handler/exception_handler.cc:66:
/usr/include/bits/signal_ext.h:29:12: note: previous declaration of ‘int tgkill(__pid_t, __pid_t, int)’
   29 | extern int tgkill (__pid_t __tgid, __pid_t __tid, int __signal);
      |            ^~~~~~
make[2]: *** [src/libs_3rdparty/breakpad/CMakeFiles/breakpad.dir/build.make:167: src/libs_3rdparty/breakpad/CMakeFiles/breakpad.dir/src/client/linux/handler/exception_handler.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1236: src/libs_3rdparty/breakpad/CMakeFiles/breakpad.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
`