### PR TITLE
UGENE-7016. Tree branch expand/collapse state is not reflected in the…

### DIFF
--- a/src/corelibs/U2View/src/ov_msa/Export/MSAImageExportTask.cpp
+++ b/src/corelibs/U2View/src/ov_msa/Export/MSAImageExportTask.cpp
@@ -306,7 +306,7 @@ void MSAImageExportController::initSettingsWidget() {
     CHECK(!selection.isEmpty(), );
     msaSettings.region = U2Region(selection.x(), selection.width());
     msaSettings.seqIdx.clear();
-    if (!ui->isCollapsibleMode()) {
+    if (!ui->isVirtualOrderMode()) {
         for (qint64 i = selection.y(); i < selection.height() + selection.y(); i++) {
             msaSettings.seqIdx.append(i);
         }
@@ -385,7 +385,7 @@ bool MSAImageExportController::canExportToSvg() const {
 
 void MSAImageExportController::updateSeqIdx() const {
     CHECK(msaSettings.exportAll, );
-    if (!ui->isCollapsibleMode()) {
+    if (!ui->isVirtualOrderMode()) {
         msaSettings.seqIdx.clear();
         for (qint64 i = 0; i < ui->getEditor()->getNumSequences(); i++) {
             msaSettings.seqIdx.append(i);
@@ -393,7 +393,7 @@ void MSAImageExportController::updateSeqIdx() const {
         msaSettings.region = U2Region(0, ui->getEditor()->getAlignmentLen());
     }
 
-    CHECK(ui->isCollapsibleMode(), );
+    CHECK(ui->isVirtualOrderMode(), );
 
     MaCollapseModel *model = ui->getCollapseModel();
     SAFE_POINT(model != NULL, tr("MSA Collapsible Model is NULL"), );

--- a/src/corelibs/U2View/src/ov_msa/MSAEditor.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditor.cpp
@@ -509,11 +509,6 @@ void MSAEditor::sl_onContextMenuRequested(const QPoint & /*pos*/) {
     m.exec(QCursor::pos());
 }
 
-void MSAEditor::sl_onSeqOrderChanged(const QStringList &order) {
-    CHECK(!maObject->isStateLocked(), );
-    maObject->sortRowsByList(order);
-}
-
 void MSAEditor::sl_showTreeOP() {
     OptionsPanelWidget *opWidget = dynamic_cast<OptionsPanelWidget *>(optionsPanel->getMainWidget());
     if (opWidget == nullptr) {
@@ -776,8 +771,8 @@ void MSAEditor::sortSequences(const MultipleAlignment::SortType &sortType, const
     U2Region sortRange = selection.height() <= 1 ? U2Region() : U2Region(selection.y(), selection.height());
     msa->sortRows(sortType, sortOrder, sortRange);
 
-    // Drop collapsing mode.
-    getUI()->getSequenceArea()->sl_setCollapsingMode(false);
+    // Disable virtual mode.
+    getUI()->getSequenceArea()->sl_toggleVirtualOrderMode(false);
 
     QStringList rowNames = msa->getRowNames();
     if (rowNames != msaObject->getMultipleAlignment()->getRowNames()) {

--- a/src/corelibs/U2View/src/ov_msa/MSAEditor.h
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditor.h
@@ -114,7 +114,6 @@ protected slots:
     void sl_setSeqAsReference();
     void sl_unsetReferenceSeq();
 
-    void sl_onSeqOrderChanged(const QStringList &order);
     void sl_showTreeOP();
     void sl_hideTreeOP();
     void sl_rowsRemoved(const QList<qint64> &rowIds);

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.cpp
@@ -124,15 +124,15 @@ MSAEditorSequenceArea::MSAEditorSequenceArea(MaEditorWgt *_ui, GScrollBar *hb, G
     addSeqFromProjectAction->setObjectName("Sequence from current project");
     connect(addSeqFromProjectAction, SIGNAL(triggered()), SLOT(sl_addSeqFromProject()));
 
-    collapseModeSwitchAction = new QAction(QIcon(":core/images/collapse.png"), tr("Switch on/off collapsing"), this);
-    collapseModeSwitchAction->setObjectName("Enable collapsing");
-    collapseModeSwitchAction->setCheckable(true);
-    connect(collapseModeSwitchAction, SIGNAL(toggled(bool)), SLOT(sl_setCollapsingMode(bool)));
+    toggleVirtualOrderModeAction = new QAction(QIcon(":core/images/collapse.png"), tr("Switch on/off collapsing"), this);
+    toggleVirtualOrderModeAction->setObjectName("Enable collapsing");
+    toggleVirtualOrderModeAction->setCheckable(true);
+    connect(toggleVirtualOrderModeAction, SIGNAL(toggled(bool)), SLOT(sl_toggleVirtualOrderMode(bool)));
 
-    collapseModeUpdateAction = new QAction(QIcon(":core/images/collapse_update.png"), tr("Update collapsed groups"), this);
-    collapseModeUpdateAction->setObjectName("Update collapsed groups");
-    collapseModeUpdateAction->setEnabled(false);
-    connect(collapseModeUpdateAction, SIGNAL(triggered()), SLOT(sl_updateCollapsingMode()));
+    groupSequencesByContentAction = new QAction(QIcon(":core/images/collapse_update.png"), tr("Update collapsed groups"), this);
+    groupSequencesByContentAction->setObjectName("Update collapsed groups");
+    groupSequencesByContentAction->setEnabled(false);
+    connect(groupSequencesByContentAction, SIGNAL(triggered()), SLOT(sl_groupSequencesByContent()));
 
     reverseComplementAction = new QAction(tr("Replace selected rows with reverse-complement"), this);
     reverseComplementAction->setObjectName("replace_selected_rows_with_reverse-complement");
@@ -229,7 +229,7 @@ void MSAEditorSequenceArea::updateCollapseModel(const MaModificationInfo &modInf
     MaCollapseModel *collapseModel = ui->getCollapseModel();
     MultipleSequenceAlignmentObject *msaObject = getEditor()->getMaObject();
 
-    if (!ui->isCollapsibleMode()) {
+    if (!ui->isVirtualOrderMode()) {
         // Synchronize collapsible model with a current alignment.
         collapseModel->reset(getEditor()->getMaRowIds());
         return;
@@ -263,8 +263,8 @@ void MSAEditorSequenceArea::sl_buildStaticToolbar(GObjectView *v, QToolBar *t) {
     t->addAction(removeAllGapsAction);
     t->addSeparator();
 
-    t->addAction(collapseModeSwitchAction);
-    t->addAction(collapseModeUpdateAction);
+    t->addAction(toggleVirtualOrderModeAction);
+    t->addAction(groupSequencesByContentAction);
     t->addSeparator();
 }
 
@@ -353,7 +353,7 @@ void MSAEditorSequenceArea::sl_updateActions() {
     saveSequence->setEnabled(!isAlignmentEmpty());
     addSeqFromProjectAction->setEnabled(!readOnly);
     addSeqFromFileAction->setEnabled(!readOnly);
-    collapseModeSwitchAction->setEnabled(!readOnly && !isAlignmentEmpty());
+    toggleVirtualOrderModeAction->setEnabled(!readOnly && !isAlignmentEmpty());
 
     //Update actions of "Edit" group
     bool canEditAlignment = !readOnly && !isAlignmentEmpty();
@@ -516,8 +516,8 @@ void MSAEditorSequenceArea::sl_saveSequence() {
 void MSAEditorSequenceArea::sl_modelChanged() {
     MaCollapseModel *collapsibleModel = ui->getCollapseModel();
     if (!collapsibleModel->hasGroupsWithMultipleRows()) {
-        collapseModeSwitchAction->setChecked(false);
-        collapseModeUpdateAction->setEnabled(false);
+        toggleVirtualOrderModeAction->setChecked(false);
+        groupSequencesByContentAction->setEnabled(false);
     }
     MaEditorSequenceArea::sl_modelChanged();
 }
@@ -670,30 +670,30 @@ void MSAEditorSequenceArea::sl_addSeqFromProject() {
     }
 }
 
-void MSAEditorSequenceArea::sl_setCollapsingMode(bool enabled) {
+void MSAEditorSequenceArea::sl_toggleVirtualOrderMode(bool enabled) {
     CHECK(getEditor() != nullptr, );
     GCOUNTER(cvar, "Switch collapsing mode");
 
     MultipleSequenceAlignmentObject *msaObject = getEditor()->getMaObject();
     if (msaObject == nullptr || msaObject->isStateLocked()) {
-        if (collapseModeSwitchAction->isChecked()) {
-            collapseModeSwitchAction->setChecked(false);
-            collapseModeUpdateAction->setEnabled(false);
+        if (toggleVirtualOrderModeAction->isChecked()) {
+            toggleVirtualOrderModeAction->setChecked(false);
+            groupSequencesByContentAction->setEnabled(false);
         }
         return;
     }
 
-    bool isCollapseModeChanged = ui->isCollapsibleMode() != enabled;
-    ui->setCollapsibleMode(enabled);
-    collapseModeUpdateAction->setEnabled(enabled);
+    bool isChanged = ui->isVirtualOrderMode() != enabled;
+    ui->setVirtualOrderMode(enabled);
+    groupSequencesByContentAction->setEnabled(enabled);
 
     if (enabled) {
-        sl_updateCollapsingMode();
+        sl_groupSequencesByContent();
     } else {
         ui->getCollapseModel()->reset(editor->getMaRowIds());
     }
 
-    if (isCollapseModeChanged) {
+    if (isChanged) {
         setSelection(MaEditorSelection());
     }
 
@@ -701,7 +701,7 @@ void MSAEditorSequenceArea::sl_setCollapsingMode(bool enabled) {
     emit si_collapsingModeChanged();
 }
 
-void MSAEditorSequenceArea::sl_updateCollapsingMode() {
+void MSAEditorSequenceArea::sl_groupSequencesByContent() {
     MaModificationInfo mi;
     mi.alignmentLengthChanged = false;
     updateCollapseModel(mi);
@@ -816,39 +816,32 @@ void MSAEditorSequenceArea::sl_complementCurrentSelection() {
     reverseComplementModification(type);
 }
 
-void MSAEditorSequenceArea::sl_setCollapsingRegions(const QList<QStringList> &collapsedGroups) {
-    CHECK(getEditor() != nullptr, );
+void MSAEditorSequenceArea::sl_setVirtualGroupingMode(const QList<QStringList> &collapsedGroups) {
     MultipleSequenceAlignmentObject *msaObject = getEditor()->getMaObject();
-    if (msaObject->isStateLocked()) {
-        collapseModeSwitchAction->setChecked(false);
-        return;
-    }
-
-    MaCollapseModel *collapseModel = ui->getCollapseModel();
     QStringList rowNames = msaObject->getMultipleAlignment()->getRowNames();
+    QList<qint64> rowIds = msaObject->getRowIds();
 
-    // Calculate regions of collapsible groups
-    QVector<U2Region> collapsedRegions;
-    foreach (const QStringList &seqsGroup, collapsedGroups) {
-        int regionStartIdx = rowNames.size() - 1;
-        int regionEndIdx = 0;
-        foreach (const QString &seqName, seqsGroup) {
-            int sequenceIdx = rowNames.indexOf(seqName);
-            regionStartIdx = qMin(sequenceIdx, regionStartIdx);
-            regionEndIdx = qMax(sequenceIdx, regionEndIdx);
+    // The result list of virtual groups.
+    QVector<MaCollapsibleGroup> collapsibleGroupList;
+
+    for (const QStringList &groupSequenceNameList : qAsConst(collapsedGroups)) {
+        QList<int> maRowIndexList;
+        QList<qint64> maRowIdList;
+        for (const QString &sequenceName : qAsConst(groupSequenceNameList)) {
+            int rowIndex = rowNames.indexOf(sequenceName);
+            SAFE_POINT(rowIndex >= 0, "Row is not found: " + sequenceName, );
+            maRowIndexList << rowIndex;
+            maRowIdList << rowIds[rowIndex];
         }
-        if (regionStartIdx >= 0 && regionEndIdx < rowNames.size() && regionEndIdx > regionStartIdx) {
-            U2Region collapsedGroupRegion(regionStartIdx, regionEndIdx - regionStartIdx + 1);
-            collapsedRegions.append(collapsedGroupRegion);
-        }
+        // All groups are collapsed by default for compatibility. TODO: make it configurable.
+        bool isCollapsed = maRowIndexList.length() > 1;
+        collapsibleGroupList << MaCollapsibleGroup(maRowIndexList, maRowIdList, isCollapsed);
     }
-    if (collapsedRegions.length() > 0) {
-        ui->setCollapsibleMode(true);
-        collapseModel->updateFromUnitedRows(collapsedRegions, editor->getMaRowIds());
-    }
+    ui->setVirtualOrderMode(true);
+    ui->getCollapseModel()->update(collapsibleGroupList);
 }
 
-ExportHighligtningTask::ExportHighligtningTask(ExportHighligtingDialogController *dialog, MaEditor *maEditor)
+ExportHighlightingTask::ExportHighlightingTask(ExportHighligtingDialogController *dialog, MaEditor *maEditor)
     : Task(tr("Export highlighting"), TaskFlags_FOSCOE | TaskFlag_ReportingIsSupported | TaskFlag_ReportingIsEnabled) {
     msaEditor = qobject_cast<MSAEditor *>(maEditor);
     startPos = dialog->startPos;
@@ -860,7 +853,7 @@ ExportHighligtningTask::ExportHighligtningTask(ExportHighligtingDialogController
     url = dialog->url;
 }
 
-void ExportHighligtningTask::run() {
+void ExportHighlightingTask::run() {
     QString exportedData = exportHighlighting(startPos, endPos, startingIndex, keepGaps, dots, transpose);
     QFile resultFile(url.getURLString());
     CHECK_EXT(resultFile.open(QFile::WriteOnly | QFile::Truncate), url.getURLString(), );
@@ -868,11 +861,11 @@ void ExportHighligtningTask::run() {
     contentWriter << exportedData;
 }
 
-Task::ReportResult ExportHighligtningTask::report() {
+Task::ReportResult ExportHighlightingTask::report() {
     return ReportResult_Finished;
 }
 
-QString ExportHighligtningTask::generateReport() const {
+QString ExportHighlightingTask::generateReport() const {
     QString res;
     if (!isCanceled() && !hasError()) {
         res += "<b>" + tr("Export highlighting finished successfully") + "</b><br><b>" + tr("Result file:") + "</b> " + url.getURLString();
@@ -880,7 +873,7 @@ QString ExportHighligtningTask::generateReport() const {
     return res;
 }
 
-QString ExportHighligtningTask::exportHighlighting(int startPos, int endPos, int startingIndex, bool keepGaps, bool dots, bool transpose) {
+QString ExportHighlightingTask::exportHighlighting(int startPos, int endPos, int startingIndex, bool keepGaps, bool dots, bool transpose) {
     CHECK(msaEditor != nullptr, QString());
     SAFE_POINT(msaEditor->getReferenceRowId() != U2MsaRow::INVALID_ROW_ID, "Export highlighting is not supported without a reference", QString());
     QStringList result;

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.h
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.h
@@ -133,7 +133,13 @@ public:
     bool hasAminoAlphabet();
 
 public slots:
-    void sl_setCollapsingMode(bool enabled);
+
+    /**
+     * Enables/disables virtual order mode for the MSA.
+     * When enabled automatically groups sequences by their content: calls sl_groupSequencesByContent().
+     */
+    void sl_toggleVirtualOrderMode(bool enabled);
+
     void sl_copySelectionFormatted();
 
 protected:
@@ -160,7 +166,13 @@ private slots:
     void sl_delCol();
     void sl_goto();
     void sl_removeAllGaps();
-    void sl_updateCollapsingMode();
+
+    /**
+     * Groups sequences by content, so each group contains only sequences with the equal base (gaps-excluded) content.
+     * Works a a part of virtual ordering mode only.
+     */
+    void sl_groupSequencesByContent();
+
     void sl_reverseComplementCurrentSelection();
     void sl_reverseCurrentSelection();
     void sl_complementCurrentSelection();
@@ -173,7 +185,12 @@ private slots:
 
     void sl_modelChanged();
 
-    void sl_setCollapsingRegions(const QList<QStringList> &);
+    /**
+     * Enables virtual grouping mode. Re-orders and re-groups sequences according to the name lists.
+     * TODO: rework to use sequence IDs. Multiple same-name sequences can be present in the list.
+     */
+    void sl_setVirtualGroupingMode(const QList<QStringList> &);
+
     void sl_fontChanged(QFont font);
 
     void sl_alphabetChanged(const MaModificationInfo &mi, const DNAAlphabet *prevAlphabet);
@@ -197,18 +214,30 @@ private:
     QAction *saveSequence;
     QAction *addSeqFromFileAction;
     QAction *addSeqFromProjectAction;
-    QAction *collapseModeSwitchAction;
-    QAction *collapseModeUpdateAction;
+
+    /**
+     * Toggles state of the virtual order mode.
+     * TODO: this is a global action for MA editor. Move it to the M(S)AEditor.h
+     */
+    QAction *toggleVirtualOrderModeAction;
+
+    /**
+     * Joins sequences with the equal content into a single collapsible group.
+     * Enabled only in the virtual grouping mode.
+     * TODO: this is a global action for MA editor. Move it to M(S)AEditor.h
+     */
+    QAction *groupSequencesByContentAction;
+
     QAction *reverseComplementAction;
     QAction *reverseAction;
     QAction *complementAction;
 };
 
 // SANGER_TODO: move to EditorTasks?
-class U2VIEW_EXPORT ExportHighligtningTask : public Task {
+class U2VIEW_EXPORT ExportHighlightingTask : public Task {
     Q_OBJECT
 public:
-    ExportHighligtningTask(ExportHighligtingDialogController *dialog, MaEditor *editor);
+    ExportHighlightingTask(ExportHighligtingDialogController *dialog, MaEditor *editor);
 
     void run();
     QString generateReport() const;

--- a/src/corelibs/U2View/src/ov_msa/MaCollapseModel.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaCollapseModel.cpp
@@ -69,34 +69,6 @@ void MaCollapseModel::update(const QVector<MaCollapsibleGroup> &newGroups) {
     emit si_toggled();
 }
 
-void MaCollapseModel::updateFromUnitedRows(const QVector<U2Region> &unitedRows, const QList<qint64> &allOrderedMaRowIds) {
-    QVector<U2Region> sortedRegions = unitedRows;
-    qSort(sortedRegions);
-    QVector<MaCollapsibleGroup> newGroups;
-    int maIndex = 0;
-    foreach (const U2Region region, unitedRows) {
-        for (; maIndex < region.startPos; maIndex++) {
-            newGroups.append(MaCollapsibleGroup(maIndex, allOrderedMaRowIds[maIndex], true));
-        }
-        QList<int> maRows;
-        QList<qint64> maRowIds;
-        for (; maIndex < region.endPos(); maIndex++) {
-            maRows << maIndex;
-            maRowIds << allOrderedMaRowIds[maIndex];
-        }
-        newGroups.append(MaCollapsibleGroup(maRows, maRowIds, true));
-    }
-    int numSequences = allOrderedMaRowIds.size();
-    for (; maIndex < numSequences; maIndex++) {
-        newGroups.append(MaCollapsibleGroup(maIndex, allOrderedMaRowIds[maIndex], true));
-    }
-    // Copy collapse info from the current state.
-    for (int i = 0, n = qMin(newGroups.size(), groups.size()); i < n; i++) {
-        newGroups[i].isCollapsed = groups[i].isCollapsed;
-    }
-    update(newGroups);
-}
-
 void MaCollapseModel::reset(const QList<qint64> &allOrderedMaRowIds, const QSet<int> &expandedGroupIndexes) {
     QVector<MaCollapsibleGroup> newGroups;
     int numSequences = allOrderedMaRowIds.size();

--- a/src/corelibs/U2View/src/ov_msa/MaCollapseModel.h
+++ b/src/corelibs/U2View/src/ov_msa/MaCollapseModel.h
@@ -35,10 +35,10 @@ namespace U2 {
 class MaCollapsibleGroup {
 public:
     /* Creates with 1 MA row inside. */
-    MaCollapsibleGroup(int maRow, qint64 maRowId, bool isCollapsed = false);
+    MaCollapsibleGroup(int maRowIndex, qint64 maRowId, bool isCollapsed = false);
 
     /* Creates new collapsible group item that starts with maRowIndex and has numRows inside. */
-    MaCollapsibleGroup(const QList<int> &maRows, const QList<qint64> &maRowIds, bool isCollapsed = false);
+    MaCollapsibleGroup(const QList<int> &maRowIndexList, const QList<qint64> &maRowIds, bool isCollapsed = false);
 
     /* Creates empty group. This method should not be used directly but is required by the Vector<MaCollapsibleGroup>. */
     MaCollapsibleGroup();
@@ -78,12 +78,6 @@ public:
 
     /* Updates model to the given groups. */
     void update(const QVector<MaCollapsibleGroup> &groups);
-
-    /**
-     * Updates collapse model using united rows as input.
-     * 'allOrderedMaRowIds' is a list of all ma row ids in the alignment.
-     */
-    void updateFromUnitedRows(const QVector<U2Region> &unitedRows, const QList<qint64> &allOrderedMaRowIds);
 
     /*
      * Flattens all collapsible groups: makes every group contain only 1 sequence.

--- a/src/corelibs/U2View/src/ov_msa/MaEditor.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditor.cpp
@@ -351,7 +351,7 @@ void MaEditor::sl_exportHighlighted() {
     CHECK(!d.isNull(), );
 
     if (d->result() == QDialog::Accepted) {
-        AppContext::getTaskScheduler()->registerTopLevelTask(new ExportHighligtningTask(d.data(), this));
+        AppContext::getTaskScheduler()->registerTopLevelTask(new ExportHighlightingTask(d.data(), this));
     }
 }
 

--- a/src/corelibs/U2View/src/ov_msa/MaEditorNameList.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorNameList.cpp
@@ -171,7 +171,7 @@ void MaEditorNameList::updateScrollBar() {
         maxNameWidth = qMax(fm.width(row->getName()), maxNameWidth);
     }
     // adjustment for branch primitive in collapsing mode
-    if (ui->isCollapsibleMode()) {
+    if (ui->isVirtualOrderMode()) {
         maxNameWidth += 2 * CROSS_SIZE + CHILDREN_OFFSET;
     }
 
@@ -679,7 +679,7 @@ void MaEditorNameList::drawContent(QPainter &painter) {
     SAFE_POINT_OP(os, );
 
     const MaCollapseModel *collapsibleModel = ui->getCollapseModel();
-    int crossSpacing = ui->isCollapsibleMode() ? CROSS_SIZE * 2 : 0;
+    int crossSpacing = ui->isVirtualOrderMode() ? CROSS_SIZE * 2 : 0;
     const ScrollController *scrollController = ui->getScrollController();
     int firstVisibleViewRow = scrollController->getFirstVisibleViewRowIndex(true);
     int lastVisibleViewRow = scrollController->getLastVisibleViewRowIndex(height(), true);
@@ -863,7 +863,7 @@ void MaEditorNameList::scrollSelectionToView(bool fromStart) {
 }
 
 bool MaEditorNameList::triggerExpandCollapseOnSelectedRow(bool collapse) {
-    if (!ui->isCollapsibleMode()) {
+    if (!ui->isVirtualOrderMode()) {
         return false;
     }
     U2Region selection = getSelection();

--- a/src/corelibs/U2View/src/ov_msa/McaEditorWgt.cpp
+++ b/src/corelibs/U2View/src/ov_msa/McaEditorWgt.cpp
@@ -76,7 +76,7 @@ McaEditorWgt::McaEditorWgt(McaEditor *editor)
     nameAreaLayout->setContentsMargins(0, TOP_INDENT, 0, 0);
 
     // MCA editor has "always ON" collapsible mode.
-    collapsibleMode = true;
+    virtualOrderMode = true;
     enableCollapsingOfSingleRowGroups = true;
     collapseModel->reset(editor->getMaRowIds());
 

--- a/src/corelibs/U2View/src/ov_msa/PhyTrees/MSAEditorTreeManager.h
+++ b/src/corelibs/U2View/src/ov_msa/PhyTrees/MSAEditorTreeManager.h
@@ -45,8 +45,6 @@ class MSAEditorTreeManager : public QObject {
     Q_OBJECT
 public:
     MSAEditorTreeManager(MSAEditor *msaEditor);
-    ~MSAEditorTreeManager() {
-    }
 
     void loadRelatedTrees();
 

--- a/src/corelibs/U2View/src/ov_msa/PhyTrees/MSAEditorTreeViewer.cpp
+++ b/src/corelibs/U2View/src/ov_msa/PhyTrees/MSAEditorTreeViewer.cpp
@@ -129,6 +129,10 @@ bool MSAEditorTreeViewer::sync() {
     sortSeqAction->setEnabled(true);
     treeViewerUI->sl_sortAlignment();
     treeViewerUI->highlightBranches();
+
+    // Trigger si_visibleRangeChanged that will make tree widget update geometry to the correct scale. TODO: create a better API for this.
+    editor->getUI()->getSequenceArea()->onVisibleRangeChanged();
+
     return true;
 }
 

--- a/src/corelibs/U2View/src/ov_msa/PhyTrees/MSAEditorTreeViewer.cpp
+++ b/src/corelibs/U2View/src/ov_msa/PhyTrees/MSAEditorTreeViewer.cpp
@@ -164,8 +164,7 @@ void MSAEditorTreeViewer::connectSignals() {
 
     connect(msaUI, SIGNAL(si_startMaChanging()), this, SLOT(sl_stopTracking()));
 
-    connect(treeViewerUI, SIGNAL(si_seqOrderChanged(const QStringList &)), editor, SLOT(sl_onSeqOrderChanged(const QStringList &)));
-    connect(treeViewerUI, SIGNAL(si_collapseModelChangedInTree(const QList<QStringList> &)), msaUI->getSequenceArea(), SLOT(sl_setCollapsingRegions(const QList<QStringList> &)));
+    connect(treeViewerUI, SIGNAL(si_collapseModelChangedInTree(const QList<QStringList> &)), msaUI->getSequenceArea(), SLOT(sl_setVirtualGroupingMode(const QList<QStringList> &)));
     connect(treeViewerUI, SIGNAL(si_groupColorsChanged(const GroupColorSchema &)), msaUI->getEditorNameList(), SLOT(sl_onGroupColorsChanged(const GroupColorSchema &)));
 
     connect(editor, SIGNAL(si_referenceSeqChanged(qint64)), treeViewerUI, SLOT(sl_onReferenceSeqChanged(qint64)));
@@ -189,8 +188,7 @@ void MSAEditorTreeViewer::disconnectSignals() {
 
     disconnect(msaUI, SIGNAL(si_startMaChanging()), this, SLOT(sl_stopTracking()));
 
-    disconnect(treeViewerUI, SIGNAL(si_seqOrderChanged(const QStringList &)), editor, SLOT(sl_onSeqOrderChanged(const QStringList &)));
-    disconnect(treeViewerUI, SIGNAL(si_collapseModelChangedInTree(const QList<QStringList> &)), msaUI->getSequenceArea(), SLOT(sl_setCollapsingRegions(const QList<QStringList> &)));
+    disconnect(treeViewerUI, SIGNAL(si_collapseModelChangedInTree(const QList<QStringList> &)), msaUI->getSequenceArea(), SLOT(sl_setVirtualGroupingMode(const QList<QStringList> &)));
     disconnect(treeViewerUI, SIGNAL(si_groupColorsChanged(const GroupColorSchema &)), msaUI->getEditorNameList(), SLOT(sl_onGroupColorsChanged(const GroupColorSchema &)));
 
     disconnect(editor, SIGNAL(si_referenceSeqChanged(qint64)), treeViewerUI, SLOT(sl_onReferenceSeqChanged(qint64)));
@@ -495,63 +493,6 @@ void MSAEditorTreeViewerUI::sl_sequenceNameChanged(QString prevName, QString new
     scene()->update();
 }
 
-typedef QPair<qreal, QString> NameWithValuePair;
-
-QStringList MSAEditorTreeViewerUI::getOrderedSeqNames() {
-    QList<QGraphicsItem *> items = scene()->items();
-    QList<NameWithValuePair> namesAndHeightPairList;
-
-    for (QGraphicsItem *item : qAsConst(items)) {
-        GraphicsRectangularBranchItem *branchItem = dynamic_cast<GraphicsRectangularBranchItem *>(item);
-        if (branchItem == nullptr) {
-            continue;
-        }
-        QGraphicsSimpleTextItem *nameItem = branchItem->getNameText();
-        if (nameItem == nullptr) {
-            continue;
-        }
-        qreal y = branchItem->scenePos().y();
-        QString str = nameItem->text();
-        namesAndHeightPairList.append(QPair<qreal, QString>(y, str));
-    }
-    qSort(namesAndHeightPairList.begin(), namesAndHeightPairList.end());
-
-    QStringList seqNames;
-    for (const NameWithValuePair &pair : qAsConst(namesAndHeightPairList)) {
-        seqNames.append(pair.second);
-    }
-
-    getTreeSize();
-
-    return seqNames;
-}
-U2Region MSAEditorTreeViewerUI::getTreeSize() {
-    QList<QGraphicsItem *> items = scene()->items();
-
-    QRectF sceneRect = scene()->sceneRect();
-    qreal minYPos = sceneRect.top();
-    qreal maxYPos = sceneRect.bottom();
-
-    for (QGraphicsItem *item : qAsConst(items)) {
-        auto branchItem = dynamic_cast<GraphicsRectangularBranchItem *>(item);
-        if (branchItem == nullptr) {
-            continue;
-        }
-        QGraphicsSimpleTextItem *nameItem = branchItem->getNameText();
-        if (nameItem == nullptr) {
-            continue;
-        }
-        qreal y = branchItem->scenePos().y();
-        minYPos = qMin(minYPos, y);
-        maxYPos = qMax(maxYPos, y);
-    }
-
-    int minH = mapFromScene(0, minYPos).y();
-    int maxH = mapFromScene(0, maxYPos).y();
-
-    return U2Region(minH, maxH - minH);
-}
-
 void MSAEditorTreeViewerUI::setTreeLayout(TreeLayout newLayout) {
     TreeViewerUI::setTreeLayout(newLayout);
 }
@@ -593,7 +534,9 @@ void MSAEditorTreeViewerUI::sl_onReferenceSeqChanged(qint64) {
 }
 
 void MSAEditorTreeViewerUI::sl_sortAlignment() {
-    emit si_seqOrderChanged(getOrderedSeqNames());
+    // Apply current tree order & collapsing to the alignment.
+    QList<QStringList> groupList = getGroupingStateForMsa(rectRoot);
+    emit si_collapseModelChangedInTree(groupList);
 }
 
 void MSAEditorTreeViewerUI::highlightBranches() {
@@ -806,34 +749,47 @@ void MSAEditorTreeViewerUI::sl_onVisibleRangeChanged(QStringList visibleSeqs, in
 
 void MSAEditorTreeViewerUI::sl_onBranchCollapsed(GraphicsRectangularBranchItem *branch) {
     TreeViewerUI::sl_onBranchCollapsed(branch);
-    QList<QStringList> collapsedGroups = MSAEditorTreeViewerUtils::getCollapsedGroups(rectRoot);
-    emit si_collapseModelChangedInTree(collapsedGroups);
+    sl_sortAlignment();
 }
 
-QList<QStringList> MSAEditorTreeViewerUtils ::getCollapsedGroups(const GraphicsBranchItem *root) {
-    QList<QStringList> result;
+QList<QStringList> MSAEditorTreeViewerUI::getGroupingStateForMsa(const GraphicsBranchItem *root) const {
+    QList<QStringList> groupList;
 
-    QStack<const GraphicsBranchItem *> treeBranches;
-    treeBranches.push(root);
+    // treeBranchStack is used here for Depth-First-Search algorithm implementation with no recursion.
+    QStack<const GraphicsBranchItem *> treeBranchStack;
+    treeBranchStack.push(root);
 
-    do {
-        const GraphicsBranchItem *parentBranch = treeBranches.pop();
-        if (parentBranch->isCollapsed()) {
-            result.append(getSeqsNamesInBranch(parentBranch));
+    while (!treeBranchStack.isEmpty()) {
+        const GraphicsBranchItem *branchItem = treeBranchStack.pop();
+        if (branchItem->isCollapsed()) {
+            groupList.append(MSAEditorTreeViewerUtils::getSeqsNamesInBranch(branchItem));
             continue;
         }
 
-        QList<QGraphicsItem *> childItemList = parentBranch->childItems();
-        for (QGraphicsItem *graphItem : qAsConst(childItemList)) {
-            auto childrenBranch = dynamic_cast<GraphicsBranchItem *>(graphItem);
-            if (childrenBranch == nullptr) {
+        QGraphicsSimpleTextItem *branchNameItem = branchItem->getNameText();
+        if (branchNameItem != nullptr && !branchNameItem->text().isEmpty()) {
+            // Add this leaf of as a separate non-grouped sequence to the list.
+            groupList.append({branchNameItem->text()});
+            continue;
+        }
+
+        QList<QGraphicsItem *> childItemList = branchItem->childItems();
+
+        // Sort items by Y, so virtual order will be the same with the tree.
+        std::sort(childItemList.begin(), childItemList.end(), [](QGraphicsItem *item1, QGraphicsItem *item2) {
+            return item1->y() - item2->y();
+        });
+
+        for (QGraphicsItem *childItem : qAsConst(childItemList)) {
+            auto childBranchItem = dynamic_cast<GraphicsBranchItem *>(childItem);
+            if (childBranchItem == nullptr) {
                 continue;
             }
-            treeBranches.push(childrenBranch);
+            treeBranchStack.push(childBranchItem);
         }
-    } while (!treeBranches.isEmpty());
+    }
 
-    return result;
+    return groupList;
 }
 
 QStringList MSAEditorTreeViewerUtils::getSeqsNamesInBranch(const GraphicsBranchItem *branch) {

--- a/src/corelibs/U2View/src/ov_msa/PhyTrees/MSAEditorTreeViewer.h
+++ b/src/corelibs/U2View/src/ov_msa/PhyTrees/MSAEditorTreeViewer.h
@@ -131,16 +131,18 @@ public:
         emit si_groupColorsChanged(GroupColorSchema());
     }
 
-    QStringList getOrderedSeqNames();
-
-    U2Region getTreeSize();
-
     bool canSynchronizeWithMSA(MSAEditor *msa);
 
     void setSynchronizeMode(SynchronizationMode syncMode);
     bool isCurTreeViewerSynchronized() const;
 
     void highlightBranches();
+
+    /**
+     * Return virtual grouping state for MSA that corresponds to the current tree state.
+     * All sequences are ordered by 'y' position. All collapsed branches are mapped to the virtual groups.
+     */
+    QList<QStringList> getGroupingStateForMsa(const GraphicsBranchItem *root) const;
 
 protected:
     virtual void mousePressEvent(QMouseEvent *e);
@@ -156,7 +158,6 @@ protected:
 
 signals:
     void si_collapseModelChangedInTree(const QList<QStringList> &);
-    void si_seqOrderChanged(const QStringList &order);
     void si_groupColorsChanged(const GroupColorSchema &schema);
     void si_zoomIn();
     void si_zoomOut();
@@ -199,11 +200,10 @@ private:
 };
 
 class MSAEditorTreeViewerUtils {
-public:
-    static QList<QStringList> getCollapsedGroups(const GraphicsBranchItem *root);
-
 private:
     MSAEditorTreeViewerUtils();
+
+public:
     static QStringList getSeqsNamesInBranch(const GraphicsBranchItem *branch);
 };
 

--- a/src/corelibs/U2View/src/ov_msa/find_pattern/FindPatternMsaWidget.cpp
+++ b/src/corelibs/U2View/src/ov_msa/find_pattern/FindPatternMsaWidget.cpp
@@ -1116,7 +1116,7 @@ void FindPatternMsaWidget::sl_groupResultsButtonClicked() {
     CHECK(!maObject->isStateLocked(), );
 
     // Drop grouping mode.
-    msaEditor->getUI()->getSequenceArea()->sl_setCollapsingMode(false);
+    msaEditor->getUI()->getSequenceArea()->sl_toggleVirtualOrderMode(false);
 
     QSet<qint64> resultUidSet;
     for (const FindPatternWidgetResult &result : qAsConst(allSearchResults)) {

--- a/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorSequenceArea.h
+++ b/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorSequenceArea.h
@@ -291,8 +291,8 @@ public:
     MaMode getModInfo();
 
 protected:
-    MaEditor *editor;
-    MaEditorWgt *ui;
+    MaEditor *const editor;
+    MaEditorWgt *const ui;
 
     MsaColorScheme *colorScheme;
     MsaHighlightingScheme *highlightingScheme;

--- a/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorWgt.cpp
+++ b/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorWgt.cpp
@@ -65,7 +65,7 @@ MaEditorWgt::MaEditorWgt(MaEditor *editor)
       seqAreaLayout(nullptr),
       nameAreaLayout(nullptr),
       collapseModel(new MaCollapseModel(this, editor->getMaRowIds())),
-      collapsibleMode(false),
+      virtualOrderMode(false),
       enableCollapsingOfSingleRowGroups(false),
       scrollController(new ScrollController(editor, this, collapseModel)),
       baseWidthController(new BaseWidthController(this)),
@@ -290,6 +290,14 @@ void MaEditorWgt::sl_countUndo() {
 
 void MaEditorWgt::sl_countRedo() {
     GCounter::increment("Redo", editor->getFactoryId());
+}
+
+bool MaEditorWgt::isVirtualOrderMode() const {
+    return virtualOrderMode;
+}
+
+void MaEditorWgt::setVirtualOrderMode(bool flag) {
+    virtualOrderMode = flag;
 }
 
 }    // namespace U2

--- a/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorWgt.h
+++ b/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorWgt.h
@@ -107,19 +107,14 @@ public:
 
     QAction *getRedoAction() const;
 
-    /* Returns if collapsible mode is enabled or not.
-     *
-     * Note: the collapsible model is used regardless if collapsible mode is enabled or not,
-     * but have different features: in the collapsible mode the model can contains group of multiple sequences
-     * or reordered rows.
-     */
-    bool isCollapsibleMode() const {
-        return collapsibleMode;
-    }
+    /* Returns 'true' if the virtual ordering/grouping mode is enabled. See docs for 'virtualOrderMode' for more details. */
+    bool isVirtualOrderMode() const;
 
-    void setCollapsibleMode(bool collapse) {
-        collapsibleMode = collapse;
-    }
+    /*
+     * Sets virtual grouping mode ON or OFF.
+     * A trivial method that updates the flag in the view model with no other actions/callbacks.
+     */
+    void setVirtualOrderMode(bool flag);
 
     MaCollapseModel *getCollapseModel() const {
         return collapseModel;
@@ -180,7 +175,27 @@ protected:
     MsaUndoRedoFramework *undoFWK;
 
     MaCollapseModel *collapseModel;
-    bool collapsibleMode;
+
+    /**
+     * If true, the 'collapseModel' holds virtual ordering/grouping state.
+     * Otherwise 'collapseModel' contains a trivial (1:1) mapping of in-view row indexes to the file indexes that are always the same.
+     *
+     * This virtual state is never saved to MA file and is preserved in the current view only in runtime.
+     *
+     * Examples of use of virtual grouping/ordering state:
+     *  - Group of sequences with the common content: reorder + groups.
+     *  - Tree sync mode: reorder + groups.
+     *  - Any other mode that requires grouping & expand-collapse capabilities.
+     *
+     * Examples of non-virtual (in-file order modifications):
+     *  - Sort by name, length, leading gap size.
+     *  - Drag & drop or rows in the non-virutalOrderingMode.
+     *
+     *  The virtual ordering/grouping can be applied to read-only alignments.
+     *  Any changes to the order while in the virtualOrderMode are not saved to the MA file.
+     */
+    bool virtualOrderMode;
+
     bool enableCollapsingOfSingleRowGroups;
     ScrollController *scrollController;
     BaseWidthController *baseWidthController;

--- a/src/corelibs/U2View/src/ov_phyltree/GraphicsBranchItem.h
+++ b/src/corelibs/U2View/src/ov_phyltree/GraphicsBranchItem.h
@@ -24,6 +24,8 @@
 
 #include <QAbstractGraphicsShapeItem>
 
+#include <U2Core/global.h>
+
 #include "TreeSettings.h"
 
 namespace U2 {
@@ -31,7 +33,7 @@ namespace U2 {
 class PhyNode;
 class GraphicsButtonItem;
 
-class GraphicsBranchItem : public QAbstractGraphicsShapeItem {
+class U2VIEW_EXPORT GraphicsBranchItem : public QAbstractGraphicsShapeItem {
 public:
     enum Direction { up,
                      down };

--- a/src/corelibs/U2View/src/ov_phyltree/GraphicsRectangularBranchItem.h
+++ b/src/corelibs/U2View/src/ov_phyltree/GraphicsRectangularBranchItem.h
@@ -32,7 +32,7 @@ class PhyNode;
 class PhyBranch;
 class GraphicsButtonItem;
 
-class GraphicsRectangularBranchItem : public QObject, public GraphicsBranchItem {
+class U2VIEW_EXPORT GraphicsRectangularBranchItem : public QObject, public GraphicsBranchItem {
     Q_OBJECT
 public:
     static const qreal DEFAULT_WIDTH;

--- a/src/plugins/GUITestBase/GUITestBase.pro
+++ b/src/plugins/GUITestBase/GUITestBase.pro
@@ -219,6 +219,7 @@ HEADERS +=  src/GUITestBasePlugin.h \
             src/tests/common_scenarios/msa_editor/align/GTTestsAlignSequenceToMsa.h \
             src/tests/common_scenarios/msa_editor/colors/GTTestsMSAEditorColors.h \
             src/tests/common_scenarios/msa_editor/consensus/GTTestsMSAEditorConsensus.h \
+            src/tests/common_scenarios/msa_editor/tree/GTTestsMSAEditorTree.h \
             src/tests/common_scenarios/msa_editor/edit/GTTestsMSAEditorEdit.h \
             src/tests/common_scenarios/msa_editor/replace_character/GTTestsMSAEditorReplaceCharacter.h \
             src/tests/common_scenarios/msa_editor/overview/GTTestsMSAEditorOverview.h \
@@ -490,6 +491,7 @@ SOURCES +=  src/GUITestBasePlugin.cpp \
             src/tests/common_scenarios/msa_editor/align/GTTestsAlignSequenceToMsa.cpp \
             src/tests/common_scenarios/msa_editor/colors/GTTestsMSAEditorColors.cpp \
             src/tests/common_scenarios/msa_editor/consensus/GTTestsMSAEditorConsensus.cpp \
+            src/tests/common_scenarios/msa_editor/tree/GTTestsMSAEditorTree.cpp \
             src/tests/common_scenarios/msa_editor/edit/GTTestsMSAEditorEdit.cpp  \
             src/tests/common_scenarios/msa_editor/replace_character/GTTestsMSAEditorReplaceCharacter.cpp \
             src/tests/common_scenarios/msa_editor/overview/GTTestsMSAEditorOverview.cpp \

--- a/src/plugins/GUITestBase/src/GUITestBasePlugin.cpp
+++ b/src/plugins/GUITestBase/src/GUITestBasePlugin.cpp
@@ -54,6 +54,7 @@
 #include "tests/common_scenarios/msa_editor/align/GTTestsAlignSequenceToMsa.h"
 #include "tests/common_scenarios/msa_editor/colors/GTTestsMSAEditorColors.h"
 #include "tests/common_scenarios/msa_editor/consensus/GTTestsMSAEditorConsensus.h"
+#include "tests/common_scenarios/msa_editor/tree/GTTestsMSAEditorTree.h"
 #include "tests/common_scenarios/msa_editor/edit/GTTestsMSAEditorEdit.h"
 #include "tests/common_scenarios/msa_editor/overview/GTTestsMSAEditorOverview.h"
 #include "tests/common_scenarios/msa_editor/replace_character/GTTestsMSAEditorReplaceCharacter.h"
@@ -2384,6 +2385,11 @@ void GUITestBasePlugin::registerTests(UGUITestBase *guiTestBase) {
 
     REGISTER_TEST(GUITest_common_scenarios_msa_editor_consensus::test_0005);
     REGISTER_TEST(GUITest_common_scenarios_msa_editor_consensus::test_0006);
+
+    /////////////////////////////////////////////////////////////////////////
+    // Common scenarios/msa_editor/tree
+    /////////////////////////////////////////////////////////////////////////
+    REGISTER_TEST(GUITest_common_scenarios_msa_editor_tree::test_0001);
 
     /////////////////////////////////////////////////////////////////////////
     // Common scenarios/msa_editor/edit

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/tree/GTTestsMSAEditorTree.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/tree/GTTestsMSAEditorTree.cpp
@@ -1,0 +1,79 @@
+/**
+ * UGENE - Integrated Bioinformatics Tools.
+ * Copyright (C) 2008-2020 UniPro <ugene@unipro.ru>
+ * http://ugene.net
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+#include <base_dialogs/GTFileDialog.h>
+#include <primitives/GTComboBox.h>
+#include <primitives/GTTreeWidget.h>
+#include <primitives/GTWidget.h>
+
+#include <QGraphicsView>
+
+#include <U2View/MSAEditor.h>
+
+#include "GTGlobals.h"
+#include "GTTestsMSAEditorTree.h"
+#include "GTUtilsMdi.h"
+#include "GTUtilsMsaEditor.h"
+#include "GTUtilsMsaEditorSequenceArea.h"
+#include "GTUtilsPhyTree.h"
+#include "GTUtilsTaskTreeView.h"
+
+namespace U2 {
+
+namespace GUITest_common_scenarios_msa_editor_tree {
+
+GUI_TEST_CLASS_DEFINITION(test_0001) {
+    GTFileDialog::openFile(os, testDir + "_common_data/clustal/", "collapse_mode_1.aln");
+    GTUtilsMsaEditor::checkMsaEditorWindowIsActive(os);
+
+    // Check that original name list is correct.
+    MSAEditor *msaEditor = GTUtilsMsaEditor::getEditor(os);
+    MultipleSequenceAlignmentObject *msaObject = msaEditor->getMaObject();
+    QStringList nameList = msaObject->getMultipleAlignment()->getRowNames();
+    QStringList originalNameList = {"a", "b", "c", "d", "e", "f", "g", "h"};
+    CHECK_SET_ERR(nameList == originalNameList, "1. Wrong original name list: " + nameList.join(","));
+
+    // Build a tree.
+    GTUtilsMsaEditor::buildPhylogeneticTree(os, sandBoxDir + "tree_test_0001.nwk");
+    GTUtilsTaskTreeView::waitTaskFinished(os);
+
+    // Check that the tree is opened and MSA order was changed to match the tree order. The original MSA-object order must not change.
+    nameList = msaObject->getMultipleAlignment()->getRowNames();
+    CHECK_SET_ERR(nameList == originalNameList, "2. Wrong original name list: " + nameList.join(","));
+    nameList = GTUtilsMSAEditorSequenceArea::getVisibleNames(os);
+    QStringList expectedExpandedTreeNameList = {"h", "b", "f", "d", "c", "e", "g", "a"};
+    CHECK_SET_ERR(nameList == expectedExpandedTreeNameList, "Initial full tree name list not matched: " + nameList.join(","));
+
+    // Collapse subtree. Check that MSA name list has a collapsed group.
+    QList<GraphicsButtonItem *> nodeList = GTUtilsPhyTree::getOrderedRectangularNodes(os);
+    GraphicsButtonItem *parentOfSequenceC = nodeList[1];
+    GTUtilsPhyTree::doubleClickNode(os, parentOfSequenceC);
+    nameList = GTUtilsMSAEditorSequenceArea::getVisibleNames(os);
+    expectedExpandedTreeNameList = QStringList({"h", "b", "f", "d", "g", "a"});
+    CHECK_SET_ERR(nameList == expectedExpandedTreeNameList, "Collapsed tree name list not matched: " + nameList.join(","));
+
+    GTUtilsPhyTree::doubleClickNode(os, parentOfSequenceC);
+    nameList = GTUtilsMSAEditorSequenceArea::getVisibleNames(os);
+    expectedExpandedTreeNameList = QStringList({"h", "b", "f", "d", "c", "e", "g", "a"});
+    CHECK_SET_ERR(nameList == expectedExpandedTreeNameList, "Restored full tree name list not matched: " + nameList.join(","));
+}
+
+}    // namespace GUITest_common_scenarios_msa_editor_tree
+}    // namespace U2

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/tree/GTTestsMSAEditorTree.h
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/tree/GTTestsMSAEditorTree.h
@@ -6,6 +6,7 @@
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
+k
  * of the License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
@@ -19,40 +20,23 @@
  * MA 02110-1301, USA.
  */
 
-#ifndef _U2_GRAPHICS_CIRCULAR_BRANCH_ITEM_H_
-#define _U2_GRAPHICS_CIRCULAR_BRANCH_ITEM_H_
+/** Tree integration into MSA editor. */
+#ifndef GTTESTS_MSA_EDITOR_TREE_H_
+#define GTTESTS_MSA_EDITOR_TREE_H_
 
-#include <U2Core/Task.h>
-
-#include "GraphicsBranchItem.h"
-
-class QGraphicsItem;
+#include <U2Test/UGUITestBase.h>
 
 namespace U2 {
 
-class PhyNode;
-class GraphicsButtonItem;
-class GraphicsRectangularBranchItem;
+namespace GUITest_common_scenarios_msa_editor_tree {
+#undef GUI_TEST_SUITE
+#define GUI_TEST_SUITE "GUITest_common_scenarios_msa_editor_tree"
 
-class U2VIEW_EXPORT GraphicsCircularBranchItem : public GraphicsBranchItem {
-    qreal height;
-    Direction direction;
-    bool visible;
+GUI_TEST_CLASS_DECLARATION(test_0001)
 
-public:
-    GraphicsCircularBranchItem(QGraphicsItem *parent, qreal height, GraphicsRectangularBranchItem *from, double nodeValue = -1.0);
-
-    QRectF boundingRect() const;
-    QPainterPath shape() const;
-    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
-    void setVisibleW(bool v) {
-        visible = v;
-    }
-
-protected:
-    void setLabelPositions();
-};
+#undef GUI_TEST_SUITE
+}    // namespace GUITest_common_scenarios_msa_editor_tree
 
 }    // namespace U2
 
-#endif
+#endif    //GTTESTS_MSA_EDITOR_TREE_H_

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/options_panel/msa/GTTestsOptionPanelMSA.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/options_panel/msa/GTTestsOptionPanelMSA.cpp
@@ -1575,22 +1575,18 @@ GUI_TEST_CLASS_DEFINITION(tree_settings_test_0003) {
     GTUtilsOptionPanelMsa::openTab(os, GTUtilsOptionPanelMsa::TreeSettings);
     GTUtilsDialog::waitForDialog(os, new BuildTreeDialogFiller(os, "default", 0, 0, true));
     GTWidget::click(os, GTWidget::findWidget(os, "BuildTreeButton"));
-    GTGlobals::sleep(1000);
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    //prepating widgets
+    // Check/prepare tree widgets.
     QWidget *treeView = GTWidget::findWidget(os, "treeView");
-    CHECK_SET_ERR(treeView != NULL, "tree view not found");
     QWidget *heightSlider = GTWidget::findWidget(os, "heightSlider");
-    CHECK_SET_ERR(heightSlider != NULL, "heightSlider not found");
-    QComboBox *layoutCombo = qobject_cast<QComboBox *>(GTWidget::findWidget(os, "layoutCombo"));
-    CHECK_SET_ERR(layoutCombo != NULL, "layoutCombo not found");
+    QComboBox *layoutCombo = GTWidget::findExactWidget<QComboBox*>(os, "layoutCombo");
 
     const QImage initImage = GTWidget::getImage(os, treeView);
 
     //    3. Select circular layout
     GTComboBox::selectItemByText(os, layoutCombo, "Circular");
-    GTGlobals::sleep(500);
+    GTUtilsTaskTreeView::waitTaskFinished(os);
 
     //    Expected state: layout changed, height slider is disabled
     const QImage circularImage = GTWidget::getImage(os, treeView);
@@ -1599,7 +1595,7 @@ GUI_TEST_CLASS_DEFINITION(tree_settings_test_0003) {
 
     //    4. Select unrooted layout
     GTComboBox::selectItemByText(os, layoutCombo, "Unrooted");
-    GTGlobals::sleep(500);
+    GTUtilsTaskTreeView::waitTaskFinished(os);
 
     //    Expected state: layout changed, height slider is disabled
     const QImage unrootedImage = GTWidget::getImage(os, treeView);
@@ -1608,9 +1604,9 @@ GUI_TEST_CLASS_DEFINITION(tree_settings_test_0003) {
 
     //    5. Select rectangular layout
     GTComboBox::selectItemByText(os, layoutCombo, "Rectangular");
-    GTGlobals::sleep(500);
+    GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    //    Expected state: tree is similar to the beginning, height slider is enabled
+    // Expected state: tree is similar to the beginning, height slider is enabled
     const QImage rectangularImage = GTWidget::getImage(os, treeView);
     CHECK_SET_ERR(initImage == rectangularImage, "final image is not equal to initial");
     CHECK_SET_ERR(heightSlider->isEnabled(), "heightSlider in disabled for rectangular layout");

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_3001_4000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_3001_4000.cpp
@@ -3149,19 +3149,22 @@ GUI_TEST_CLASS_DEFINITION(test_3484) {
     GTWidget::click(os, GTAction::button(os, "Build Tree"));
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    QGraphicsView *treeView = qobject_cast<QGraphicsView *>(GTWidget::findWidget(os, "treeView"));
-    CHECK_SET_ERR(treeView != NULL, "TreeView not found");
+    // Check that tree is visible.
+    GTWidget::findExactWidget<QGraphicsView *>(os, "treeView");
 
     GTUtilsDocument::unloadDocument(os, "COI_3484.nwk", false);
-    GTGlobals::sleep(500);
-    GTUtilsDocument::saveDocument(os, "COI_3484.aln");
+    GTUtilsTaskTreeView::waitTaskFinished(os);
+
     GTUtilsDocument::unloadDocument(os, "COI_3484.aln", true);
+    GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    GTGlobals::sleep();
     GTUtilsDocument::removeDocument(os, "COI_3484.nwk");
-    GTUtilsDocument::loadDocument(os, "COI_3484.aln");
+    GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    CHECK_SET_ERR(GTUtilsProjectTreeView::checkItem(os, "COI_3484  .nwk") == false, "Unauthorized tree opening!");
+    GTUtilsDocument::loadDocument(os, "COI_3484.aln");
+    GTUtilsTaskTreeView::waitTaskFinished(os);
+
+    CHECK_SET_ERR(GTUtilsProjectTreeView::checkItem(os, "COI_3484  .nwk", false) == false, "Unauthorized tree opening!");
 }
 
 GUI_TEST_CLASS_DEFINITION(test_3484_1) {

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_3001_4000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_3001_4000.cpp
@@ -3550,25 +3550,25 @@ GUI_TEST_CLASS_DEFINITION(test_3563_1) {
     //    3. Unload both documents (alignment and tree)
     //    4. Load alignment
     //    Expected state: no errors in the log
-    GTLogTracer l;
+    GTLogTracer logTracer;
 
     GTFile::copy(os, testDir + "_common_data/clustal/dna.fasta.aln", testDir + "_common_data/scenarios/sandbox/test_3563_1.aln");
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/sandbox/", "test_3563_1.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    GTUtilsDialog::waitForDialog(os, new BuildTreeDialogFiller(os, testDir + "_common_data/scenarios/sandbox/test_3563_1.nwk", 0, 0, true));
-    QAbstractButton *tree = GTAction::button(os, "Build Tree");
-    GTWidget::click(os, tree);
-    GTGlobals::sleep();
-    GTUtilsDocument::saveDocument(os, "test_3563_1.aln");
+    GTUtilsMsaEditor::buildPhylogeneticTree(os, testDir + "_common_data/scenarios/sandbox/test_3563_1.nwk");
+    GTUtilsTaskTreeView::waitTaskFinished(os);
 
     GTUtilsDocument::unloadDocument(os, "test_3563_1.nwk", false);
-    GTGlobals::sleep();
+    GTUtilsTaskTreeView::waitTaskFinished(os);
 
     GTUtilsDocument::unloadDocument(os, "test_3563_1.aln", true);
-    GTGlobals::sleep();
+    GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    GTUtilsLog::check(os, l);
+    GTUtilsDocument::loadDocument(os, "test_3563_1.aln");
+    GTUtilsTaskTreeView::waitTaskFinished(os);
+
+    GTUtilsLog::check(os, logTracer);
 }
 
 GUI_TEST_CLASS_DEFINITION(test_3563_2) {


### PR DESCRIPTION
I also renamed/added detailed docs for the collapsing mode actions.

The goal of the renaming is to emphasize that this mode may be used by different use-cases, not only grouping by sequence content. There are no changes in the renamed code. The only changes are on the Tree-MSA boundary.