### PR TITLE
Fix UTI-458

### DIFF
--- a/src/ugeneui/src/shtirlitz/Shtirlitz.cpp
+++ b/src/ugeneui/src/shtirlitz/Shtirlitz.cpp
@@ -148,6 +148,7 @@ QList<Task *> Shtirlitz::wakeup() {
 
         if (!prevDate.isValid() || daysPassed > DAYS_BETWEEN_REPORTS) {
             coreLog.details(ShtirlitzTask::tr("%1 days passed passed since previous Shtirlitz's report. Shtirlitz is sending the new one."));
+            result << sendSystemReport();
             result << sendCountersReport();
             //and save the new date
             s->setValue(SETTINGS_PREVIOUS_REPORT_DATE, QDate::currentDate());


### PR DESCRIPTION
The fix is quit a simple.
Just add `sendSystemReport();` before `sendCountersReport();`
So, every update in "ugeneui launch" event will create or update the user's registration
Moreover, we will have the actual OS data for users.