### PR TITLE
UGENE-6682 Opencl fix crash

### DIFF
--- a/src/corelibs/U2Algorithm/src/registry/OpenCLGpuRegistry.cpp
+++ b/src/corelibs/U2Algorithm/src/registry/OpenCLGpuRegistry.cpp
@@ -50,7 +50,7 @@ void OpenCLGpuRegistry::unregisterOpenCLGpu(OpenCLGpuModel * gpu) {
     delete gpus.take(gpu->getId());
 }
 
-OpenCLGpuModel * OpenCLGpuRegistry::getGpuById( OpenCLGpuId id ) const {
+OpenCLGpuModel * OpenCLGpuRegistry::getGpuById(cl_device_id id ) const {
     return gpus.value( id, 0 );
 }
 
@@ -72,7 +72,7 @@ QList<OpenCLGpuModel *> OpenCLGpuRegistry::getEnabledGpus() const {
 }
 
 OpenCLGpuModel * OpenCLGpuRegistry::getAnyEnabledGpu() const {
-    QHash<OpenCLGpuId, OpenCLGpuModel*>::const_iterator it = std::find_if( gpus.begin(), gpus.end(), std::mem_fun(&OpenCLGpuModel::isEnabled) );
+    QHash<cl_device_id, OpenCLGpuModel*>::const_iterator it = std::find_if( gpus.begin(), gpus.end(), std::mem_fun(&OpenCLGpuModel::isEnabled) );
     if( gpus.end() != it ) {
         return *it;
     }
@@ -80,7 +80,7 @@ OpenCLGpuModel * OpenCLGpuRegistry::getAnyEnabledGpu() const {
 }
 
 OpenCLGpuModel * OpenCLGpuRegistry::acquireAnyReadyGpu() {
-    QHash<OpenCLGpuId, OpenCLGpuModel*>::iterator it = std::find_if( gpus.begin(), gpus.end(), std::mem_fun(&OpenCLGpuModel::isReady) );
+    QHash<cl_device_id, OpenCLGpuModel*>::iterator it = std::find_if( gpus.begin(), gpus.end(), std::mem_fun(&OpenCLGpuModel::isReady) );
     if( gpus.end() != it ) {
         (*it)->setAcquired(true);
         return *it;
@@ -91,7 +91,7 @@ OpenCLGpuModel * OpenCLGpuRegistry::acquireAnyReadyGpu() {
 void OpenCLGpuRegistry::saveGpusSettings() const {
     Settings * s = AppContext::getSettings();
     foreach( OpenCLGpuModel * m, gpus ) {
-        QString key = OPENCL_GPU_REGISTRY_SETTINGS_GPU_SPECIFIC + QString::number(m->getId()) + OPENCL_GPU_SETTINGS_ENABLED;
+        QString key = OPENCL_GPU_REGISTRY_SETTINGS_GPU_SPECIFIC + QString::number((qlonglong)m->getId()) + OPENCL_GPU_SETTINGS_ENABLED;
         s->setValue( key, QVariant::fromValue(m->isEnabled()) );
     }
 }

--- a/src/corelibs/U2Algorithm/src/registry/OpenCLGpuRegistry.h
+++ b/src/corelibs/U2Algorithm/src/registry/OpenCLGpuRegistry.h
@@ -32,19 +32,16 @@
 
 namespace U2 {
 
-typedef long OpenCLGpuId;
-typedef long OpenCLGpuContext;
-
 #define OPENCL_GPU_REGISTRY_SETTINGS "/opencl_gpu_registry"
-//stores settings for concrete GPU. The key for appending - textual representation of OpenCLGpuId
+//stores settings for concrete GPU. The key for appending - textual representation of cl_device_id
 #define OPENCL_GPU_REGISTRY_SETTINGS_GPU_SPECIFIC "/opencl_gpu_registry/gpu_specific"
 #define OPENCL_GPU_SETTINGS_ENABLED "/enabled"
 
 class U2ALGORITHM_EXPORT OpenCLGpuModel {
 public:
     OpenCLGpuModel( const QString & _name,
-                    const OpenCLGpuContext & _context,
-                    const OpenCLGpuId & _id,
+                    const cl_context & _context,
+                    const cl_device_id & _id,
                     quint64 _platformId,
                     quint64 _globalMemorySizeBytes,
                     quint64 _maxAllocateMemorySizeBytes,
@@ -67,8 +64,8 @@ public:
       acquired(false) {};
 
     QString getName() const {return name;}
-    OpenCLGpuId getId() const {return id;}
-    OpenCLGpuContext getContext() const {return context;}
+    cl_device_id getId() const {return id;}
+    cl_context getContext() const {return context;}
     quint64 getGlobalMemorySizeBytes() const {return globalMemorySizeBytes;}
     quint64 getMaxAllocateMemorySizeBytes() const {return maxAllocateMemorySizeBytes;}
     quint64 getLocalMemorySizeBytes() const {return localMemorySizeBytes;}
@@ -86,8 +83,8 @@ public:
     bool isReady() {return !isAcquired() && isEnabled(); }
 private:
     QString name;
-    OpenCLGpuContext context; // There should be one context for each device, no need to recreate context billion times TODO: releasing
-    OpenCLGpuId id;
+    cl_context context; // There should be one context for each device, no need to recreate context billion times TODO: releasing
+    cl_device_id id;
     quint64 platformId;
     quint64 globalMemorySizeBytes;
     quint64 maxAllocateMemorySizeBytes;
@@ -106,7 +103,7 @@ public:
 
     void registerOpenCLGpu( OpenCLGpuModel * gpu );
     void unregisterOpenCLGpu( OpenCLGpuModel * gpu);
-    OpenCLGpuModel * getGpuById( OpenCLGpuId id ) const;
+    OpenCLGpuModel * getGpuById(cl_device_id id ) const;
     QList<OpenCLGpuModel*> getRegisteredGpus() const;
     QList<OpenCLGpuModel*> getEnabledGpus() const;
 
@@ -122,7 +119,7 @@ public:
 
 private:
     void saveGpusSettings() const;
-    QHash< OpenCLGpuId, OpenCLGpuModel * > gpus;
+    QHash< cl_device_id, OpenCLGpuModel * > gpus;
     OpenCLHelper* openCLHelper;
 };
 

--- a/src/plugins/opencl_support/src/OpenCLSupportPlugin.cpp
+++ b/src/plugins/opencl_support/src/OpenCLSupportPlugin.cpp
@@ -244,8 +244,8 @@ OpenCLSupportPlugin::OpenCLSupportError OpenCLSupportPlugin::obtainGpusInfo( QSt
 
             //create OpenCL model
             OpenCLGpuModel * openCLGpuModel = new OpenCLGpuModel( vendorName + " " + deviceName,
-                                                                  OpenCLGpuContext((long)deviceContext),
-                                                                  OpenCLGpuId((long)deviceId),
+                                                                  cl_context(deviceContext),
+                                                                  cl_device_id(deviceId),
                                                                   (qint64)platformIDs.get()[i],
                                                                   globalMemSize,
                                                                   maxAllocateMemorySize,
@@ -295,7 +295,7 @@ void OpenCLSupportPlugin::loadGpusSettings() {
     Settings * s = AppContext::getSettings();
     foreach( OpenCLGpuModel * m, gpus ) {
         QString key = OPENCL_GPU_REGISTRY_SETTINGS_GPU_SPECIFIC +
-            QString::number(m->getId()) + OPENCL_GPU_SETTINGS_ENABLED;
+            QString::number((qlonglong)m->getId()) + OPENCL_GPU_SETTINGS_ENABLED;
         QVariant enabled_v = s->getValue( key );
         if( !enabled_v.isNull() ) {
             m->setEnabled( enabled_v.toBool() );

--- a/src/plugins/smith_waterman/src/SWAlgorithmTask.cpp
+++ b/src/plugins/smith_waterman/src/SWAlgorithmTask.cpp
@@ -238,7 +238,7 @@ void SWAlgorithmTask::prepare() {
         if(gpuMemBytes < needMemBytes) {
             stateInfo.setError(QString("Not enough memory on OpenCL-enabled device. "
                 "The space required is %1 bytes, but only %2 bytes are available. Device id: %3, device name: %4").
-                arg(QString::number(needMemBytes), QString::number(gpuMemBytes), QString::number(openClGpu->getId()), QString(openClGpu->getName())));
+                arg(QString::number(needMemBytes), QString::number(gpuMemBytes), QString::number((qlonglong)openClGpu->getId()), QString(openClGpu->getName())));
             return;
         } else {
             algoLog.details(QString("The Smith-Waterman search allocates ~%1 bytes (%2 Mb) on OpenCL device").
@@ -829,7 +829,7 @@ void PairwiseAlignmentSmithWatermanTask::prepare() {
         if(gpuMemBytes < needMemBytes) {
             stateInfo.setError(QString("Not enough memory on OpenCL-enabled device. "
                 "The space required is %1 bytes, but only %2 bytes are available. Device id: %3, device name: %4").
-                arg(QString::number(needMemBytes), QString::number(gpuMemBytes), QString::number(openClGpu->getId()), QString(openClGpu->getName())));
+                arg(QString::number(needMemBytes), QString::number(gpuMemBytes), QString::number((qlonglong)openClGpu->getId()), QString(openClGpu->getName())));
             return;
         } else {
             algoLog.details(QString("The Smith-Waterman search allocates ~%1 bytes (%2 Mb) on OpenCL device").


### PR DESCRIPTION
This a fix for #6682
The problem was type conversion:
  cl_device_id -> long -> cl_device_id

On Windows long is 32 bit, but cl_device_id is 64 bit pointer
So, this conversion destroyed the cl_device_id
