### PR TITLE
UGENE-6987. DetViewMultiLineRenderer::getAnnotationYRange does not co…

### DIFF
--- a/src/corelibs/U2View/src/ov_sequence/view_rendering/DetViewMultiLineRenderer.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/view_rendering/DetViewMultiLineRenderer.cpp
@@ -60,7 +60,7 @@ float DetViewMultiLineRenderer::posToXCoordF(const qint64 p, const QSize &canvas
 }
 
 U2Region DetViewMultiLineRenderer::getAnnotationYRange(Annotation *annotation, int locationRegionIndex, const AnnotationSettings *annotationSettings, const QSize &canvasSize, const U2Region &visibleRange) const {
-    SAFE_POINT(locationRegionIndex < annotation->getRegions().length(), "Invalid locationRegionIndex", U2Region());
+    SAFE_POINT(locationRegionIndex >= 0 && locationRegionIndex < annotation->getRegions().length(), "Invalid locationRegionIndex", U2Region());
 
     // Compute region offset within a single line.
     U2Region yRegion = singleLineRenderer->getAnnotationYRange(annotation, locationRegionIndex, annotationSettings, canvasSize, visibleRange);

--- a/src/corelibs/U2View/src/ov_sequence/view_rendering/DetViewMultiLineRenderer.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/view_rendering/DetViewMultiLineRenderer.cpp
@@ -37,17 +37,17 @@ const int DetViewMultiLineRenderer::INDENT_BETWEEN_LINES = 30;
 DetViewMultiLineRenderer::DetViewMultiLineRenderer(DetView *detView, SequenceObjectContext *ctx)
     : DetViewRenderer(detView, ctx),
       extraIndent(0) {
-    singleLinePainter = new DetViewSingleLineRenderer(detView, ctx);
+    singleLineRenderer = new DetViewSingleLineRenderer(detView, ctx);
 }
 
 DetViewMultiLineRenderer::~DetViewMultiLineRenderer() {
-    delete singleLinePainter;
+    delete singleLineRenderer;
 }
 
 qint64 DetViewMultiLineRenderer::coordToPos(const QPoint &p, const QSize &canvasSize, const U2Region &visibleRange) const {
     qint64 symbolsPerLine = getSymbolsPerLine(canvasSize.width());
     U2Region firstLineVisibleRange(visibleRange.startPos, symbolsPerLine);
-    qint64 posOnFirstLine = singleLinePainter->coordToPos(p, canvasSize, firstLineVisibleRange);
+    qint64 posOnFirstLine = singleLineRenderer->coordToPos(p, canvasSize, firstLineVisibleRange);
     int line = p.y() / getOneLineHeight();
     return qMin(ctx->getSequenceLength(), posOnFirstLine + line * symbolsPerLine);
 }
@@ -59,13 +59,25 @@ float DetViewMultiLineRenderer::posToXCoordF(const qint64 p, const QSize &canvas
     return commonMetrics.charWidth * (p % symbolsPerLine);
 }
 
-U2Region DetViewMultiLineRenderer::getAnnotationYRange(Annotation *a, int r, const AnnotationSettings *as, const QSize &canvasSize, const U2Region &visibleRange) const {
-    if (qgetenv(ENV_GUI_TEST).toInt() == 1) {
-        U2Region res = singleLinePainter->getAnnotationYRange(a, r, as, QSize(canvasSize.width(), getOneLineHeight()), visibleRange);
-        res.startPos += INDENT_BETWEEN_LINES / 2;
-        return res;
+U2Region DetViewMultiLineRenderer::getAnnotationYRange(Annotation *annotation, int locationRegionIndex, const AnnotationSettings *annotationSettings, const QSize &canvasSize, const U2Region &visibleRange) const {
+    SAFE_POINT(locationRegionIndex < annotation->getRegions().length(), "Invalid locationRegionIndex", U2Region());
+
+    // Compute region offset within a single line.
+    U2Region yRegion = singleLineRenderer->getAnnotationYRange(annotation, locationRegionIndex, annotationSettings, canvasSize, visibleRange);
+    // The first line is indented from the widget start by the half of indent.
+    yRegion.startPos += INDENT_BETWEEN_LINES / 2;
+
+    // Push yRegion to the correct wrap-line.
+    const U2Region &locationRegion = annotation->getRegions()[locationRegionIndex];
+    int locationRegionOffset = locationRegion.startPos - visibleRange.startPos;
+    int baseCountPerLine = getSymbolsPerLine(canvasSize.width());
+    if (locationRegionOffset > baseCountPerLine) {
+        int locationRegionLineIndex = locationRegionOffset / baseCountPerLine;
+        yRegion.startPos += locationRegionLineIndex * getOneLineHeight();
     }
-    FAIL("The method must never be called", U2Region());
+    // Apply vertical scroll shift within multi-line det-view.
+    yRegion.startPos -= detView->getShift();
+    return yRegion;
 }
 
 U2Region DetViewMultiLineRenderer::getMirroredYRange(const U2Strand &) const {
@@ -76,7 +88,7 @@ bool DetViewMultiLineRenderer::isOnTranslationsLine(const QPoint &p, const QSize
     qint64 symbolsPerLine = getSymbolsPerLine(canvasSize.width());
     U2Region range(visibleRange.startPos, qMin(symbolsPerLine, visibleRange.length));
     do {
-        if (singleLinePainter->isOnTranslationsLine(p, canvasSize, range)) {
+        if (singleLineRenderer->isOnTranslationsLine(p, canvasSize, range)) {
             return true;
         }
         range.startPos += symbolsPerLine;
@@ -88,7 +100,7 @@ bool DetViewMultiLineRenderer::isOnTranslationsLine(const QPoint &p, const QSize
 bool DetViewMultiLineRenderer::isOnAnnotationLine(const QPoint &p, Annotation *a, int region, const AnnotationSettings *as, const QSize &canvasSize, const U2Region &visibleRange) const {
     qint64 symbolsPerLine = getSymbolsPerLine(canvasSize.width());
     QSize oneLineMinSize(canvasSize.width(), getMinimumHeight());
-    U2Region yRange = singleLinePainter->getAnnotationYRange(a, region, as, oneLineMinSize, U2Region(visibleRange.startPos, qMin(visibleRange.length, symbolsPerLine)));
+    U2Region yRange = singleLineRenderer->getAnnotationYRange(a, region, as, oneLineMinSize, U2Region(visibleRange.startPos, qMin(visibleRange.length, symbolsPerLine)));
     yRange.startPos += (INDENT_BETWEEN_LINES + extraIndent) / 2;
     do {
         if (yRange.contains(p.y())) {
@@ -101,11 +113,11 @@ bool DetViewMultiLineRenderer::isOnAnnotationLine(const QPoint &p, Annotation *a
 }
 
 qint64 DetViewMultiLineRenderer::getMinimumHeight() const {
-    return singleLinePainter->getMinimumHeight();
+    return singleLineRenderer->getMinimumHeight();
 }
 
 qint64 DetViewMultiLineRenderer::getOneLineHeight() const {
-    return singleLinePainter->getOneLineHeight() + INDENT_BETWEEN_LINES + extraIndent;
+    return singleLineRenderer->getOneLineHeight() + INDENT_BETWEEN_LINES + extraIndent;
 }
 
 qint64 DetViewMultiLineRenderer::getLinesCount(const QSize &canvasSize) const {
@@ -117,11 +129,11 @@ qint64 DetViewMultiLineRenderer::getContentIndentY(const QSize &, const U2Region
 }
 
 int DetViewMultiLineRenderer::getDirectLine() const {
-    return singleLinePainter->getDirectLine();
+    return singleLineRenderer->getDirectLine();
 }
 
 int DetViewMultiLineRenderer::getRowsInLineCount() const {
-    return singleLinePainter->getRowsInLineCount() + 2;
+    return singleLineRenderer->getRowsInLineCount() + 2;
 }
 
 QSize DetViewMultiLineRenderer::getBaseCanvasSize(const U2Region &visibleRange) const {
@@ -139,7 +151,7 @@ void DetViewMultiLineRenderer::drawAll(QPainter &p, const QSize &canvasSize, con
     U2Region oneLineRegion(visibleRange.startPos, symbolsPerLine);
     p.fillRect(QRect(QPoint(0, 0), canvasSize), Qt::white);
 
-    // wide the indent between lines if neccessary
+    // Add extra indent between lines if necessary.
     extraIndent = 0;
     int sequenceLinesCount = visibleRange.length / symbolsPerLine + 1;
     if (ctx->getSequenceLength() == visibleRange.length) {
@@ -154,9 +166,9 @@ void DetViewMultiLineRenderer::drawAll(QPainter &p, const QSize &canvasSize, con
         // cut the extra space at the end of the sequence
         oneLineRegion.length = qMin(visibleRange.endPos() - oneLineRegion.startPos, oneLineRegion.length);
 
-        singleLinePainter->drawAll(p,
-                                   QSize(canvasSize.width(), getOneLineHeight()),
-                                   oneLineRegion);
+        singleLineRenderer->drawAll(p,
+                                    QSize(canvasSize.width(), getOneLineHeight()),
+                                    oneLineRegion);
 
         p.translate(0, getOneLineHeight());
         indentCounter += getOneLineHeight();
@@ -178,9 +190,9 @@ void DetViewMultiLineRenderer::drawSelection(QPainter &p, const QSize &canvasSiz
         // cut the extra space at the end of the sequence
         oneLineRegion.length = qMin(visibleRange.endPos() - oneLineRegion.startPos, oneLineRegion.length);
 
-        singleLinePainter->drawSelection(p,
-                                         QSize(canvasSize.width(), getOneLineHeight()),
-                                         oneLineRegion);
+        singleLineRenderer->drawSelection(p,
+                                          QSize(canvasSize.width(), getOneLineHeight()),
+                                          oneLineRegion);
 
         p.translate(0, getOneLineHeight());
         indentCounter += getOneLineHeight();
@@ -202,9 +214,9 @@ void DetViewMultiLineRenderer::drawCursor(QPainter &p, const QSize &canvasSize, 
     do {
         // cut the extra space at the end of the sequence
         oneLineRegion.length = qMin(visibleRange.endPos() - oneLineRegion.startPos, oneLineRegion.length);
-        singleLinePainter->drawCursor(p,
-                                      QSize(canvasSize.width(), getOneLineHeight()),
-                                      oneLineRegion);
+        singleLineRenderer->drawCursor(p,
+                                       QSize(canvasSize.width(), getOneLineHeight()),
+                                       oneLineRegion);
 
         p.translate(0, getOneLineHeight());
         indentCounter += getOneLineHeight();
@@ -218,7 +230,7 @@ void DetViewMultiLineRenderer::drawCursor(QPainter &p, const QSize &canvasSize, 
 }
 
 void DetViewMultiLineRenderer::update() {
-    singleLinePainter->update();
+    singleLineRenderer->update();
 }
 
 }    // namespace U2

--- a/src/corelibs/U2View/src/ov_sequence/view_rendering/DetViewMultiLineRenderer.h
+++ b/src/corelibs/U2View/src/ov_sequence/view_rendering/DetViewMultiLineRenderer.h
@@ -36,34 +36,34 @@ public:
     DetViewMultiLineRenderer(DetView *detView, SequenceObjectContext *ctx);
     ~DetViewMultiLineRenderer();
 
-    qint64 coordToPos(const QPoint &p, const QSize &canvasSize, const U2Region &visibleRange) const;
-    float posToXCoordF(const qint64 p, const QSize &canvasSize, const U2Region &visibleRange) const;
+    qint64 coordToPos(const QPoint &p, const QSize &canvasSize, const U2Region &visibleRange) const override;
+    float posToXCoordF(const qint64 p, const QSize &canvasSize, const U2Region &visibleRange) const override;
 
-    U2Region getAnnotationYRange(Annotation *a, int r, const AnnotationSettings *as, const QSize &canvasSize, const U2Region &visibleRange) const;
-    U2Region getMirroredYRange(const U2Strand &mStrand) const;
+    U2Region getAnnotationYRange(Annotation *annotation, int locationRegionIndex, const AnnotationSettings *annotationSettings, const QSize &canvasSize, const U2Region &visibleRange) const override;
+    U2Region getMirroredYRange(const U2Strand &mStrand) const override;
 
-    qint64 getMinimumHeight() const;
-    qint64 getOneLineHeight() const;
-    qint64 getLinesCount(const QSize &canvasSize) const;
-    qint64 getContentIndentY(const QSize &canvasSize, const U2Region &visibleRange) const;
+    qint64 getMinimumHeight() const override;
+    qint64 getOneLineHeight() const override;
+    qint64 getLinesCount(const QSize &canvasSize) const override;
+    qint64 getContentIndentY(const QSize &canvasSize, const U2Region &visibleRange) const override;
 
-    int getDirectLine() const;
+    int getDirectLine() const override;
 
-    int getRowsInLineCount() const;
+    int getRowsInLineCount() const override;
 
-    QSize getBaseCanvasSize(const U2Region &visibleRange) const;
+    QSize getBaseCanvasSize(const U2Region &visibleRange) const override;
 
-    bool isOnTranslationsLine(const QPoint &p, const QSize &canvasSize, const U2Region &visibleRange) const;
-    bool isOnAnnotationLine(const QPoint &p, Annotation *a, int region, const AnnotationSettings *as, const QSize &canvasSize, const U2Region &visibleRange) const;
+    bool isOnTranslationsLine(const QPoint &p, const QSize &canvasSize, const U2Region &visibleRange) const override;
+    bool isOnAnnotationLine(const QPoint &p, Annotation *a, int region, const AnnotationSettings *as, const QSize &canvasSize, const U2Region &visibleRange) const override;
 
-    void drawAll(QPainter &p, const QSize &canvasSize, const U2Region &visibleRange);
-    void drawSelection(QPainter &p, const QSize &canvasSize, const U2Region &visibleRange);
-    void drawCursor(QPainter &p, const QSize &canvasSize, const U2Region &visibleRange);
+    void drawAll(QPainter &p, const QSize &canvasSize, const U2Region &visibleRange) override;
+    void drawSelection(QPainter &p, const QSize &canvasSize, const U2Region &visibleRange) override;
+    void drawCursor(QPainter &p, const QSize &canvasSize, const U2Region &visibleRange) override;
 
-    void update();
+    void update() override;
 
 private:
-    DetViewSingleLineRenderer *singleLinePainter;
+    DetViewSingleLineRenderer *singleLineRenderer;
 
     int extraIndent;
 

--- a/src/corelibs/U2View/src/ov_sequence/view_rendering/SequenceViewAnnotatedRenderer.h
+++ b/src/corelibs/U2View/src/ov_sequence/view_rendering/SequenceViewAnnotatedRenderer.h
@@ -77,7 +77,14 @@ public:
 
     virtual double getCurrentScale() const = 0;
 
-    virtual U2Region getAnnotationYRange(Annotation *a, int r, const AnnotationSettings *as, const QSize &canvasSize, const U2Region &visibleRange) const = 0;
+    /**
+     * Returns on-screen Y-range of the annotation region in render area coordinates or an empty region if the view does not support this method.
+     * For multi-line views a region may span across multiple lines. In this case the method returns the region on the first line.
+     *
+     * TODO: this method is used only from isOnAnnotationLine(). They both can be replaced with
+     *  a more generic isScreenPointWithinAnnotationRegion(QPoint point, region ... ) which can be safely supported by all kind of views.
+     */
+    virtual U2Region getAnnotationYRange(Annotation *annotation, int locationRegionIndex, const AnnotationSettings *annotationSettings, const QSize &canvasSize, const U2Region &visibleRange) const = 0;
     virtual U2Region getMirroredYRange(const U2Strand &mStrand) const = 0;
 
     virtual qint64 getContentIndentY(const QSize &canvasSize, const U2Region &visibleRange) const = 0;


### PR DESCRIPTION
Notes: 
In the next CR, I plan to remove y-range related methods from the virtual interface: they won't be required from all views anymore.
The DetView method will be kept but maybe re-located to the tests package because we do not need it in runtime.

This CR is to unblock tests and to review the internal method code.