### PR TITLE
Fix clang-format errors for Windows

### DIFF
--- a/src/corelibs/U2Core/src/globals/AppResources.cpp
+++ b/src/corelibs/U2Core/src/globals/AppResources.cpp
@@ -19,14 +19,6 @@
  * MA 02110-1301, USA.
  */
 
-// clang-format off
-#ifdef Q_OS_WIN
-#include <windows.h>
-#include <Psapi.h>
-#include <Winbase.h> //for IsProcessorFeaturePresent
-#endif
-// clang-format on
-
 #include "AppResources.h"
 
 #include <U2Core/AppContext.h>
@@ -44,6 +36,12 @@
 #endif
 #if defined(Q_OS_LINUX)
 #    include <fstream>
+#endif
+
+#ifdef Q_OS_WIN
+#include <windows.h>
+#include <Psapi.h>
+#include <Winbase.h> //for IsProcessorFeaturePresent
 #endif
 
 namespace U2 {

--- a/src/ugenem/src/SendReportDialog.cpp
+++ b/src/ugenem/src/SendReportDialog.cpp
@@ -22,10 +22,10 @@
 #include <qglobal.h>
 
 #ifdef Q_OS_WIN
-#    include <Psapi.h>
-#    include <Winbase.h>    //for IsProcessorFeaturePresent
 #    include <intrin.h>
 #    include <windows.h>
+#    include <Psapi.h>
+#    include <Winbase.h>    //for IsProcessorFeaturePresent
 
 #    include "DetectWin10.h"
 #endif


### PR DESCRIPTION
Fix clang-format errors for Windows after merging UTI-390 to master