### PR TITLE
UGENE-7131. Make unused-parameter compiler warning be a compile-time …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ if (CMAKE_COMPILER_IS_GNUCXX)
             " -Werror=parentheses"
             " -Werror=return-type"
             " -Werror=uninitialized"
+            " -Werror=unused-parameter"
             " -Wno-catch-value"
             " -Wno-class-memaccess"
             " -Wno-deprecated-copy"

--- a/src/corelibs/U2Core/src/globals/disable-warnings.h
+++ b/src/corelibs/U2Core/src/globals/disable-warnings.h
@@ -23,11 +23,11 @@
 #define _U2_DISABLE_WARNINGS_H_
 
 /***
- * Once included this file disables all warning in the current compilation unit.
- * It used to suppress warnings in 3rd party code included into UGENE on the source level.
+ * Once included this file disables all warnings in the current compilation unit.
+ * This utility should be used to suppress warnings in 3rd party code included into UGENE.
  *
- * Note: never use this file in files owned/created by UGENE (both headers and cpp) because
- *  it will disable warnings in our own code too.
+ * Note: never include this file into files owned/created by UGENE (both headers and cpp) because
+ *  it will disable warnings in our code too.
  */
 
 #ifdef __GNUC__
@@ -39,7 +39,7 @@
 #endif
 
 /**
- * This macro does nothing but helps to avoid "unused include" warning for #include <U2Core/disable-warnings.h>:
+ * This macro does nothing today but helps to avoid "unused include" warning for #include <U2Core/disable-warnings.h>:
  *
  * Usage:
  * #include <U2Core/disable-warnings>

--- a/src/corelibs/U2Core/src/globals/disable-warnings.h
+++ b/src/corelibs/U2Core/src/globals/disable-warnings.h
@@ -1,0 +1,50 @@
+/**
+ * UGENE - Integrated Bioinformatics Tools.
+ * Copyright (C) 2008-2021 UniPro <ugene@unipro.ru>
+ * http://ugene.net
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#ifndef _U2_DISABLE_WARNINGS_H_
+#define _U2_DISABLE_WARNINGS_H_
+
+/***
+ * Once included this file disables all warning in the current compilation unit.
+ * It used to suppress warnings in 3rd party code included into UGENE on the source level.
+ *
+ * Note: never use this file in files owned/created by UGENE (both headers and cpp) because
+ *  it will disable warnings in our own code too.
+ */
+
+#ifdef __GNUC__
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wunused-parameter"
+#    pragma GCC diagnostic ignored "-Wunused-function"
+#    pragma GCC diagnostic ignored "-Wmisleading-indentation"
+#    pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
+
+/**
+ * This macro does nothing but helps to avoid "unused include" warning for #include <U2Core/disable-warnings.h>:
+ *
+ * Usage:
+ * #include <U2Core/disable-warnings>
+ * U2_DISABLE_WARNINGS
+ */
+#define U2_DISABLE_WARNINGS
+
+#endif

--- a/src/corelibs/U2Gui/src/util/shared_db/ImportOptionsWidget.ui
+++ b/src/corelibs/U2Gui/src/util/shared_db/ImportOptionsWidget.ui
@@ -161,7 +161,7 @@
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
              <property name="suffix">
-              <string> </string>
+              <string/>
              </property>
              <property name="maximum">
               <number>1000000</number>
@@ -181,11 +181,6 @@
           </widget>
          </item>
         </layout>
-        <zorder>layoutWidget</zorder>
-        <zorder>rbSeparate</zorder>
-        <zorder>rbMerge</zorder>
-        <zorder>rbMalignment</zorder>
-        <zorder>horizontalSpacer</zorder>
        </widget>
       </item>
       <item>

--- a/src/corelibs/U2View/src/ov_sequence/sequence_info/SequenceInfo.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/sequence_info/SequenceInfo.cpp
@@ -361,7 +361,7 @@ void SequenceInfo::sl_onSequenceModified() {
     updateData();
 }
 
