### PR TITLE
UGENE-7130. Fix windows build on MSVC 2019

### DIFF
--- a/src/libs_3rdparty/QSpec/src/primitives/PopupChooser.cpp
+++ b/src/libs_3rdparty/QSpec/src/primitives/PopupChooser.cpp
@@ -192,22 +192,6 @@ PopupCheckerByText::PopupCheckerByText(GUITestOpStatus &os,
     itemsShortcuts = namesAndShortcuts.values();
 }
 
-PopupCheckerByText::PopupCheckerByText(GUITestOpStatus &os,
-                                       const QList<QStringList> &itemsPaths,
-                                       PopupChecker::CheckOptions options,
-                                       GTGlobals::UseMethod useMethod)
-    : Filler(os, GUIDialogWaiter::WaitSettings(QString(), GUIDialogWaiter::Popup)),
-      options(options),
-      useMethod(useMethod) {
-    CHECK_SET_ERR(!itemsPaths.isEmpty(), "itemsPaths is empty");
-    menuPath = itemsPaths.first().mid(0, itemsPaths.first().size() - 1);
-    foreach (const QStringList &itemPath, itemsPaths) {
-        CHECK_SET_ERR(!itemPath.isEmpty(), "itemPath is empty");
-        CHECK_SET_ERR(itemPath.mid(0, itemPath.size() - 1) == menuPath, "Items from different submenus were passed to the PopupCheckerByText constructor");
-        itemsNames << itemPath.last();
-    }
-}
-
 #define GT_METHOD_NAME "commonScenario"
 void PopupCheckerByText::commonScenario() {
     QMenu *activePopupMenu = PopupChooser::getMenuPopup(os);

--- a/src/libs_3rdparty/QSpec/src/primitives/PopupChooser.h
+++ b/src/libs_3rdparty/QSpec/src/primitives/PopupChooser.h
@@ -109,12 +109,8 @@ public:
                        const QMap<QString, QKeySequence> &namesAndShortcuts,
                        PopupChecker::CheckOptions options = PopupChecker::CheckOptions(PopupChecker::IsEnabled),
                        GTGlobals::UseMethod useMethod = GTGlobals::UseKey);
-    PopupCheckerByText(GUITestOpStatus &os,
-                       const QList<QStringList> &itemsPaths,
-                       PopupChecker::CheckOptions options = PopupChecker::CheckOptions(PopupChecker::IsEnabled),
-                       GTGlobals::UseMethod useMethod = GTGlobals::UseKey);
 
-    virtual void commonScenario();
+    void commonScenario() override;
 
 protected:
     QStringList menuPath;


### PR DESCRIPTION
The patch does not require any binaries to be re-build for Release v38, but is worth to be included into the release-38.0 branch to avoid build errors on Windows, MSVC 2019