### PR TITLE
Optimize tests per suite distribution on Linux

### DIFF
--- a/src/corelibs/U2Test/src/gui_tests/GUITestLauncher.cpp
+++ b/src/corelibs/U2Test/src/gui_tests/GUITestLauncher.cpp
@@ -144,7 +144,7 @@ QList<GUITest *> getIdealNightlyTestsSplit(int suiteIndex, int suiteCount, const
     } else if (suiteCount == 4) {
         testsPerSuite << 640 << 680 << 640 << -1;
     } else if (suiteCount == 5) {
-        testsPerSuite << 535 << 570 << 458 << 525 << -1;
+        testsPerSuite << 540 << 575 << 465 << 535 << -1;
     }
     QList<GUITest *> tests;
     if (testsPerSuite.size() == suiteCount) {


### PR DESCRIPTION
We need to make a tuning like this every time new 40-50 tests added (once per month or two),