### PR TITLE
UGENE-6958. 3D struct is not rendered on Windows

### DIFF
--- a/src/plugins/biostruct3d_view/src/BioStruct3DGLWidget.cpp
+++ b/src/plugins/biostruct3d_view/src/BioStruct3DGLWidget.cpp
@@ -93,6 +93,22 @@ bool BioStruct3DGLWidget::checkShaderPrograms() {
     return opgl;
 }
 
+bool BioStruct3DGLWidget::canRender() {
+    QOffscreenSurface surf;
+    QOpenGLContext ctx;
+    surf.create();
+    ctx.create();
+    ctx.makeCurrent(&surf);
+
+    GLenum error = glGetError();
+    bool canRender = error == GL_NO_ERROR;
+    if (!canRender) {
+        coreLog.error(tr("The \"3D Structure Viewer\" was disabled, because OpenGL has error ") +
+            QString("(%1): %2").arg(error).arg(reinterpret_cast<const char *>(gluErrorString(error))));
+    }
+    return canRender;
+}
+
 void BioStruct3DGLWidget::tryGL() {
     volatile QOpenGLWidget wgt;
     Q_UNUSED(wgt);

--- a/src/plugins/biostruct3d_view/src/BioStruct3DGLWidget.h
+++ b/src/plugins/biostruct3d_view/src/BioStruct3DGLWidget.h
@@ -94,6 +94,7 @@ class BioStruct3DGLWidget : public QOpenGLWidget {
 public:
     // Used in PluginChecker to detect whether the GL is available
     static bool checkShaderPrograms();
+    static bool canRender();
     static void tryGL();
 
     static const double MINIMUM_ACCEPTABLE_VERSION;

--- a/src/plugins/biostruct3d_view/src/BioStruct3DViewPlugin.cpp
+++ b/src/plugins/biostruct3d_view/src/BioStruct3DViewPlugin.cpp
@@ -94,7 +94,7 @@ extern "C" Q_DECL_EXPORT QString *U2_PLUGIN_FAIL_MASSAGE_FUNC() {
 BioStruct3DViewPlugin::BioStruct3DViewPlugin()
     : Plugin(tr("3D Structure Viewer"), tr("Visualizes 3D structures of biological molecules.")) {
     // Init plugin view context
-    if (BioStruct3DGLWidget::checkShaderPrograms()) {
+    if (BioStruct3DGLWidget::checkShaderPrograms() && BioStruct3DGLWidget::canRender()) {
         viewContext = new BioStruct3DViewContext(this);
         viewContext->init();
     }

--- a/src/plugins/biostruct3d_view/src/deprecated/BioStruct3DGLWidget.cpp
+++ b/src/plugins/biostruct3d_view/src/deprecated/BioStruct3DGLWidget.cpp
@@ -82,9 +82,12 @@ void BioStruct3DGLWidget::tryGL() {
 bool BioStruct3DGLWidget::canRender() {
     QGLWidget w;
     w.makeCurrent();
-    bool canRender = glGetError() == GL_NO_ERROR;
+
+    GLenum error = glGetError();
+    bool canRender = error == GL_NO_ERROR;
     if (!canRender) {
-        coreLog.error(tr("BioStruct3DView plugin has been added, but cannot be used"));
+        coreLog.error(tr("The \"3D Structure Viewer\" was disabled, because OpenGL has error ") +
+            QString("(%1): %2").arg(error).arg(reinterpret_cast<const char *>(gluErrorString(error))));
     }
     return canRender;
 }

--- a/src/plugins/biostruct3d_view/src/deprecated/BioStruct3DGLWidget.cpp
+++ b/src/plugins/biostruct3d_view/src/deprecated/BioStruct3DGLWidget.cpp
@@ -82,7 +82,11 @@ void BioStruct3DGLWidget::tryGL() {
 bool BioStruct3DGLWidget::canRender() {
     QGLWidget w;
     w.makeCurrent();
-    return glGetError() == GL_NO_ERROR;
+    bool canRender = glGetError() == GL_NO_ERROR;
+    if (!canRender) {
+        coreLog.error(tr("BioStruct3DView plugin has been added, but cannot be used"));
+    }
+    return canRender;
 }
 
 static QColor DEFAULT_BACKGROUND_COLOR = Qt::black;

--- a/src/plugins/biostruct3d_view/src/deprecated/BioStruct3DGLWidget.cpp
+++ b/src/plugins/biostruct3d_view/src/deprecated/BioStruct3DGLWidget.cpp
@@ -79,6 +79,12 @@ void BioStruct3DGLWidget::tryGL() {
     Q_UNUSED(wgt);
 }
 
+bool BioStruct3DGLWidget::canRender() {
+    QGLWidget w;
+    w.makeCurrent();
+    return glGetError() == GL_NO_ERROR;
+}
+
 static QColor DEFAULT_BACKGROUND_COLOR = Qt::black;
 static QColor DEFAULT_SELECTION_COLOR = Qt::yellow;
 

--- a/src/plugins/biostruct3d_view/src/deprecated/BioStruct3DGLWidget.h
+++ b/src/plugins/biostruct3d_view/src/deprecated/BioStruct3DGLWidget.h
@@ -94,7 +94,6 @@ class BioStruct3DGLWidget : public QGLWidget {
 public:
     // Used in PluginChecker to detect whether the GL is available
     static void tryGL();
-    // Used in BioStruct3DViewPlugin constructor to detect possibilities of creating QGLWidget and render
     static bool canRender();
 
 public:

--- a/src/plugins/biostruct3d_view/src/deprecated/BioStruct3DGLWidget.h
+++ b/src/plugins/biostruct3d_view/src/deprecated/BioStruct3DGLWidget.h
@@ -94,6 +94,8 @@ class BioStruct3DGLWidget : public QGLWidget {
 public:
     // Used in PluginChecker to detect whether the GL is available
     static void tryGL();
+    // Used in BioStruct3DViewPlugin constructor to detect possibilities of creating QGLWidget and render
+    static bool canRender();
 
 public:
     /*!

--- a/src/plugins/biostruct3d_view/src/deprecated/BioStruct3DViewPlugin.cpp
+++ b/src/plugins/biostruct3d_view/src/deprecated/BioStruct3DViewPlugin.cpp
@@ -93,8 +93,12 @@ extern "C" Q_DECL_EXPORT QString *U2_PLUGIN_FAIL_MASSAGE_FUNC() {
 BioStruct3DViewPlugin::BioStruct3DViewPlugin()
     : Plugin(tr("3D Structure Viewer"), tr("Visualizes 3D structures of biological molecules.")) {
     // Init plugin view context
-    viewContext = new BioStruct3DViewContext(this);
-    viewContext->init();
+    if (BioStruct3DGLWidget::canRender()) {
+        viewContext = new BioStruct3DViewContext(this);
+        viewContext->init();
+    } else {
+        uiLog.details(QStringLiteral("BioStruct3DView plugin has been added, but cannot be used"));
+    }
 }
 
 BioStruct3DViewPlugin::~BioStruct3DViewPlugin() {

--- a/src/plugins/biostruct3d_view/src/deprecated/BioStruct3DViewPlugin.cpp
+++ b/src/plugins/biostruct3d_view/src/deprecated/BioStruct3DViewPlugin.cpp
@@ -96,8 +96,6 @@ BioStruct3DViewPlugin::BioStruct3DViewPlugin()
     if (BioStruct3DGLWidget::canRender()) {
         viewContext = new BioStruct3DViewContext(this);
         viewContext->init();
-    } else {
-        uiLog.details(QStringLiteral("BioStruct3DView plugin has been added, but cannot be used"));
     }
 }
 


### PR DESCRIPTION
Some Windows systems have OpenGL 1.1 installed by default (this is a very old version of OpenGL, currently not supported) and supported DirectX. On such computers, it is possible to render 3D graphics using Qt, but at the moment, 3D models are not rendered in UGENE for unknown reasons.
Added a check that disables the plugin if there are rendering errors. This check is added to deprecated and non-deprecated code