### PR TITLE
UTI-484

### DIFF
--- a/src/plugins/GUITestBase/src/tests/common_scenarios/create_shortcut/GTTestsCreateShortcut.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/create_shortcut/GTTestsCreateShortcut.cpp
@@ -22,8 +22,8 @@
 #include <QDir>
 
 #if defined(Q_OS_WIN)
-#    include <shlguid.h>
 #    include <shlobj.h>
+#    include <shlguid.h>
 #    include <windows.h>
 #elif defined(Q_OS_LINUX)
 #    include <QCoreApplication>


### PR DESCRIPTION
https://ugene.dev/tracker/browse/UTI-484

The problem has appeared in Windows API functions`shlobj.h` (1) and `shlguid.h` (2) . They both have inners inside of the  `WINAPI_PARTITION_DESKTOP` partition. The problem is that (2) uses the macro defined in the (1). So, they should be included in the following order, otherwise - compile errors:
```
#include <shlobj.h>
#include <shlguid.h>

```