### PR TITLE
Ugene 5371 fix local var

### DIFF
--- a/src/corelibs/U2Core/src/globals/GUrl.cpp
+++ b/src/corelibs/U2Core/src/globals/GUrl.cpp
@@ -149,6 +149,7 @@ bool GUrl::operator !=(const GUrl& url) const {
 
 // The function converts url string to multibyte form
 // default code page is CP_THREAD_ACP
+// must use "delete" to delete returned value
 const char* GUrl::getURLStringAnsi(int codePage) const {
 #ifdef Q_OS_WIN
     std::wstring wPath = getURLString().toStdWString();
@@ -158,12 +159,15 @@ const char* GUrl::getURLStringAnsi(int codePage) const {
     if (!buffSize)
         return nullptr;
     
-    char * buffer = new char[buffSize];
+    char* buffer = new char[buffSize + 1];
     if (!WideCharToMultiByte(codePage, 0, wPath.c_str(), -1, buffer, buffSize, NULL, NULL))
         return nullptr;
     return (buffer);
 #else
-    return getURLString().toLocal8Bit().constData();
+    const char* tmp = getURLString().toLocal8Bit().constData();
+    char* buffer = new char[qstrlen(tmp) + 1];
+    qstrcpy(buffer, tmp);
+    return buffer;
 #endif // Q_OS_WIN
 }
 

--- a/src/corelibs/U2Core/src/globals/GUrl.h
+++ b/src/corelibs/U2Core/src/globals/GUrl.h
@@ -74,6 +74,7 @@ public:
 
     // The function converts url string to multibyte form
     // default code page is CP_THREAD_ACP
+    // must use "delete" to delete returned value
     const char* getURLStringAnsi(int codePage = -1) const;
 
     GUrlType getType() const {return type;}

--- a/src/libs_3rdparty/samtools/src/ugene_custom_io.c
+++ b/src/libs_3rdparty/samtools/src/ugene_custom_io.c
@@ -33,7 +33,7 @@ int ugene_custom_open(const char *filename, int oflag) {
 // The conversion is with CP_THREAD_ACP by default
 int ugene_custom_open2(const char *filename, int oflag, int pflag) {
 #ifndef _WIN32
-    return open(filename, oflag);
+    return open(filename, oflag, pflag);
 #else
     int wchars_num = MultiByteToWideChar(CP_THREAD_ACP, 0, filename, -1, NULL, 0);
     wchar_t* w_filename = malloc(sizeof(wchar_t) * wchars_num);


### PR DESCRIPTION
The problem is that the local var of the function GUrl::getURLStringAnsi(int codePage) is dead outside of the function, so return string memory must be explicitly allocated