### PR TITLE
UGENE-6966. Enzymes auto-annotation task uses does not process the wh…

### DIFF
--- a/src/corelibs/U2Algorithm/src/misc/EnzymeModel.cpp
+++ b/src/corelibs/U2Algorithm/src/misc/EnzymeModel.cpp
@@ -29,8 +29,6 @@ const QString EnzymeSettings::LAST_SELECTION("plugin_enzymes/selection");
 const QString EnzymeSettings::ENABLE_HIT_COUNT("plugin_enzymes/enable_hit_count");
 const QString EnzymeSettings::MAX_HIT_VALUE("plugin_enzymes/max_hit_value");
 const QString EnzymeSettings::MIN_HIT_VALUE("plugin_enzymes/min_hit_value");
-const QString EnzymeSettings::SEARCH_REGION("plugin_enzymes/search_region");
-const QString EnzymeSettings::EXCLUDED_REGION("plugin_enzymes/non_cut_region");
 const QString EnzymeSettings::MAX_RESULTS("plugin_enzymes/max_results");
 const QString EnzymeSettings::COMMON_ENZYMES("ClaI,BamHI,BglII,DraI,EcoRI,EcoRV,HindIII,PstI,SalI,SmaI,XmaI");
 

--- a/src/corelibs/U2Algorithm/src/misc/EnzymeModel.h
+++ b/src/corelibs/U2Algorithm/src/misc/EnzymeModel.h
@@ -62,8 +62,6 @@ public:
     static const QString ENABLE_HIT_COUNT;
     static const QString MAX_HIT_VALUE;
     static const QString MIN_HIT_VALUE;
-    static const QString SEARCH_REGION;
-    static const QString EXCLUDED_REGION;
     static const QString MAX_RESULTS;
     static const QString COMMON_ENZYMES;
 };

--- a/src/corelibs/U2Core/src/gobjects/DNASequenceObject.cpp
+++ b/src/corelibs/U2Core/src/gobjects/DNASequenceObject.cpp
@@ -303,78 +303,92 @@ QVariantMap U2SequenceObject::getSequenceInfo() const {
     return variantMap;
 }
 