-void SequenceInfo::sl_onActiveSequenceChanged(ADVSequenceWidget *oldSequenceWidget /*from*/, ADVSequenceWidget *newSequenceWidget) {
+void SequenceInfo::sl_onActiveSequenceChanged(ADVSequenceWidget * /*oldSequenceWidget*/, ADVSequenceWidget *newSequenceWidget) {
     if (newSequenceWidget != nullptr) {    // i.e. the sequence has been deleted
         updateLayout();
         updateCurrentRegions();

--- a/src/corelibs/U2View/src/ov_sequence/view_rendering/DetViewMultiLineRenderer.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/view_rendering/DetViewMultiLineRenderer.cpp
@@ -105,7 +105,7 @@ bool DetViewMultiLineRenderer::isOnTranslationsLine(const QPoint &p, const QSize
     return false;
 }
 
-bool DetViewMultiLineRenderer::isOnAnnotationLine(const QPoint &p, Annotation *a, int region, const AnnotationSettings *as, const QSize &canvasSize, const U2Region &visibleRange) const {
+bool DetViewMultiLineRenderer::isOnAnnotationLine(const QPoint &p, Annotation *a, int region, const AnnotationSettings *as, const QSize &canvasSize, const U2Region & /*visibleRange*/) const {
     int availableHeightForSingleLine = singleLineRenderer->getOneLineHeight();    // Use minimal required height to draw a single line in singleLineRenderer.
     U2Region yRange = singleLineRenderer->getAnnotationYRange(a, region, as, availableHeightForSingleLine);
     yRange.startPos += (INDENT_BETWEEN_LINES + extraIndent) / 2;

--- a/src/include/U2Core/disable-warnings.h
+++ b/src/include/U2Core/disable-warnings.h
@@ -1,0 +1,1 @@
+#include "../../corelibs/U2Core/src/globals/disable-warnings.h"

--- a/src/libs_3rdparty/QSpec/src/primitives/GTLineEdit.cpp
+++ b/src/libs_3rdparty/QSpec/src/primitives/GTLineEdit.cpp
@@ -22,7 +22,6 @@
 #include "primitives/GTLineEdit.h"
 
 #include "drivers/GTKeyboardDriver.h"
-#include "drivers/GTMouseDriver.h"
 #include "primitives/GTWidget.h"
 #include "system/GTClipboard.h"
 #include "utils/GTKeyboardUtils.h"
@@ -97,7 +96,7 @@ void GTLineEdit::clear(GUITestOpStatus &os, QLineEdit *lineEdit) {
 
     GTWidget::setFocus(os, lineEdit);
 
-    GTKeyboardUtils::selectAll(os);
+    GTKeyboardUtils::selectAll();
     GTGlobals::sleep(100);
     GTKeyboardDriver::keyClick(Qt::Key_Delete);
     GTGlobals::sleep(100);
@@ -120,7 +119,7 @@ void GTLineEdit::pasteClipboard(GUITestOpStatus &os, QLineEdit *lineEdit, PasteM
 
     default:
     case Shortcut:
-        GTKeyboardUtils::paste(os);
+        GTKeyboardUtils::paste();
         break;
     }
 

--- a/src/libs_3rdparty/QSpec/src/primitives/GTTextEdit.cpp
+++ b/src/libs_3rdparty/QSpec/src/primitives/GTTextEdit.cpp
@@ -66,7 +66,7 @@ void GTTextEdit::clear(GUITestOpStatus &os, QTextEdit *textEdit) {
 
     GTWidget::setFocus(os, textEdit);
 
-    GTKeyboardUtils::selectAll(os);
+    GTKeyboardUtils::selectAll();
     GTGlobals::sleep(100);
     GTKeyboardDriver::keyClick(Qt::Key_Delete);
     GTGlobals::sleep(1000);

--- a/src/libs_3rdparty/QSpec/src/primitives/GTWidget.cpp
+++ b/src/libs_3rdparty/QSpec/src/primitives/GTWidget.cpp
@@ -330,12 +330,12 @@ QSet<QRgb> GTWidget::countColors(const QImage &image, int maxColors) {
 #define GT_METHOD_NAME "hasPixelWithColor"
 bool GTWidget::hasPixelWithColor(GUITestOpStatus &os, QWidget *widget, const QColor &expectedColor) {
     QImage image = getImage(os, widget);
-    return hasPixelWithColor(os, image, expectedColor);
+    return hasPixelWithColor(image, expectedColor);
 }
 #undef GT_METHOD_NAME
 
 #define GT_METHOD_NAME "hasPixelWithColorInImage"
-bool GTWidget::hasPixelWithColor(GUITestOpStatus &os, const QImage &image, const QColor &expectedColor) {
+bool GTWidget::hasPixelWithColor(const QImage &image, const QColor &expectedColor) {
     for (int x = 0; x < image.width(); x++) {
         for (int y = 0; y < image.height(); y++) {
             QColor pixelColor = image.pixel(x, y);

--- a/src/libs_3rdparty/QSpec/src/primitives/GTWidget.h
+++ b/src/libs_3rdparty/QSpec/src/primitives/GTWidget.h
@@ -53,7 +53,7 @@ public:
     //returns color of point p in widget w coordinates
     static QColor getColor(GUITestOpStatus &os, QWidget *widget, const QPoint &point);
     static bool hasPixelWithColor(GUITestOpStatus &os, QWidget *widget, const QColor &expectedColor);
-    static bool hasPixelWithColor(GUITestOpStatus &os, const QImage &image, const QColor &expectedColor);
+    static bool hasPixelWithColor(const QImage &image, const QColor &expectedColor);
 
     /** Returns true if the image has only the given color. */
     static bool hasSingleFillColor(const QImage &image, const QColor &color);

--- a/src/libs_3rdparty/QSpec/src/utils/GTKeyboardUtils.cpp
+++ b/src/libs_3rdparty/QSpec/src/utils/GTKeyboardUtils.cpp
@@ -24,20 +24,20 @@
 
 namespace HI {
 
-void GTKeyboardUtils::selectAll(GUITestOpStatus &os) {
+void GTKeyboardUtils::selectAll() {
     GTKeyboardDriver::keyClick('a', Qt::ControlModifier);
 }
 
-void GTKeyboardUtils::copy(GUITestOpStatus &os) {
+void GTKeyboardUtils::copy() {
     GTKeyboardDriver::keyClick('c', Qt::ControlModifier);
 }
 
-void GTKeyboardUtils::paste(GUITestOpStatus &os) {
+void GTKeyboardUtils::paste() {
     GTKeyboardDriver::keyClick('v', Qt::ControlModifier);
     GTThread::waitForMainThread();
 }
 
-void GTKeyboardUtils::cut(GUITestOpStatus &os) {
+void GTKeyboardUtils::cut() {
     GTKeyboardDriver::keyClick('x', Qt::ControlModifier);
 }
 

--- a/src/libs_3rdparty/QSpec/src/utils/GTKeyboardUtils.h
+++ b/src/libs_3rdparty/QSpec/src/utils/GTKeyboardUtils.h
@@ -26,15 +26,23 @@
 #include "drivers/GTKeyboardDriver.h"
 
 namespace HI {
-/*!
- * \brief The class contains the most commonly used keyboard hotkeys
+
+/**
+ * The class contains the most commonly used keyboard hotkeys.
  */
 class HI_EXPORT GTKeyboardUtils {
 public:
-    static void selectAll(GUITestOpStatus &);    // ctrl (or cmd on MacOS) + A
-    static void copy(GUITestOpStatus &);    // ctrl (or cmd on MacOS) + C
-    static void paste(GUITestOpStatus &);    // ctrl (or cmd on MacOS) + V
-    static void cut(GUITestOpStatus &);    // ctrl (or cmd on MacOS) + X
+    /** Triggers Ctrl (or cmd on MacOS) + A. */
+    static void selectAll();
+
+    /* Triggers Ctrl (or cmd on MacOS) + C. */
+    static void copy();
+
+    /* Triggers Ctrl (or cmd on MacOS) + V. */
+    static void paste();
+
+    /* Triggers Ctrl (or cmd on MacOS) + X. */
+    static void cut();
 };
 
 }    // namespace HI

--- a/src/libs_3rdparty/QSpec/src/utils/GTUtilsMac.cpp
+++ b/src/libs_3rdparty/QSpec/src/utils/GTUtilsMac.cpp
@@ -66,6 +66,9 @@ void GTUtilsMac::startWorkaroundForMacCGEvents(int delay, bool waitFinished) {
             process = nullptr;
         }
     }
+#else
+    Q_UNUSED(delay);
+    Q_UNUSED(waitFinished);
 #endif
 }
 

--- a/src/libs_3rdparty/qscore/src/qscore/qscore_fasta.cpp
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore_fasta.cpp
@@ -1,7 +1,7 @@
 #include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
 
 #include "qscore.h"
-U2_DISABLE_WARNINGS
 
 /***
 Strip trailing whitespace from FASTA annotation and

--- a/src/libs_3rdparty/qscore/src/qscore/qscore_fasta.cpp
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore_fasta.cpp
@@ -1,4 +1,7 @@
+#include <U2Core/disable-warnings.h>
+
 #include "qscore.h"
+U2_DISABLE_WARNINGS
 
 /***
 Strip trailing whitespace from FASTA annotation and

--- a/src/libs_3rdparty/qscore/src/qscore/qscore_fastq.cpp
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore_fastq.cpp
@@ -1,4 +1,7 @@
+#include <U2Core/disable-warnings.h>
+
 #include "qscore.h"
+U2_DISABLE_WARNINGS
 
 // O(NL) computation of PREFAB Q score and Balibase TC score.
 // Algorithm based on an idea due to Chuong (Tom) Do.

--- a/src/libs_3rdparty/qscore/src/qscore/qscore_fastq.cpp
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore_fastq.cpp
@@ -1,7 +1,7 @@
 #include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
 
 #include "qscore.h"
-U2_DISABLE_WARNINGS
 
 // O(NL) computation of PREFAB Q score and Balibase TC score.
 // Algorithm based on an idea due to Chuong (Tom) Do.

--- a/src/libs_3rdparty/qscore/src/qscore/qscore_sab.cpp
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore_sab.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "qscore.h"
 #include "sab_ref2.h"
 #include "sab_ids.h"

--- a/src/plugins/GUITestBase/src/GTUtilsMsaEditor.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsMsaEditor.cpp
@@ -386,7 +386,7 @@ QStringList GTUtilsMsaEditor::getWholeData(GUITestOpStatus &os) {
     clickSequenceName(os, names.last());
     GTKeyboardDriver::keyRelease(Qt::Key_Shift);
 
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
     GTGlobals::sleep(500);
 
     return GTClipboard::text(os).split('\n');

--- a/src/plugins/GUITestBase/src/GTUtilsMsaEditorSequenceArea.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsMsaEditorSequenceArea.cpp
@@ -523,7 +523,7 @@ QString GTUtilsMSAEditorSequenceArea::getSequenceData(GUITestOpStatus &os, const
     GT_CHECK_RESULT(rowNumber >= 0, QString("Sequence '%1' not found").arg(sequenceName), "");
 
     GTUtilsMsaEditor::clickSequenceName(os, sequenceName);
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
     return GTClipboard::text(os);
 }
 #undef GT_METHOD_NAME
@@ -537,7 +537,7 @@ QString GTUtilsMSAEditorSequenceArea::getSequenceData(GUITestOpStatus &os, int r
     GT_CHECK_RESULT(rowNumber >= 0 && rowNumber <= names.size(), QString("Row with number %1 is out of boundaries").arg(rowNumber), "");
 
     GTUtilsMsaEditor::clickSequenceName(os, names[rowNumber]);
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
     return GTClipboard::text(os);
 }
 #undef GT_METHOD_NAME

--- a/src/plugins/GUITestBase/src/GTUtilsPrimerLibrary.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsPrimerLibrary.cpp
@@ -132,7 +132,7 @@ void GTUtilsPrimerLibrary::selectPrimers(HI::GUITestOpStatus &os, const QList<in
 
 void GTUtilsPrimerLibrary::selectAll(HI::GUITestOpStatus &os) {
     GTWidget::click(os, table(os));
-    GTKeyboardUtils::selectAll(os);
+    GTKeyboardUtils::selectAll();
 }
 
 QTableView *GTUtilsPrimerLibrary::table(HI::GUITestOpStatus &os) {

--- a/src/plugins/GUITestBase/src/GTUtilsSequenceView.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsSequenceView.cpp
@@ -120,7 +120,7 @@ void GTUtilsSequenceView::getSequenceAsString(HI::GUITestOpStatus &os, QString &
     GTWidget::click(os, sequenceWidget);
 
     GTUtilsDialog::waitForDialog(os, new SelectSequenceRegionDialogFiller(os));
-    GTKeyboardUtils::selectAll(os);
+    GTKeyboardUtils::selectAll();
     GTUtilsDialog::waitAllFinished(os);
 
     GTUtilsDialog::waitForDialog(os, new PopupChooser(os, QStringList() << ADV_MENU_EDIT << ACTION_EDIT_REPLACE_SUBSEQUENCE, GTGlobals::UseKey));
@@ -136,7 +136,7 @@ QString GTUtilsSequenceView::getSequenceAsString(HI::GUITestOpStatus &os, int nu
     GTWidget::click(os, getSeqWidgetByNumber(os, number));
 
     GTUtilsDialog::waitForDialog(os, new SelectSequenceRegionDialogFiller(os));
-    GTKeyboardUtils::selectAll(os);
+    GTKeyboardUtils::selectAll();
     GTGlobals::sleep(500);
     GTUtilsDialog::waitForDialog(os, new PopupChooser(os, QStringList() << ADV_MENU_COPY << "Copy sequence"));
     // Use PanView or DetView but not the sequence widget itself: there are internal scrollbars in the SequenceWidget that may affect popup menu content.
@@ -155,7 +155,7 @@ QString GTUtilsSequenceView::getSequenceAsString(HI::GUITestOpStatus &os, int nu
 QString GTUtilsSequenceView::getBeginOfSequenceAsString(HI::GUITestOpStatus &os, int length) {
     checkSequenceViewWindowIsActive(os);
     GTUtilsDialog::waitForDialog(os, new SelectSequenceRegionDialogFiller(os, length));
-    GTKeyboardUtils::selectAll(os);
+    GTKeyboardUtils::selectAll();
     GTThread::waitForMainThread();
 
     QString sequence;
@@ -177,7 +177,7 @@ QString GTUtilsSequenceView::getEndOfSequenceAsString(HI::GUITestOpStatus &os, i
     Runnable *filler = new SelectSequenceRegionDialogFiller(os, length, false);
     GTUtilsDialog::waitForDialog(os, filler);
 
-    GTKeyboardUtils::selectAll(os);
+    GTKeyboardUtils::selectAll();
     GTGlobals::sleep(1000);
     GTGlobals::sleep(1000);    // don't touch
 
@@ -209,7 +209,7 @@ int GTUtilsSequenceView::getLengthOfSequence(HI::GUITestOpStatus &os) {
 
     int length = -1;
     GTUtilsDialog::waitForDialog(os, new SelectSequenceRegionDialogFiller(os, &length));
-    GTKeyboardUtils::selectAll(os);
+    GTKeyboardUtils::selectAll();
     GTGlobals::sleep(1000);
 
     return length;
@@ -241,7 +241,7 @@ void GTUtilsSequenceView::checkSequence(HI::GUITestOpStatus &os, const QString &
 void GTUtilsSequenceView::selectSequenceRegion(HI::GUITestOpStatus &os, int from, int to) {
     GTUtilsDialog::waitForDialog(os, new SelectSequenceRegionDialogFiller(os, from, to));
     clickMouseOnTheSafeSequenceViewArea(os);
-    GTKeyboardUtils::selectAll(os);
+    GTKeyboardUtils::selectAll();
 }
 #undef GT_METHOD_NAME
 
@@ -249,7 +249,7 @@ void GTUtilsSequenceView::selectSequenceRegion(HI::GUITestOpStatus &os, int from
 void GTUtilsSequenceView::selectSeveralRegionsByDialog(HI::GUITestOpStatus &os, const QString multipleRangeString) {
     GTUtilsDialog::waitForDialog(os, new SelectSequenceRegionDialogFiller(os, multipleRangeString));
     clickMouseOnTheSafeSequenceViewArea(os);
-    GTKeyboardUtils::selectAll(os);
+    GTKeyboardUtils::selectAll();
 }
 #undef GT_METHOD_NAME
 
@@ -688,7 +688,7 @@ QString GTUtilsSequenceView::getRegionAsString(HI::GUITestOpStatus &os, const U2
     GTUtilsSequenceView::selectSequenceRegion(os, region.startPos, region.endPos() - 1);
     GTGlobals::sleep();
 
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
 
     const QString result = GTClipboard::text(os);
 

--- a/src/plugins/GUITestBase/src/tests/PosteriorActions.cpp
+++ b/src/plugins/GUITestBase/src/tests/PosteriorActions.cpp
@@ -51,6 +51,7 @@ namespace U2 {
 namespace GUITest_posterior_actions {
 
 POSTERIOR_ACTION_DEFINITION(post_action_0000) {
+    Q_UNUSED(os);
     // Release all hold keyboard modifier keys
 
     Qt::KeyboardModifiers modifiers = QGuiApplication::queryKeyboardModifiers();

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/GTTestsMsaEditor.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/GTTestsMsaEditor.cpp
@@ -1643,7 +1643,7 @@ GUI_TEST_CLASS_DEFINITION(test_0016_1) {
 
     // copy to clipboard
     GTUtilsMSAEditorSequenceArea::selectArea(os, QPoint(0, 0), QPoint(2, 0));
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
 
     QString clipboardText = GTClipboard::text(os);
     CHECK_SET_ERR(clipboardText == "CTT", "MSA part differs from expected. Expected: CTT, actual: " + clipboardText);
@@ -2217,7 +2217,7 @@ GUI_TEST_CLASS_DEFINITION(test_0027) {
 
     //    Expected state: area is moved,position 4-9 filled with gaps
     GTUtilsMSAEditorSequenceArea::selectArea(os, QPoint(3, 2), QPoint(8, 2));
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
     const QString clipboardText = GTClipboard::text(os);
     CHECK_SET_ERR(clipboardText == "------", "Expected: ------ Found: " + clipboardText);
 }
@@ -2235,7 +2235,7 @@ GUI_TEST_CLASS_DEFINITION(test_0027_1) {
 
     //    Expected stste: area is moved,position 4-9 filled with gaps
     GTUtilsMSAEditorSequenceArea::selectArea(os, QPoint(3, 2), QPoint(8, 3));
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
     const QString clipboardText = GTClipboard::text(os);
     CHECK_SET_ERR(clipboardText == "------\n------", "Expected: ------\n------ Found: " + clipboardText);
 }

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/align/GTTestsAlignSequenceToMsa.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/align/GTTestsAlignSequenceToMsa.cpp
@@ -67,7 +67,7 @@ void checkAlignedRegion(HI::GUITestOpStatus &os, const QRect &selectionRect, con
     GTMenu::showContextMenu(os, GTUtilsMdi::activeWindow(os));
 
     GTUtilsMSAEditorSequenceArea::selectArea(os, selectionRect.topLeft(), selectionRect.bottomRight());
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
 
     const QString clipboardText = GTClipboard::text(os);
     CHECK_SET_ERR(clipboardText == expectedContent, QString("Incorrect alignment of the region\n Expected: \n%1 \nResult: \n%2").arg(expectedContent).arg(clipboardText));

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/edit/GTTestsMSAEditorEdit.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/edit/GTTestsMSAEditorEdit.cpp
@@ -445,11 +445,11 @@ void test_9(HI::GUITestOpStatus &os, int i = 0) {
     //Expected state: two columns with gaps added to the end of sequence.
     if (0 != i) {
         GTUtilsMSAEditorSequenceArea::selectArea(os, QPoint(i, 0), QPoint(i + 1, 9));
-        GTKeyboardUtils::copy(os);
+        GTKeyboardUtils::copy();
         gaps = QString("--\n--\n--\n--\n--\n--\n--\n--\n--\n--");
     } else {
         GTUtilsMSAEditorSequenceArea::selectArea(os, QPoint(14, 0), QPoint(15, 9));
-        GTKeyboardUtils::copy(os);
+        GTKeyboardUtils::copy();
         gaps = QString("-A\n--\n--\n--\n--\n--\n--\n--\n--\n--");
     }
 

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/project/GTTestsProject.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/project/GTTestsProject.cpp
@@ -1181,7 +1181,7 @@ GUI_TEST_CLASS_DEFINITION(test_0070) {
     GTClipboard::setText(os, ">human_T1\r\nACGTACGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\r\n");
 
     GTUtilsSequenceView::enableEditingMode(os, true);
-    GTKeyboardUtils::paste(os);
+    GTKeyboardUtils::paste();
     GTGlobals::sleep();
     GTUtilsTaskTreeView::waitTaskFinished(os);
     int len = GTUtilsSequenceView::getLengthOfSequence(os);
@@ -1202,6 +1202,7 @@ GUI_TEST_CLASS_DEFINITION(test_0071) {
 
 //ann
 GUI_TEST_CLASS_DEFINITION(test_0072) {
+    Q_UNUSED(os); // TODO: fix the test.
     //Ctrl+Shift+V в GUI-test?
     //UGENE-4907
     /*
@@ -1217,6 +1218,7 @@ GUI_TEST_CLASS_DEFINITION(test_0072) {
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0073) {
+    Q_UNUSED(os); // TODO: fix the test!
     //Ctrl+Shift+V в GUI-test?
     /*
     GTUtilsProject::openFiles(os, dataDir + "samples/Genbank/murine.gb");

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/project/sequence_exporting/from_project_view/GTTestsFromProjectView.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/project/sequence_exporting/from_project_view/GTTestsFromProjectView.cpp
@@ -180,7 +180,7 @@ GUI_TEST_CLASS_DEFINITION(test_0003) {
     GTMouseDriver::moveTo(GTUtilsProjectTreeView::getItemCenter(os, "multiple.fa"));
     GTMouseDriver::click();
 
-    GTKeyboardUtils::selectAll(os);
+    GTKeyboardUtils::selectAll();
     GTGlobals::sleep(1000);
 
     GTUtilsDialog::waitForDialog(os, new PopupChooser(os, QStringList() << ACTION_PROJECT__EXPORT_IMPORT_MENU_ACTION << ACTION_EXPORT_SEQUENCE_AS_ALIGNMENT, GTGlobals::UseMouse));

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/sequence_edit/GTTestsSequenceEdit.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/sequence_edit/GTTestsSequenceEdit.cpp
@@ -67,7 +67,7 @@ GUI_TEST_CLASS_DEFINITION(test_0001) {
 
     GTUtilsDialog::waitForDialog(os, new SelectSequenceRegionDialogFiller(os, 1, 50));
     GTWidget::click(os, GTWidget::findWidget(os, "ADV_single_sequence_widget_0"));
-    GTKeyboardUtils::selectAll(os);
+    GTKeyboardUtils::selectAll();
     GTGlobals::sleep(1000);
 
     Runnable *removeDialog = new RemovePartFromSequenceDialogFiller(os,
@@ -108,7 +108,7 @@ GUI_TEST_CLASS_DEFINITION(test_0002) {
     //
     GTUtilsDialog::waitForDialog(os, new SelectSequenceRegionDialogFiller(os, 1, 50));
     GTUtilsSequenceView::clickMouseOnTheSafeSequenceViewArea(os);
-    GTKeyboardUtils::selectAll(os);
+    GTKeyboardUtils::selectAll();
 
     // 4. Click OK. Right click on sequence area. Use context menu {Edit sequence->Remove selected sequence}.
     // Expected state: Remove subsequence dialog appears
@@ -202,7 +202,7 @@ GUI_TEST_CLASS_DEFINITION(test_0005) {
     GTFileDialog::openFile(os, dataDir + "samples/FASTA/", "human_T1.fa");
     GTUtilsTaskTreeView::waitTaskFinished(os);
     GTUtilsDialog::waitForDialog(os, new SelectSequenceRegionDialogFiller(os, 1, 50));
-    GTKeyboardUtils::selectAll(os);
+    GTKeyboardUtils::selectAll();
     GTGlobals::sleep(1000);
     Runnable *removeDialog = new RemovePartFromSequenceDialogFiller(os,
                                                                     RemovePartFromSequenceDialogFiller::Remove,
@@ -271,7 +271,7 @@ GUI_TEST_CLASS_DEFINITION(test_0008) {
     CHECK_SET_ERR(dummyTest != NULL, "There is no annotation DUMMY_1");
 
     GTUtilsDialog::waitForDialog(os, new SelectSequenceRegionDialogFiller(os, 2, 2));
-    GTKeyboardUtils::selectAll(os);
+    GTKeyboardUtils::selectAll();
     GTGlobals::sleep();
 
     Runnable *removeDialog = new RemovePartFromSequenceDialogFiller(os,
@@ -303,7 +303,7 @@ GUI_TEST_CLASS_DEFINITION(test_0009) {
 
     GTWidget::click(os, GTWidget::findWidget(os, "ADV_single_sequence_widget_0"));
     GTGlobals::sleep();
-    GTKeyboardUtils::selectAll(os);
+    GTKeyboardUtils::selectAll();
     GTGlobals::sleep(1000);
 
     GTKeyboardDriver::keyClick('c', Qt::ControlModifier);
@@ -319,7 +319,7 @@ GUI_TEST_CLASS_DEFINITION(test_0010) {
     QWidget *mdiWindow = GTUtilsMdi::activeWindow(os);
 
     GTUtilsDialog::waitForDialog(os, new SelectSequenceRegionDialogFiller(os, 1, 11));
-    GTKeyboardUtils::selectAll(os);
+    GTKeyboardUtils::selectAll();
     GTGlobals::sleep(1000);
     GTUtilsDialog::waitForDialog(os, new PopupChooser(os, QStringList() << ADV_MENU_COPY << ADV_COPY_TRANSLATION_ACTION, GTGlobals::UseKey));
     GTMenu::showContextMenu(os, mdiWindow);

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/sequence_edit/GTTestsSequenceEditMode.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/sequence_edit/GTTestsSequenceEditMode.cpp
@@ -299,11 +299,11 @@ GUI_TEST_CLASS_DEFINITION(without_anns_test_0004) {
 
     //5. Select these 6 symbols and do �TRL+C
     GTUtilsSequenceView::selectSequenceRegion(os, 1, 6);
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
 
     //6. Put cursor in "199 939" position and do �TRL + V
     GTUtilsSequenceView::setCursor(os, 199939);
-    GTKeyboardUtils::paste(os);
+    GTKeyboardUtils::paste();
     GTGlobals::sleep();
 
     //Expected state : Sequence ends with "A,C, G,T,N,gap"

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/sequence_selection/GTTestsSequenceSelection.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/sequence_selection/GTTestsSequenceSelection.cpp
@@ -130,7 +130,7 @@ GUI_TEST_CLASS_DEFINITION(double_click_test_0002) {
     CHECK_SET_ERR(text.startsWith("MGQTVTTPLSL"), QString("'Copy annotation sequence translation' clipboard check, expected: MGQTVTTPLSL, current: %1").arg(text.left(10)));
 
     //8. Press Ctrl + C(or Cmd + C on Mac OS X).
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
 
     //Expected state : a sequence that starts from "ATGGGCCAGACTGTT" is stored in the clipboard.
     text = GTClipboard::text(os);
@@ -370,7 +370,7 @@ GUI_TEST_CLASS_DEFINITION(mixed_test_0002) {
     CHECK_SET_ERR(text.endsWith("QLKPIEYEP*"), QString("Unexpected end of the clipboard text, expected: QLKPIEYEP*, current: %1").arg(text.right(10)));
 
     //12. Press Ctrl + C(Cmd + C on Mac OS X).
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
 
     //    Expected state : there is joined sequence from the third and fourth annotations in the clipboard.
     text = GTClipboard::text(os);
@@ -582,7 +582,7 @@ GUI_TEST_CLASS_DEFINITION(one_click_test_0002) {
     CHECK_SET_ERR(text.startsWith("MGQTVTTPLS"), QString("Unexpected start of the clipboard text, expected: MGQTVTTPLS, current: %1").arg(text.left(10)));
 
     //8. Press Ctrl + C(or Cmd + C on Mac OS X).
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
 
     //    Expected state : a sequence that starts from "ATGGGCCAGACTGTT" is stored in the clipboard.
     text = GTClipboard::text(os);
@@ -652,7 +652,7 @@ GUI_TEST_CLASS_DEFINITION(one_click_test_0003) {
     CHECK_SET_ERR("RSGTKKQLNTKQDICGKRFLPRLRAKNR*DS*V" == text, QString("Unexpected text in the clipboard, expected: RSGTKKQLNTKQDICGKRFLPRLRAKNR*DS*V, current: %1").arg(text));
 
     //4. Press Ctrl + C(or Cmd + C on Mac OS X) on the keyboard.
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
 
     //    Expected state : the selected region is stored in the clipboard.
     text = GTClipboard::text(os);

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_1001_2000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_1001_2000.cpp
@@ -5686,7 +5686,7 @@ GUI_TEST_CLASS_DEFINITION(test_1575) {
 
     //    Expected state: gap was inserted in every sequence of this group.
     GTUtilsMSAEditorSequenceArea::selectArea(os, QPoint(0, 10), QPoint(0, 12));
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
     QString clipboardText = GTClipboard::text(os);
     CHECK_SET_ERR(clipboardText == "-\nT\nT", "Unexpected selection: " + clipboardText);
 
@@ -5696,7 +5696,7 @@ GUI_TEST_CLASS_DEFINITION(test_1575) {
 
     //    Expected state: all sequences in the group are changed simultaneously.
     GTUtilsMSAEditorSequenceArea::selectArea(os, QPoint(2, 10), QPoint(2, 12));
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
     clipboardText = GTClipboard::text(os);
     CHECK_SET_ERR(clipboardText == "T\n-\nA", "Unexpected selection 2: " + clipboardText);
 }

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_2001_3000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_2001_3000.cpp
@@ -2796,7 +2796,7 @@ GUI_TEST_CLASS_DEFINITION(test_2410) {
     CHECK_SET_ERR(NULL != sequenceWidget, "sequenceWidget is not present");
 
     GTWidget::click(os, sequenceWidget);
-    GTKeyboardUtils::selectAll(os);
+    GTKeyboardUtils::selectAll();
 
     QWidget *graphAction = GTWidget::findWidget(os, "GraphMenuAction", sequenceWidget, false);
     Runnable *chooser = new PopupChooser(os, QStringList() << "GC Content (%)");

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_3001_4000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_3001_4000.cpp
@@ -1401,9 +1401,9 @@ GUI_TEST_CLASS_DEFINITION(test_3226) {
 
     //3. Copy and paste the 'Read File URL(s)' element.
     GTUtilsWorkflowDesigner::click(os, "Read File URL(s)");
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
     //GTWidget::click(os, GTAction::button(os, "Copy action"));
-    GTKeyboardUtils::paste(os);
+    GTKeyboardUtils::paste();
 
     //4. Save the workflow.
     QString path = sandBoxDir + "test_3226_workflow.uwl";

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_4001_5000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_4001_5000.cpp
@@ -322,10 +322,10 @@ GUI_TEST_CLASS_DEFINITION(test_4022) {
             GTWidget::click(os, GTWidget::findExactWidget<QPlainTextEdit *>(os, "sequenceEdit", dialog));
 
             GTUtilsDialog::waitForDialog(os, new MessageBoxDialogFiller(os, QMessageBox::No, "amount of data"));
-            GTKeyboardUtils::paste(os);
+            GTKeyboardUtils::paste();
 
             GTUtilsDialog::waitForDialog(os, new MessageBoxDialogFiller(os, QMessageBox::Yes, "amount of data"));
-            GTKeyboardUtils::paste(os);
+            GTKeyboardUtils::paste();
 
             GTUtilsDialog::clickButtonBox(os, dialog, QDialogButtonBox::Cancel);
         }
@@ -4961,7 +4961,7 @@ GUI_TEST_CLASS_DEFINITION(test_4764_1) {
     CHECK_SET_ERR(clipboardText == expectedClipboard, "expected test didn't equal to actual");
 
     //Expected state subalignment pasted correctly
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
     clipboardText = GTClipboard::text(os);
     GTWidget::click(os, GTWidget::findWidget(os, "msa_editor_sequence_area"));
     CHECK_SET_ERR(clipboardText == expectedClipboard, "expected test didn't equal to actual");
@@ -5706,7 +5706,7 @@ GUI_TEST_CLASS_DEFINITION(test_4908) {
     GTFileDialog::openFile(os, dataDir + "samples/FASTA", "human_T1.fa");
     GTUtilsTaskTreeView::waitTaskFinished(os);
     GTUtilsSequenceView::selectSequenceRegion(os, 1, 199950);
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
 
     GTFileDialog::openFile(os, testDir + "_common_data/fasta/", "seq5.fa");
     GTUtilsTaskTreeView::waitTaskFinished(os);
@@ -5730,7 +5730,7 @@ GUI_TEST_CLASS_DEFINITION(test_4908) {
     //2. Select the first sequence and add data to the clipboard
     DetView *firstSeqWidget = GTUtilsSequenceView::getDetViewByNumber(os, 0);
     GTWidget::click(os, firstSeqWidget);
-    GTKeyboardUtils::paste(os);
+    GTKeyboardUtils::paste();
 
     //3. While the data is been pasted, select the second sequence
     DetView *secondSeqWidget = GTUtilsSequenceView::getDetViewByNumber(os, 1);

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_5001_6000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_5001_6000.cpp
@@ -726,13 +726,13 @@ GUI_TEST_CLASS_DEFINITION(test_5211) {
     GTUtilsMsaEditor::clickSequenceName(os, "Phaneroptera_falcata");
 
     //    3. Copy it to the clipboard.
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
 
 //    4. Press the next key sequence:
 //        Windows and Linux: Shift+Ins
 //        macOS: Meta+Y
 #ifndef Q_OS_MAC
-    GTKeyboardUtils::paste(os);
+    GTKeyboardUtils::paste();
 #else
     GTKeyboardDriver::keyClick('y', Qt::MetaModifier);
 #endif
@@ -4920,7 +4920,7 @@ GUI_TEST_CLASS_DEFINITION(test_5948) {
 
     //3. Copy a sequence region
     GTUtilsSequenceView::selectSequenceRegion(os, 10, 20);
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
 
     //4. "Copy/Paste > Paste sequence" is disabled in the context menu.
     GTUtilsDialog::waitForDialog(os, new PopupCheckerByText(os, QStringList() << "Copy/Paste"

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_6001_7000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_6001_7000.cpp
@@ -714,7 +714,7 @@ GUI_TEST_CLASS_DEFINITION(test_6078) {
 
     //2. Select 1 - 10 chars
     GTUtilsSequenceView::selectSequenceRegion(os, 1, 10);
-    GTKeyboardUtils::copy(os);
+    GTKeyboardUtils::copy();
 
     //3. Enable edit mode
     GTUtilsSequenceView::enableEditingMode(os);
@@ -723,7 +723,7 @@ GUI_TEST_CLASS_DEFINITION(test_6078) {
     GTUtilsSequenceView::setCursor(os, 5);
 
     //5. Press paste
-    GTKeyboardUtils::paste(os);
+    GTKeyboardUtils::paste();
     GTGlobals::sleep();
 
     //Expected: cursor on the 15-th pos

--- a/src/plugins/external_tool_support/src/blast_plus/align_worker_subtasks/BlastReadsSubTask.cpp
+++ b/src/plugins/external_tool_support/src/blast_plus/align_worker_subtasks/BlastReadsSubTask.cpp
@@ -80,7 +80,7 @@ void BlastReadsSubTask::prepare() {
     }
 }
 
-QList<Task *> BlastReadsSubTask::onSubTaskFinished(Task *task) {
+QList<Task *> BlastReadsSubTask::onSubTaskFinished(Task * /*task*/) {
     QList<Task *> newSubtasks;
     CHECK(!isCanceled() && !hasError(), newSubtasks);
     stateInfo.progress = qRound(100.0 * (readIndex + 1) / reads.size());

--- a/src/plugins_3rdparty/hmm2/src/hmmer2/aligneval.cpp
+++ b/src/plugins_3rdparty/hmm2/src/hmmer2/aligneval.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 /*****************************************************************
 * HMMER - Biological sequence analysis with profile HMMs
 * Copyright (C) 1992-2003 Washington University School of Medicine

--- a/src/plugins_3rdparty/hmm2/src/hmmer2/core_algorithms.cpp
+++ b/src/plugins_3rdparty/hmm2/src/hmmer2/core_algorithms.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 /************************************************************
 * HMMER - Biological sequence analysis with profile HMMs
 * Copyright (C) 1992-2003 Washington University School of Medicine

--- a/src/plugins_3rdparty/hmm2/src/hmmer2/histogram.cpp
+++ b/src/plugins_3rdparty/hmm2/src/hmmer2/histogram.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 /************************************************************
 * HMMER - Biological sequence analysis with profile HMMs
 * Copyright (C) 1992-2003 Washington University School of Medicine

--- a/src/plugins_3rdparty/hmm2/src/hmmer2/msa.cpp
+++ b/src/plugins_3rdparty/hmm2/src/hmmer2/msa.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 /*****************************************************************
 * HMMER - Biological sequence analysis with profile HMMs
 * Copyright (C) 1992-2003 Washington University School of Medicine

--- a/src/plugins_3rdparty/hmm2/src/hmmer2/weight.cpp
+++ b/src/plugins_3rdparty/hmm2/src/hmmer2/weight.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 /*****************************************************************
 * HMMER - Biological sequence analysis with profile HMMs
 * Copyright (C) 1992-2003 Washington University School of Medicine

--- a/src/plugins_3rdparty/hmm2/src/u_build/uhmmbuild.cpp
+++ b/src/plugins_3rdparty/hmm2/src/u_build/uhmmbuild.cpp
@@ -347,7 +347,7 @@ static float frag_trace_score(struct plan7_s *hmm, unsigned char *dsq, struct p7
 //           hmm changed to an ME HMM
 //           ainfo changed, contains ME weights          
 
-static void maximum_entropy(struct alphabet_s* al, struct plan7_s *hmm, unsigned char **dsq, MSA *msa,
+static void maximum_entropy(struct alphabet_s* /*al*/, struct plan7_s *hmm, unsigned char **dsq, MSA *msa,
                             float eff_nseq, struct p7prior_s *prior, struct p7trace_s **tr)
 {
     float *wgt;                 // current best set of ME weights

--- a/src/plugins_3rdparty/hmm2/src/u_search/uhmmsearch.cpp
+++ b/src/plugins_3rdparty/hmm2/src/u_search/uhmmsearch.cpp
@@ -145,7 +145,7 @@ QList<UHMMSearchResult> UHMMSearch::search(plan7_s *_hmm, const char *seq, int s
 // Returns:  (void)
 
 static void
-    main_loop_serial(struct plan7_s *hmm, const char *seq, int seqLen, struct threshold_s *thresh, int do_forward, int do_null2, int do_xnu, struct histogram_s *histogram, struct tophit_s *ghit, struct tophit_s *dhit, int *ret_nseq, TaskStateInfo &ti) {
+    main_loop_serial(struct plan7_s *hmm, const char *seq, int seqLen, struct threshold_s *thresh, int do_forward, int do_null2, int do_xnu, struct histogram_s *histogram, struct tophit_s *ghit, struct tophit_s *dhit, int */*ret_nseq*/, TaskStateInfo &ti) {
     //get HMMERTaskLocalData
     HMMERTaskLocalData *tld = getHMMERTaskLocalData();
     alphabet_s *al = &tld->al;

--- a/src/plugins_3rdparty/kalign/src/KalignAdapter.cpp
+++ b/src/plugins_3rdparty/kalign/src/KalignAdapter.cpp
@@ -56,7 +56,7 @@ void KalignAdapter::align(const MultipleSequenceAlignment &ma, MultipleSequenceA
 
 namespace {
 
-void cleanupMemory(float **submatrix, unsigned int numseq, float **dm, struct alignment *aln, struct parameters *param) {
+void cleanupMemory(float **/*submatrix*/, unsigned int /*numseq*/, float **/*dm*/, struct alignment */*aln*/, struct parameters */*param*/) {
 // TODO: investigating crash on Windows. The best solution would be moving KAlign into external tools?
 //    if (NULL != submatrix) {
 //        for (int i = 32; i--;){

--- a/src/plugins_3rdparty/phylip/src/cons.cpp
+++ b/src/plugins_3rdparty/phylip/src/cons.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "phylip.h"
 #include "cons.h"
 

--- a/src/plugins_3rdparty/phylip/src/dist.cpp
+++ b/src/plugins_3rdparty/phylip/src/dist.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "phylip.h"
 #include "dist.h"
 

--- a/src/plugins_3rdparty/phylip/src/phylip.cpp
+++ b/src/plugins_3rdparty/phylip/src/phylip.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 /* version 3.696.
 Written by Mary Kuhner, Jon Yamato, Joseph Felsenstein, Akiko Fuseki,
 Sean Lamont, and Andrew Keeffe.

--- a/src/plugins_3rdparty/phylip/src/seq.cpp
+++ b/src/plugins_3rdparty/phylip/src/seq.cpp
@@ -1,3 +1,5 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
 
 #include "phylip.h"
 #include "seq.h"

--- a/src/plugins_3rdparty/phylip/src/seqboot.cpp
+++ b/src/plugins_3rdparty/phylip/src/seqboot.cpp
@@ -633,7 +633,7 @@ void freenewer()
 }
 
 
-void doinput(int argc, Phylip_Char *argv[])
+void doinput(int /*argc*/, Phylip_Char *argv[])
 { /* reads the input data */
   seqboot_getoptions();
   seqboot_inputnumbers();

--- a/src/plugins_3rdparty/umuscle/src/muscle/aligngivenpath.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/aligngivenpath.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "msa.h"
 #include "pwpath.h"

--- a/src/plugins_3rdparty/umuscle/src/muscle/alpha.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/alpha.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include <ctype.h>
 

--- a/src/plugins_3rdparty/umuscle/src/muscle/clustsetdf.h
+++ b/src/plugins_3rdparty/umuscle/src/muscle/clustsetdf.h
@@ -1,6 +1,9 @@
 #ifndef ClustSetDF_h
 #define ClustSetDF_h
 
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 class MSA;
 class Clust;
 

--- a/src/plugins_3rdparty/umuscle/src/muscle/clustsetmsa.h
+++ b/src/plugins_3rdparty/umuscle/src/muscle/clustsetmsa.h
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #ifndef ClustSetMSA_h
 #define ClustSetMSA_h
 

--- a/src/plugins_3rdparty/umuscle/src/muscle/diffobjscore.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/diffobjscore.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "msa.h"
 #include "objscore.h"

--- a/src/plugins_3rdparty/umuscle/src/muscle/glbalignsimple.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/glbalignsimple.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include <math.h>
 #include "pwpath.h"

--- a/src/plugins_3rdparty/umuscle/src/muscle/globals.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/globals.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #if	WIN32
 #include <windows.h>
 #include <share.h>

--- a/src/plugins_3rdparty/umuscle/src/muscle/globalslinux.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/globalslinux.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 
 #if		defined(__linux__)

--- a/src/plugins_3rdparty/umuscle/src/muscle/msa.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/msa.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "msa.h"
 #include "textfile.h"

--- a/src/plugins_3rdparty/umuscle/src/muscle/profdb.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/profdb.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "textfile.h"
 #include "seqvect.h"

--- a/src/plugins_3rdparty/umuscle/src/muscle/profilefrommsa.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/profilefrommsa.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "msa.h"
 #include "profile.h"

--- a/src/plugins_3rdparty/umuscle/src/muscle/realigndiffs.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/realigndiffs.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "msa.h"
 #include "tree.h"

--- a/src/plugins_3rdparty/umuscle/src/muscle/refinehoriz.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/refinehoriz.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "tree.h"
 #include "msa.h"

--- a/src/plugins_3rdparty/umuscle/src/muscle/scorehistory.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/scorehistory.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "scorehistory.h"
 #include <stdio.h>

--- a/src/plugins_3rdparty/umuscle/src/muscle/subfams.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/subfams.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "distfunc.h"
 #include "muscle_context.h"

--- a/src/plugins_3rdparty/umuscle/src/muscle/sw.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/sw.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include <math.h>
 #include "pwpath.h"

--- a/src/plugins_3rdparty/umuscle/src/muscle/textfile.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/textfile.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "textfile.h"
 #include <errno.h>

--- a/src/plugins_3rdparty/umuscle/src/muscle/upgma2.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/upgma2.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "tree.h"
 #include "distcalc.h"

--- a/src/plugins_3rdparty/umuscle/src/umuscle_tests/umuscleTests.cpp
+++ b/src/plugins_3rdparty/umuscle/src/umuscle_tests/umuscleTests.cpp
@@ -287,7 +287,7 @@ Task::ReportResult GTest_CompareMAlignment::report() {
     return ReportResult_Finished;
 }
 
-void GTest_uMuscleAddUnalignedSequenceToProfile::init(XMLTestFormat *tf, const QDomElement& el) {
+void GTest_uMuscleAddUnalignedSequenceToProfile::init(XMLTestFormat */*tf*/, const QDomElement& el) {
     origAliSeqs = 0;
     aliObj = NULL;
     resultAliSeqs = 0;

--- a/src/ugene_globals.pri
+++ b/src/ugene_globals.pri
@@ -50,9 +50,12 @@ macx {
 }
 
 linux-g++ {
+    # Enable all warnings. Every new version of GCC will provide new reasonable defaults.
+    # See https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
     QMAKE_CXXFLAGS += -Wall
 
-    # We have a lot of such warning from QT -> disable them.
+    # We have a lot of such warning from QT.
+    # Disable them now and recheck every time we increase the minimal supported version of QT.
     QMAKE_CXXFLAGS += -Wno-catch-value
     QMAKE_CXXFLAGS += -Wno-class-memaccess
     QMAKE_CXXFLAGS += -Wno-deprecated-copy
@@ -65,11 +68,12 @@ linux-g++ {
     # QT 5.4 sources produce this warning when compiled with gcc9. Re-check after QT upgrade.
     QMAKE_CXXFLAGS += -Wno-cast-function-type
 
-    # Some of the warnings must be errors
+    # These warnings must be errors:
     QMAKE_CXXFLAGS += -Werror=maybe-uninitialized
     QMAKE_CXXFLAGS += -Werror=parentheses
     QMAKE_CXXFLAGS += -Werror=return-type
     QMAKE_CXXFLAGS += -Werror=uninitialized
+    QMAKE_CXXFLAGS += -Werror=unused-parameter
 
     # build with coverage (gcov) support, now for Linux only
     equals(UGENE_GCOV_ENABLE, 1) {


### PR DESCRIPTION
1. This patch does not introduce any changes to the code and is safe to be merged both into release-38 or master branches.

2. The UI file has warnings too and was opened and saved back with no changes: QtDesigner automatically removed the bad code.

3. Some files include "disable-warnings" header and some have a warning fix in place. The ones that have the fix contain our own code. The ones that have no fix but include "disable-warnings" header are 3rd party code we do not want to modify.