### PR TITLE
UGENE-7022 Annotation selection doesn't work in details view

### DIFF
--- a/src/corelibs/U2Core/src/datatype/Annotation.cpp
+++ b/src/corelibs/U2Core/src/datatype/Annotation.cpp
@@ -165,7 +165,7 @@ void Annotation::setLocation(const U2Location &location) {
     parentObject->emit_onAnnotationsModified(md);
 }
 
-QVector<U2Region> Annotation::getRegions() const {
+const QVector<U2Region>& Annotation::getRegions() const {
     return data->getRegions();
 }
 

--- a/src/corelibs/U2Core/src/datatype/Annotation.h
+++ b/src/corelibs/U2Core/src/datatype/Annotation.h
@@ -69,7 +69,7 @@ public:
 
     void setLocation(const U2Location &location);
 
-    QVector<U2Region> getRegions() const;
+    const QVector<U2Region>& getRegions() const;
 
     qint64 getRegionsLen() const;
 

--- a/src/plugins/GUITestBase/src/GUITestBasePlugin.cpp
+++ b/src/plugins/GUITestBase/src/GUITestBasePlugin.cpp
@@ -1734,6 +1734,7 @@ void GUITestBasePlugin::registerTests(UGUITestBase *guiTestBase) {
     REGISTER_TEST(GUITest_regression_scenarios::test_6995);
 
     REGISTER_TEST(GUITest_regression_scenarios::test_7014);
+    REGISTER_TEST(GUITest_regression_scenarios::test_7022);
 
     //////////////////////////////////////////////////////////////////////////
     // Common scenarios/project/

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_7001_8000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_7001_8000.cpp
@@ -19,6 +19,9 @@
  * MA 02110-1301, USA.
  */
 
+#include <system/GTClipboard.h>
+
+#include <primitives/GTAction.h>
 #include <primitives/GTMenu.h>
 #include <primitives/PopupChooser.h>
 
@@ -26,6 +29,7 @@
 #include "GTUtilsMdi.h"
 #include "GTUtilsMsaEditor.h"
 #include "GTUtilsMsaEditorSequenceArea.h"
+#include "GTUtilsSequenceView.h"
 #include "GTUtilsTaskTreeView.h"
 #include "runnables/ugene/corelibs/U2View/ov_msa/ExtractSelectedAsMSADialogFiller.h"
 
@@ -68,6 +72,33 @@ GUI_TEST_CLASS_DEFINITION(test_7014) {
     int msaLength = GTUtilsMSAEditorSequenceArea::getLength(os);
     CHECK_SET_ERR(msaLength == 5, "Unexpected exported alignment length: " + QString::number(msaLength));
 }
+
+GUI_TEST_CLASS_DEFINITION(test_7022) {
+    // 1. Open _common_data/scenarios/_regression/7022/test_7022.gb
+    GTFileDialog::openFile(os, testDir + "_common_data/scenarios/_regression/7022/test_7022.gb");
+    GTUtilsSequenceView::checkSequenceViewWindowIsActive(os);
+
+    // 2. Turn on "Wrap mode" and click on the firts annotation in DetView
+    QAction *wrapMode = GTAction::findActionByText(os, "Wrap sequence");
+    CHECK_SET_ERR(wrapMode != NULL, "Cannot find Wrap sequence action");
+    if (!wrapMode->isChecked()) {
+        GTWidget::click(os, GTAction::button(os, wrapMode));
+    }
+    GTUtilsSequenceView::clickAnnotationDet(os, "Misc. Feature", 2);
+
+    // 3. copy selected annotation
+    GTUtilsDialog::waitForDialog(os, new PopupChooserByText(os, QStringList() << "Copy/Paste"
+                                                                              << "Copy annotation sequence"));
+    GTMenu::showContextMenu(os, GTUtilsSequenceView::getPanOrDetView(os));
+    GTUtilsTaskTreeView::waitTaskFinished(os);
+
+    // Expected: TGTCAGATTCACCAAAGTTGAAATGAAGGAAAAAATGCTAAGGGCAGCCAGAGAGAGGTCAGGTTACCCACAAAGGGAAGCCCATCAGAC
+    QString expected = "TGTCAGATTCACCAAAGTTGAAATGAAGGAAAAAATGCTAAGGGCAGCCAGAGAGAGGTCAGGTTACCCACAAAGGGAAGCCCATCAGAC";
+    QString text = GTClipboard::text(os);
+    CHECK_SET_ERR(text == expected, QString("Unexpected annotation, expected: %1, current: %2").arg(expected).arg(text));
+
+}
+
 
 }    // namespace GUITest_regression_scenarios
 

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_7001_8000.h
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_7001_8000.h
@@ -32,6 +32,7 @@ namespace GUITest_regression_scenarios {
 #define GUI_TEST_SUITE "GUITest_regression_scenarios"
 
 GUI_TEST_CLASS_DECLARATION(test_7014)
+GUI_TEST_CLASS_DECLARATION(test_7022)
 
 #undef GUI_TEST_SUITE
 


### PR DESCRIPTION
https://ugene.dev/tracker/browse/UGENE-7022

The most hateful type of errors.

The problem appears in DetViewMultiLineRenderer.cpp, line 78. This is the code:
`const U2Region &locationRegion = annotation->getRegions()[locationRegionIndex];`
Where `annotation` is an instance of `Annotation`, which `getRegions()` function has been changed in the fix-commit. 

The problem is that `QVector::operator[]` has 2 implementations - for `const` and non-`const` objects. Before the fix,  `annotation->getRegions()` returns a non-`const` value, so we use this implementation:
`U2Region& QVector::operator[](int i)`.

As you can see, It returns reference to element of QVector.

Now when you use `&` you are capturing reference to vector item.

But, `annotation->getRegions()` is a temporary object which live scope is limited to that line. So just after semicolon, vector is destroyed and reference is pointing to none existing element of vector (since vector doesn't exists anymore).

So we're lucky and we have an undefined behavior

There are a lot of ways to solve this problem, but I prefer to fix the root of the problem. Now `annotation->getRegions()` returns `const &`, that means, that no reference to temporary values will be created.

The only question I find difficult to answer on - why it works on Linux, but not on Windows. I suggest, that it's somethings about compiler. It's possible that "gcc" could struggle this problem, but "msvc" is not able to do this.