-QString U2SequenceObject::getStringAttribute(const QString &seqAttr) const {
-    return getSequenceInfo().value(seqAttr).toString();
+QString U2SequenceObject::getStringAttribute(const QString &name) const {
+    //TODO: Re-check all usages and start using real attributes from DBI!
+    return getSequenceInfo().value(name).toString();
 }
 
-void U2SequenceObject::setStringAttribute(const QString &newStringAttributeValue, const QString &type) {
+void U2SequenceObject::setStringAttribute(const QString &name, const QString &value) {
     U2OpStatus2Log os;
     DbiConnection con(entityRef.dbiRef, os);
     CHECK_OP(os, );
-    QList<U2DataId> oldStringAttributeList = con.dbi->getAttributeDbi()->getObjectAttributes(entityRef.entityId, type, os);
+    QList<U2DataId> oldStringAttributeList = con.dbi->getAttributeDbi()->getObjectAttributes(entityRef.entityId, name, os);
     CHECK_OP(os, );
     if (!oldStringAttributeList.isEmpty()) {
-        con.dbi->getAttributeDbi()->removeObjectAttributes(oldStringAttributeList.first(), os);
+        con.dbi->getAttributeDbi()->removeAttributes(oldStringAttributeList, os);
         CHECK_OP(os, );
     }
-    U2StringAttribute newStringAttribute(entityRef.entityId, type, newStringAttributeValue);
+    U2StringAttribute newStringAttribute(entityRef.entityId, name, value);
     con.dbi->getAttributeDbi()->createStringAttribute(newStringAttribute, os);
     CHECK_OP(os, );
 }
 
-qint64 U2SequenceObject::getIntegerAttribute(const QString &seqAttr) const {
-    return getSequenceInfo().value(seqAttr).toInt();
+qint64 U2SequenceObject::getIntegerAttribute(const QString &name) const {
+    U2OpStatus2Log os;
+    DbiConnection con(entityRef.dbiRef, os);
+    CHECK_OP(os, 0);
+
+    U2AttributeDbi *attributeDbi = con.dbi->getAttributeDbi();
+    QList<U2DataId> attributeList = attributeDbi->getObjectAttributes(entityRef.entityId, name, os);
+    CHECK_OP(os, 0);
+    CHECK(!attributeList.isEmpty(), 0);
+
+    U2IntegerAttribute attribute = attributeDbi->getIntegerAttribute(attributeList.first(), os);
+    CHECK_OP(os, 0);
+    return attribute.value;
 }
 
-void U2SequenceObject::setIntegerAttribute(int newIntegerAttributeValue, const QString &type) {
+void U2SequenceObject::setIntegerAttribute(const QString &name, int value) {
     U2OpStatus2Log os;
     DbiConnection con(entityRef.dbiRef, os);
     CHECK_OP(os, );
-    QList<U2DataId> oldIntegerAttributeList = con.dbi->getAttributeDbi()->getObjectAttributes(entityRef.entityId, type, os);
+    QList<U2DataId> oldIntegerAttributeList = con.dbi->getAttributeDbi()->getObjectAttributes(entityRef.entityId, name, os);
     CHECK_OP(os, );
     if (!oldIntegerAttributeList.isEmpty()) {
-        con.dbi->getAttributeDbi()->removeObjectAttributes(oldIntegerAttributeList.first(), os);
+        con.dbi->getAttributeDbi()->removeAttributes(oldIntegerAttributeList, os);
         CHECK_OP(os, );
     }
-    U2IntegerAttribute newIntegerAttribute(entityRef.entityId, type, newIntegerAttributeValue);
+    U2IntegerAttribute newIntegerAttribute(entityRef.entityId, name, value);
     con.dbi->getAttributeDbi()->createIntegerAttribute(newIntegerAttribute, os);
     CHECK_OP(os, );
 }
 
-double U2SequenceObject::getRealAttribute(const QString &seqAttr) const {
-    return getSequenceInfo().value(seqAttr).toReal();
+double U2SequenceObject::getRealAttribute(const QString &name) const {
+    //TODO: Re-check all usages and start using real attributes from DBI!
+    return getSequenceInfo().value(name).toReal();
 }
 
-void U2SequenceObject::setRealAttribute(double newRealAttributeValue, const QString &type) {
+void U2SequenceObject::setRealAttribute(const QString &name, double value) {
     U2OpStatus2Log os;
     DbiConnection con(entityRef.dbiRef, os);
     CHECK_OP(os, );
-    QList<U2DataId> oldRealAttributeList = con.dbi->getAttributeDbi()->getObjectAttributes(entityRef.entityId, type, os);
+    QList<U2DataId> oldRealAttributeList = con.dbi->getAttributeDbi()->getObjectAttributes(entityRef.entityId, name, os);
     CHECK_OP(os, );
     if (!oldRealAttributeList.isEmpty()) {
-        con.dbi->getAttributeDbi()->removeObjectAttributes(oldRealAttributeList.first(), os);
+        con.dbi->getAttributeDbi()->removeAttributes(oldRealAttributeList, os);
         CHECK_OP(os, );
     }
-    U2RealAttribute newRealAttribute(entityRef.entityId, type, newRealAttributeValue);
+    U2RealAttribute newRealAttribute(entityRef.entityId, name, value);
     con.dbi->getAttributeDbi()->createRealAttribute(newRealAttribute, os);
     CHECK_OP(os, );
 }
 
-QByteArray U2SequenceObject::getByteArrayAttribute(const QString &seqAttr) const {
-    return getSequenceInfo().value(seqAttr).toByteArray();
+QByteArray U2SequenceObject::getByteArrayAttribute(const QString &name) const {
+    //TODO: Re-check all usages and start using real attributes from DBI!
+    return getSequenceInfo().value(name).toByteArray();
 }
 
-void U2SequenceObject::setByteArrayAttribute(const QByteArray &newByteArrayAttributeValue, const QString &type) {
+void U2SequenceObject::setByteArrayAttribute(const QString &name, const QByteArray &value) {
     U2OpStatus2Log os;
     DbiConnection con(entityRef.dbiRef, os);
     CHECK_OP(os, );
-    QList<U2DataId> oldByteArrayAttributeList = con.dbi->getAttributeDbi()->getObjectAttributes(entityRef.entityId, type, os);
+    QList<U2DataId> oldByteArrayAttributeList = con.dbi->getAttributeDbi()->getObjectAttributes(entityRef.entityId, name, os);
     CHECK_OP(os, );
     if (!oldByteArrayAttributeList.isEmpty()) {
-        con.dbi->getAttributeDbi()->removeObjectAttributes(oldByteArrayAttributeList.first(), os);
+        con.dbi->getAttributeDbi()->removeAttributes(oldByteArrayAttributeList, os);
         CHECK_OP(os, );
     }
-    U2ByteArrayAttribute newByteArrayAttribute(entityRef.entityId, type, newByteArrayAttributeValue);
+    U2ByteArrayAttribute newByteArrayAttribute(entityRef.entityId, name, value);
     con.dbi->getAttributeDbi()->createByteArrayAttribute(newByteArrayAttribute, os);
 }
 

--- a/src/corelibs/U2Core/src/gobjects/DNASequenceObject.h
+++ b/src/corelibs/U2Core/src/gobjects/DNASequenceObject.h
@@ -85,22 +85,31 @@ public:
 
     QVariantMap getSequenceInfo() const;
 
-    QString getStringAttribute(const QString &seqAttr) const;
+    /** Returns string attribute value of empty string if the attribute does not exist. */
+    QString getStringAttribute(const QString &name) const;
 
-    void setStringAttribute(const QString &newStringAttributeValue, const QString &type);
+    /** Sets string attribute by name.*/
+    void setStringAttribute(const QString &name, const QString &value);
 
-    qint64 getIntegerAttribute(const QString &seqAttr) const;
+    /** Returns integer attribute value of 0.0 if the attribute does not exist. */
+    qint64 getIntegerAttribute(const QString &name) const;
 
-    void setIntegerAttribute(int newIntegerAttributeValue, const QString &type);
+    /** Sets integer attribute by name.*/
+    void setIntegerAttribute(const QString &name, int value);
 
-    double getRealAttribute(const QString &seqAttr) const;
+    /** Returns real attribute value of 0.0 if the attribute does not exist. */
+    double getRealAttribute(const QString &name) const;
 
-    void setRealAttribute(double newRealAttributeValue, const QString &type);
+    /** Sets real attribute by name. */
+    void setRealAttribute(const QString &name, double value);
 
-    QByteArray getByteArrayAttribute(const QString &seqAttr) const;
+    /** Returns QByteArray attribute value of empty QByteArray if the attribute does not exist. */
+    QByteArray getByteArrayAttribute(const QString &name) const;
 
-    void setByteArrayAttribute(const QByteArray &newByteArrayAttributeValue, const QString &type);
+    /** Sets QByteArray attribute by name. */
+    void setByteArrayAttribute(const QString &name, const QByteArray &value);
 
+    /** Compares names of 2 sequence objects using '<' operator of QStrings.. */
     static bool lessThan(const U2SequenceObject *one, const U2SequenceObject *two) {
         return one->name < two->name;
     }

--- a/src/corelibs/U2Formats/src/EMBLGenbankAbstractDocument.cpp
+++ b/src/corelibs/U2Formats/src/EMBLGenbankAbstractDocument.cpp
@@ -239,7 +239,7 @@ void EMBLGenbankAbstractDocument::load(const U2DbiRef &dbiRef, IOAdapter *io, QL
                     U2SequenceObject *seqObj = new U2SequenceObject(sequenceName, U2EntityRef(dbiRef, u2seq.id));
                     QString translation = U1AnnotationUtils::guessAminoTranslation(annotationsObject, seqObj->getAlphabet());
                     if (!translation.isEmpty()) {
-                        seqObj->setStringAttribute(translation, Translation_Table_Id_Attribute);
+                        seqObj->setStringAttribute(Translation_Table_Id_Attribute, translation);
                     }
 
                     objects << seqObj;

--- a/src/plugins/biostruct3d_view/src/BioStruct3DGLWidget.cpp
+++ b/src/plugins/biostruct3d_view/src/BioStruct3DGLWidget.cpp
@@ -355,9 +355,10 @@ void BioStruct3DGLWidget::setLightPosition(const Vector3D &pos) {
 }
 
 static int getSequenceChainId(const U2SequenceObject *seqObj) {
-    QVariantMap info = seqObj->getSequenceInfo();
-    SAFE_POINT(info.contains(DNAInfo::CHAIN_ID), "Sequence does not have the CHAIN_ID attribute", -1);
-    return seqObj->getIntegerAttribute(DNAInfo::CHAIN_ID);
+    bool isFound = false;
+    qint64 result = seqObj->getSequenceInfo().value(DNAInfo::CHAIN_ID).toInt(&isFound);
+    SAFE_POINT(isFound, "Sequence does not have the CHAIN_ID attribute", -1);
+    return (int)result;
 }
 
 void BioStruct3DGLWidget::sl_onSequenceSelectionChanged(LRegionsSelection *s, const QVector<U2Region> &added, const QVector<U2Region> &removed) {

--- a/src/plugins/biostruct3d_view/src/deprecated/BioStruct3DGLWidget.cpp
+++ b/src/plugins/biostruct3d_view/src/deprecated/BioStruct3DGLWidget.cpp
@@ -338,9 +338,10 @@ void BioStruct3DGLWidget::setLightPosition(const Vector3D &pos) {
 }
 
 static int getSequenceChainId(const U2SequenceObject *seqObj) {
-    QVariantMap info = seqObj->getSequenceInfo();
-    SAFE_POINT(info.contains(DNAInfo::CHAIN_ID), "Sequence does not have the CHAIN_ID attribute", -1);
-    return seqObj->getIntegerAttribute(DNAInfo::CHAIN_ID);
+    bool isFound = false;
+    qint64 result = seqObj->getSequenceInfo().value(DNAInfo::CHAIN_ID).toInt(&isFound);
+    SAFE_POINT(isFound, "Sequence does not have the CHAIN_ID attribute", -1);
+    return (int)result;
 }
 
 void BioStruct3DGLWidget::sl_onSequenceSelectionChanged(LRegionsSelection *s, const QVector<U2Region> &added, const QVector<U2Region> &removed) {

--- a/src/plugins/enzymes/src/EnzymesPlugin.cpp
+++ b/src/plugins/enzymes/src/EnzymesPlugin.cpp
@@ -79,7 +79,6 @@ EnzymesPlugin::EnzymesPlugin()
     }
 
     EnzymesSelectorWidget::setupSettings();
-    FindEnzymesDialog::initDefaultSettings();
 
     GTestFormatRegistry *tfr = AppContext::getTestFramework()->getTestFormatRegistry();
     XMLTestFormat *xmlTestFormat = qobject_cast<XMLTestFormat *>(tfr->findFormat("XML"));

--- a/src/plugins/enzymes/src/FindEnzymesDialog.h
+++ b/src/plugins/enzymes/src/FindEnzymesDialog.h
@@ -90,8 +90,7 @@ private:
 class FindEnzymesDialog : public QDialog, public Ui_FindEnzymesDialog {
     Q_OBJECT
 public:
-    FindEnzymesDialog(ADVSequenceObjectContext *ctx);
-    static void initDefaultSettings();
+    FindEnzymesDialog(ADVSequenceObjectContext *advSequenceContext);
     virtual void accept();
 private slots:
     void sl_onSelectionModified(int total, int nChecked);
@@ -99,7 +98,10 @@ private slots:
 private:
     void initSettings();
     void saveSettings();
-    ADVSequenceObjectContext *seqCtx;
+
+    /** FindEnzymes dialog is always opened for some sequence in ADVSequenceView. */
+    ADVSequenceObjectContext *advSequenceContext;
+
     EnzymesSelectorWidget *enzSel;
     RegionSelectorWithExludedRegion *regionSelector;
 };

--- a/src/plugins/enzymes/src/FindEnzymesTask.h
+++ b/src/plugins/enzymes/src/FindEnzymesTask.h
@@ -151,6 +151,26 @@ public:
     Task *createAutoAnnotationsUpdateTask(const AutoAnnotationObject *annotationObject) override;
 
     bool checkConstraints(const AutoAnnotationConstraints &constraints) override;
+
+    /** Returns last saved search region for the given sequence object or empty region if no region was saved. */
+    static U2Region getLastSearchRegionForObject(const U2SequenceObject *sequenceObject);
+
+    /**
+     * Saves the region as last used 'search' region for the object.
+     * This region will be used by default during the next auto-annotation task run.
+     * If no region is set, the whole sequence will be processed.
+     */
+    static void setLastSearchRegionForObject(U2SequenceObject *sequenceObject, const U2Region &region);
+
+    /** Returns last saved 'excluded' region for the given sequence object or empty region if no region was saved. */
+    static U2Region getLastExcludeRegionForObject(const U2SequenceObject *sequenceObject);
+
+    /**
+     * Saves the region as last used 'exclude' region for the object.
+     * This region will be used by default during the next auto-annotation task run.
+     * If no region is set, the whole sequence will be processed.
+     */
+    static void setLastExcludeRegionForObject(U2SequenceObject *sequenceObject, const U2Region &region);
 };
 
 }    // namespace U2


### PR DESCRIPTION
Bug:
https://ugene.dev/tracker/browse/UGENE-6966

Details:
When I started using sequence object attributes to save auto-annotation related context I found that all attribute related methods have bugs:
1.  Set and Get use different tables in a database.
2. Set does not correctly remove old copies of attributes but only create new ones.

I added TODO to all problem places and fixed the ones that affect this patch.