### PR TITLE
UGENE-6908. SAFE_POINT during the validation Bio module on the first …

### DIFF
--- a/src/plugins/external_tool_support/src/ExternalToolManager.h
+++ b/src/plugins/external_tool_support/src/ExternalToolManager.h
@@ -80,12 +80,18 @@ private:
     void innerStart();
     void checkStartupTasksState();
     void markStartupCheckAsFinished();
-    void addTool(ExternalTool *tool);
+
+    // Add toolId to toolStates and all tool dependencies to dependencies and connect tool validation status change slot
+    void addToToolStatesAndDependencies(ExternalTool *tool);
+
     bool dependenciesAreOk(const QString &toolId);
-    void addToolToListsIfNecessary(const ExternalTool &tool);  // add toolId to validateList if tool is not valid and
-                                                               // its dependencies are ok, and to searchList if needed
-    QString findToolPath(const ExternalTool &tool); // return toolPath (or masterToolPath, if tool is module) if tool is
-                                                // not valid and its dependencies are ok. Otherwise return empty string
+
+    // Add toolId to validateList if tool is not valid and its dependencies are ok, and to searchList if needed. Return
+    // true if tool was added to validateList
+    bool addToSearchAndValidateLists(const ExternalTool &tool);
+
+    // Return toolPath or masterToolPath if tool is module.
+    QString findToolPath(const ExternalTool &tool);
     void validateTools(const StrStrMap &toolPaths = StrStrMap(), ExternalToolValidationListener *listener = nullptr);
     void loadCustomTools();
     void searchTools();

--- a/src/plugins/external_tool_support/src/ExternalToolManager.h
+++ b/src/plugins/external_tool_support/src/ExternalToolManager.h
@@ -80,8 +80,9 @@ private:
     void innerStart();
     void checkStartupTasksState();
     void markStartupCheckAsFinished();
-    QString addTool(ExternalTool *tool);
+    void addTool(ExternalTool *tool);
     bool dependenciesAreOk(const QString &toolId);
+    QString addToolToListsAndReturnToolPath(const ExternalTool &tool);
     void validateTools(const StrStrMap &toolPaths = StrStrMap(), ExternalToolValidationListener *listener = nullptr);
     void loadCustomTools();
     void searchTools();

--- a/src/plugins/external_tool_support/src/ExternalToolManager.h
+++ b/src/plugins/external_tool_support/src/ExternalToolManager.h
@@ -82,7 +82,10 @@ private:
     void markStartupCheckAsFinished();
     void addTool(ExternalTool *tool);
     bool dependenciesAreOk(const QString &toolId);
-    QString addToolToListsAndReturnToolPath(const ExternalTool &tool);
+    void addToolToListsIfNecessary(const ExternalTool &tool);  // add toolId to validateList if tool is not valid and
+                                                               // its dependencies are ok, and to searchList if needed
+    QString findToolPath(const ExternalTool &tool); // return toolPath (or masterToolPath, if tool is module) if tool is
+                                                // not valid and its dependencies are ok. Otherwise return empty string
     void validateTools(const StrStrMap &toolPaths = StrStrMap(), ExternalToolValidationListener *listener = nullptr);
     void loadCustomTools();
     void searchTools();

--- a/src/plugins/external_tool_support/src/python/PythonSupport.cpp
+++ b/src/plugins/external_tool_support/src/python/PythonSupport.cpp
@@ -34,12 +34,6 @@
 
 namespace U2 {
 
-namespace {
-
-const QString PYTHON_VERSION_REGEXP = "(\\d+.\\d+.\\d+)";
-
-} // namespace
-
 const QString PythonSupport::ET_PYTHON_ID = "USUPP_PYTHON2";
 const QString PythonModuleDjangoSupport::ET_PYTHON_DJANGO_ID = "DJANGO";
 const QString PythonModuleNumpySupport::ET_PYTHON_NUMPY_ID = "NUMPY";
@@ -59,11 +53,13 @@ PythonSupport::PythonSupport()
     executableFileName = "python2.7";
 #    endif
 #endif
-    validMessage = "Python " + PYTHON_VERSION_REGEXP;
+    const QString pythonVersionRegexpStr = "(\\d+.\\d+.\\d+)";
+
+    validMessage = "Python " + pythonVersionRegexpStr;
     validationArguments << "--version";
 
     description += tr("Python scripts interpreter");
-    versionRegExp = QRegExp(PYTHON_VERSION_REGEXP);
+    versionRegExp = QRegExp(pythonVersionRegexpStr);
     toolKitName = "python";
 
     muted = true;

--- a/src/plugins/external_tool_support/src/python/PythonSupport.cpp
+++ b/src/plugins/external_tool_support/src/python/PythonSupport.cpp
@@ -34,6 +34,12 @@
 
 namespace U2 {
 
+namespace {
+
+const QString PYTHON_VERSION_REGEXP = "(\\d+.\\d+.\\d+)";
+
+} // namespace
+
 const QString PythonSupport::ET_PYTHON_ID = "USUPP_PYTHON2";
 const QString PythonModuleDjangoSupport::ET_PYTHON_DJANGO_ID = "DJANGO";
 const QString PythonModuleNumpySupport::ET_PYTHON_NUMPY_ID = "NUMPY";
@@ -53,11 +59,11 @@ PythonSupport::PythonSupport()
     executableFileName = "python2.7";
 #    endif
 #endif
-    validMessage = "Python ";
+    validMessage = "Python " + PYTHON_VERSION_REGEXP;
     validationArguments << "--version";
 
     description += tr("Python scripts interpreter");
-    versionRegExp = QRegExp("(\\d+.\\d+.\\d+)");
+    versionRegExp = QRegExp(PYTHON_VERSION_REGEXP);
     toolKitName = "python";
 
     muted = true;


### PR DESCRIPTION
…launch.

When UGENE was first launched, the Bio module from Python was added to
the tools validation list earlier than Python. As a consequence, the
program was aborted by SAFE_POINT. Also Python validation was incorrect
on newer versions of Windows.

Decision:
1. Changing the message for checking the validity of Python.
2. Splitting ExternalToolManagerImpl::addTool() into two methods.