### PR TITLE
UTI-479 Revert 1 thread for XML tests

### DIFF
--- a/src/plugins/test_runner/src/TestRunnerPlugin.cpp
+++ b/src/plugins/test_runner/src/TestRunnerPlugin.cpp
@@ -38,7 +38,7 @@
 
 #define SETTINGS_ROOT QString("test_runner/")
 /** Default number of threads to run XML tests. */
-#define NUM_THREADS_VAR_VALUE "1"
+#define NUM_THREADS_VAR_VALUE "10"
 #define TIME_OUT_VAR_VALUE "0"
 
 namespace U2 {
@@ -66,7 +66,6 @@ void TestRunnerPlugin::sl_startTestRunner() {
     TestRunnerService *srv = new TestRunnerService();
     srv->setEnvironment();
 
-    /* Disabling to check if it fixes slow commit/nightly builds
     CMDLineRegistry *cmdReg = AppContext::getCMDLineRegistry();
     if (cmdReg->hasParameter(CMDLineCoreOptions::TEST_THREADS)) {
         QString val = cmdReg->getParameterValue(CMDLineCoreOptions::TEST_THREADS);
@@ -80,7 +79,7 @@ void TestRunnerPlugin::sl_startTestRunner() {
         }
         srv->setVar(NUM_THREADS_VAR, val);
     }
-*/
+
     foreach (const QString &param, suiteUrls) {
         QString dir;
         if (param.contains(":") || param[0] == '.' || param[0] == '/') {

--- a/src/plugins/test_runner/src/TestRunnerPlugin.cpp
+++ b/src/plugins/test_runner/src/TestRunnerPlugin.cpp
@@ -38,7 +38,7 @@
 
 #define SETTINGS_ROOT QString("test_runner/")
 /** Default number of threads to run XML tests. */
-#define NUM_THREADS_VAR_VALUE "10"
+#define NUM_THREADS_VAR_VALUE "1"
 #define TIME_OUT_VAR_VALUE "0"
 
 namespace U2 {


### PR DESCRIPTION
I want to get this feature back. I'd been setting up nightly XML tests on ugene-cuda and faced the problem - the execution fails because of the timeout in the single thread (e.g. [here](http://ugene-teamcity.unipro.ru:8111/ugene-teamcity/viewLog.html?buildId=213325&tab=buildResultsDiv&buildTypeId=UgeneNightlyBuilds_XmlTests_NightlyBuildUbuntu200464bitLinux)), but works good on several threads (I checked for 2 threads, [here](http://ugene-teamcity.unipro.ru:8111/ugene-teamcity/viewLog.html?buildId=212955&tab=buildResultsDiv&buildTypeId=UgeneNightlyBuilds_XmlTests_NightlyBuildUbuntu200464bitLinux), the only failed test will be fixed after #256).

I think, there is no problem about having this feature - if you want run tests in the single thread, you can just set the "TEST_THREADS" environment variable to 1.