### PR TITLE
Fix UGENE-6369

### DIFF
--- a/src/ugeneui/src/plugin_viewer/PluginViewerController.cpp
+++ b/src/ugeneui/src/plugin_viewer/PluginViewerController.cpp
@@ -50,9 +50,8 @@ PluginViewerController::PluginViewerController() {
 PluginViewerController::~PluginViewerController() {
     AppContext::getPluginSupport()->disconnect(this);
 
-    // 'true' mode is not functional anymore after service<->plugin model refactoring
-    // so always save false for pluginview settings, also see UGENE-6369
-    AppContext::getSettings()->setValue(PLUGIN_VIEW_SETTINGS + "isVisible", false);
+    // 'true' mode is not functional anymore after some old service<->plugin model refactoring
+    // so we don't save state for pluginview settings, see UGENE-6369
 
     if (mdiWindow) {
         AppContext::getMainWindow()->getMDIManager()->closeMDIWindow(mdiWindow);

--- a/src/ugeneui/src/plugin_viewer/PluginViewerController.cpp
+++ b/src/ugeneui/src/plugin_viewer/PluginViewerController.cpp
@@ -45,16 +45,14 @@ PluginViewerController::PluginViewerController() {
     showServices = false;    //'true' mode is not functional anymore after service<->plugin model refactoring
     mdiWindow = NULL;
     connectStaticActions();
-
-    if (AppContext::getSettings()->getValue(PLUGIN_VIEW_SETTINGS + "isVisible", false).toBool()) {
-        createWindow();
-    }
 }
 
 PluginViewerController::~PluginViewerController() {
     AppContext::getPluginSupport()->disconnect(this);
 
-    AppContext::getSettings()->setValue(PLUGIN_VIEW_SETTINGS + "isVisible", mdiWindow != NULL);
+    // 'true' mode is not functional anymore after service<->plugin model refactoring
+    // so always save false for pluginview settings, also see UGENE-6369
+    AppContext::getSettings()->setValue(PLUGIN_VIEW_SETTINGS + "isVisible", false);
 
     if (mdiWindow) {
         AppContext::getMainWindow()->getMDIManager()->closeMDIWindow(mdiWindow);


### PR DESCRIPTION
Just ignore visible state of the "Plugin Viewer" windows while starting Ugene gui
Always save false for visibility of the window, so don't restore the visibility state