### PR TITLE
UGENE-7138. Enable warning about unused variables in GCC build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,6 @@ if (CMAKE_COMPILER_IS_GNUCXX)
             " -Wno-ignored-attributes"
             " -Wno-implicit-fallthrough"
             " -Wno-sign-compare"
-            " -Wno-unused-variable"
             )
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_WARNING_FLAGS}")
 endif ()

--- a/src/corelibs/U2Core/src/globals/disable-warnings.h
+++ b/src/corelibs/U2Core/src/globals/disable-warnings.h
@@ -32,10 +32,16 @@
 
 #ifdef __GNUC__
 #    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wunused-parameter"
-#    pragma GCC diagnostic ignored "-Wunused-function"
+#    pragma GCC diagnostic ignored "-Wbool-compare"
+#    pragma GCC diagnostic ignored "-Wdeprecated"
 #    pragma GCC diagnostic ignored "-Wmisleading-indentation"
+#    pragma GCC diagnostic ignored "-Wpointer-compare"
+#    pragma GCC diagnostic ignored "-Wsizeof-pointer-memaccess"
+#    pragma GCC diagnostic ignored "-Wswitch"
 #    pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#    pragma GCC diagnostic ignored "-Wunused-function"
+#    pragma GCC diagnostic ignored "-Wunused-parameter"
+#    pragma GCC diagnostic ignored "-Wunused-variable"
 #endif
 
 /**

--- a/src/corelibs/U2Core/src/util/MsaDbiUtils.cpp
+++ b/src/corelibs/U2Core/src/util/MsaDbiUtils.cpp
@@ -1053,7 +1053,6 @@ QList<qint64> MsaDbiUtils::replaceNonGapCharacter(const U2EntityRef &msaRef, cha
     U2MsaDbi *msaDbi = con->dbi->getMsaDbi();
     U2SequenceDbi *sequenceDbi = con->dbi->getSequenceDbi();
 
-    qint64 msaLength = msaDbi->getMsaLength(msaRef.entityId, os);
     QList<qint64> rowIds = msaDbi->getOrderedRowIds(msaRef.entityId, os);
     CHECK_OP(os, modifiedRowIds);
     QVariantMap updateSequenceHints;

--- a/src/corelibs/U2View/src/ov_msa/MSAEditor.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditor.cpp
@@ -612,7 +612,6 @@ void MSAEditor::sl_align() {
 }
 
 void MSAEditor::sl_addToAlignment() {
-    MultipleSequenceAlignmentObject *msaObject = getMaObject();
     CHECK(!maObject->isStateLocked(), );
 
     ProjectView *pv = AppContext::getProjectView();

--- a/src/libs_3rdparty/QSpec/src/primitives/GTScrollBar.cpp
+++ b/src/libs_3rdparty/QSpec/src/primitives/GTScrollBar.cpp
@@ -208,8 +208,6 @@ QPoint GTScrollBar::getSliderPosition(GUITestOpStatus &os, QScrollBar *scrollbar
 QPoint GTScrollBar::getUpArrowPosition(GUITestOpStatus &os, QScrollBar *scrollbar) {
     GT_CHECK_RESULT(scrollbar != NULL, "scrollbar is NULL", QPoint());
     QStyleOptionSlider options = initScrollbarOptions(os, scrollbar);
-    QRect grooveRect = scrollbar->style()->subControlRect(QStyle::CC_ScrollBar, &options, QStyle::SC_ScrollBarGroove);
-
     return scrollbar->mapToGlobal(scrollbar->rect().topLeft() + QPoint(5, 5));
 }
 #undef GT_METHOD_NAME
@@ -218,8 +216,6 @@ QPoint GTScrollBar::getUpArrowPosition(GUITestOpStatus &os, QScrollBar *scrollba
 QPoint GTScrollBar::getDownArrowPosition(GUITestOpStatus &os, QScrollBar *scrollbar) {
     GT_CHECK_RESULT(scrollbar != NULL, "scrollbar is NULL", QPoint());
     QStyleOptionSlider options = initScrollbarOptions(os, scrollbar);
-    QRect grooveRect = scrollbar->style()->subControlRect(QStyle::CC_ScrollBar, &options, QStyle::SC_ScrollBarGroove);
-
     return scrollbar->mapToGlobal(scrollbar->rect().bottomRight() - QPoint(5, 5));
 }
 #undef GT_METHOD_NAME

--- a/src/libs_3rdparty/breakpad/src/client/linux/handler/exception_handler.cc
+++ b/src/libs_3rdparty/breakpad/src/client/linux/handler/exception_handler.cc
@@ -1,3 +1,7 @@
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wdeprecated"
+#endif
+
 // Copyright (c) 2010 Google Inc.
 // All rights reserved.
 //

--- a/src/libs_3rdparty/qscore/src/qscore/qscore.h
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore.h
@@ -14,7 +14,10 @@
 #include <vector>
 #include <string>
 
+#ifndef UINT_MAX
 #define UINT_MAX 0xffffffff
+#endif
+
 #ifdef _MSC_VER
 #  if _MSC_VER < 1900
 #include <hash_map>
@@ -24,8 +27,8 @@ typedef stdext::hash_map<std::string, unsigned> StrToInt;
 typedef std::unordered_map<std::string, unsigned> StrToInt;
 #  endif
 #else
+#undef __DEPRECATED // disable warning message about deprecated dependency.
 #include <ext/hash_map>
-#define HASH_MAP	
 
 struct HashStringToUnsigned
 	{

--- a/src/libs_3rdparty/qscore/src/qscore/qscore_clineshift.cpp
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore_clineshift.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "qscore.h"
 
 // Compute the Cline shift score [1] from two pair maps.

--- a/src/libs_3rdparty/qscore/src/qscore/qscore_comparemap.cpp
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore_comparemap.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "qscore.h"
 
 #if	_DEBUG

--- a/src/libs_3rdparty/qscore/src/qscore/qscore_comparemsa.cpp
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore_comparemsa.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "qscore.h"
 
 void CompareMSA(const MSA_QScore &msaTest, const MSA_QScore &msaRef, double *ptrdSP,

--- a/src/libs_3rdparty/qscore/src/qscore/qscore_comparepair.cpp
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore_comparepair.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "qscore.h"
 
 //unsigned g_TestSeqIndexA = UINT_MAX;

--- a/src/libs_3rdparty/qscore/src/qscore/qscore_gapscore.cpp
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore_gapscore.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "qscore.h"
 
 #define TRACE	0

--- a/src/libs_3rdparty/qscore/src/qscore/qscore_gapscore2.cpp
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore_gapscore2.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "qscore.h"
 
 using namespace std;

--- a/src/libs_3rdparty/qscore/src/qscore/qscore_msa_qscore.cpp
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore_msa_qscore.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "qscore.h"
 
 MSA_QScore::MSA_QScore()

--- a/src/libs_3rdparty/qscore/src/qscore/qscore_options.cpp
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore_options.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "qscore.h"
 
 struct VALUE_OPT

--- a/src/libs_3rdparty/qscore/src/qscore/qscore_perseq.cpp
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore_perseq.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "qscore.h"
 
 double QPair(const MSA_QScore &msaTest, unsigned uTestSeqIndexA, unsigned uTestSeqIndexB,

--- a/src/libs_3rdparty/qscore/src/qscore/qscore_qscore.cpp
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore_qscore.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "qscore.h"
 
 //const char *g_TestFileName;

--- a/src/libs_3rdparty/qscore/src/qscore/qscore_seq.cpp
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore_seq.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "qscore.h"
 
 #if	0

--- a/src/libs_3rdparty/qscore/src/qscore/qscore_sumpairs.cpp
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore_sumpairs.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "qscore.h"
 
 // Compute the sum of pairs score from two pair maps.

--- a/src/libs_3rdparty/qscore/src/qscore/qscore_tc.cpp
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore_tc.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "qscore.h"
 
 #ifdef _MSC_VER

--- a/src/libs_3rdparty/qscore/src/qscore/qscore_utils.cpp
+++ b/src/libs_3rdparty/qscore/src/qscore/qscore_utils.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "qscore.h"
 
 void Quit_Qscore(const char *szFormat, ...)

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_6001_7000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_6001_7000.cpp
@@ -6450,7 +6450,7 @@ GUI_TEST_CLASS_DEFINITION(test_6952) {
     class RemoteBLASTWizardFiller : public CustomScenario {
     public:
         void run(HI::GUITestOpStatus &os) override {
-            QWidget *dialog = QApplication::activeModalWidget();
+            GTWidget::getActiveModalWidget(os);
 
             GTUtilsWizard::setInputFiles(os, QList<QStringList>() << (QStringList() << QFileInfo(testDir + "_common_data/fasta/human_T1_cutted.fa").absoluteFilePath()));
 

--- a/src/plugins_3rdparty/ball/src/BallPlugin.cpp
+++ b/src/plugins_3rdparty/ball/src/BallPlugin.cpp
@@ -19,26 +19,26 @@
  * MA 02110-1301, USA.
  */
 
-#include <U2Core/AppContext.h>
-#include <U2Algorithm/MolecularSurfaceFactoryRegistry.h>
-#include <SES.h>
 #include <SAS.h>
+#include <SES.h>
+
+#include <U2Algorithm/MolecularSurfaceFactoryRegistry.h>
+
+#include <U2Core/AppContext.h>
 
 #include "BallPlugin.h"
 
 namespace U2 {
 
-extern "C" Q_DECL_EXPORT U2::Plugin* U2_PLUGIN_INIT_FUNC() {
-    BallPlugin* plug = new BallPlugin();
+extern "C" Q_DECL_EXPORT U2::Plugin *U2_PLUGIN_INIT_FUNC() {
+    BallPlugin *plug = new BallPlugin();
     return plug;
 }
 
 BallPlugin::BallPlugin()
-: Plugin(tr("BALL"),tr("A port of BALL framework for molecular surface calculation"))
-{
-    AppContext::getMolecularSurfaceFactoryRegistry()->registerSurfaceFactory(new SolventExcludedSurfaceFactory(),QString("SES"));
-    AppContext::getMolecularSurfaceFactoryRegistry()->registerSurfaceFactory(new SolventAccessibleSurfaceFactory(),QString("SAS"));
-
+    : Plugin(tr("BALL"), tr("A port of BALL framework for molecular surface calculation")) {
+    AppContext::getMolecularSurfaceFactoryRegistry()->registerSurfaceFactory(new SolventExcludedSurfaceFactory(), QString("SES"));
+    AppContext::getMolecularSurfaceFactoryRegistry()->registerSurfaceFactory(new SolventAccessibleSurfaceFactory(), QString("SAS"));
 }
 
-} // namespace
+}    // namespace U2

--- a/src/plugins_3rdparty/ball/src/BallPlugin.h
+++ b/src/plugins_3rdparty/ball/src/BallPlugin.h
@@ -24,16 +24,14 @@
 
 #include <U2Core/PluginModel.h>
 
-namespace U2
-{
+namespace U2 {
 
-class BallPlugin : public Plugin
-{
+class BallPlugin : public Plugin {
     Q_OBJECT
 public:
     BallPlugin();
 };
 
-} // namespace
+}    // namespace U2
 
-#endif // BALLPLUGIN_H
+#endif    // BALLPLUGIN_H

--- a/src/plugins_3rdparty/ball/src/SAS.cpp
+++ b/src/plugins_3rdparty/ball/src/SAS.cpp
@@ -19,72 +19,70 @@
  * MA 02110-1301, USA.
  */
 
-#include <U2Core/Counter.h>
-
 #include <U2Algorithm/MolecularSurface.h>
+
+#include <U2Core/Counter.h>
+#ifdef __GNUC__
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wdeprecated"
+#endif
 #include <BALL/STRUCTURE/triangulatedSAS.h>
+#ifdef __GNUC__
+#    pragma GCC diagnostic pop
+#endif
+
 #include "SAS.h"
 
-namespace U2
-{
+namespace U2 {
 
 // SolventAccessibleSurface
 
-SolventAccessibleSurface::SolventAccessibleSurface()
-{
-    GCOUNTER( cvar, "SolventAccessibleSurface" );
+SolventAccessibleSurface::SolventAccessibleSurface() {
+    GCOUNTER(cvar, "SolventAccessibleSurface");
 }
 
-void SolventAccessibleSurface::calculate(const QList<SharedAtom>& atoms, int& /*progress*/)
-{
+void SolventAccessibleSurface::calculate(const QList<SharedAtom> &atoms, int & /*progress*/) {
     BALL::Surface surface;
     {
-        std::vector<BALL::TSphere3<double> > spheres;
-        foreach(const SharedAtom a, atoms)
-        {
-            Vector3D coord=a->coord3d;
-            double radius=AtomConstants::getAtomCovalentRadius(a->atomicNumber)+TOLERANCE;
-            spheres.push_back(BALL::TSphere3<double>(BALL::TVector3<double>(coord.x,coord.y,coord.z),radius));
+        std::vector<BALL::TSphere3<double>> spheres;
+        foreach (const SharedAtom a, atoms) {
+            Vector3D coord = a->coord3d;
+            double radius = AtomConstants::getAtomCovalentRadius(a->atomicNumber) + TOLERANCE;
+            spheres.push_back(BALL::TSphere3<double>(BALL::TVector3<double>(coord.x, coord.y, coord.z), radius));
         }
-        double probeRadius=1.4;
-        BALL::ReducedSurface reducedSurface(spheres,probeRadius);
+        double probeRadius = 1.4;
+        BALL::ReducedSurface reducedSurface(spheres, probeRadius);
         reducedSurface.compute();
         BALL::SolventAccessibleSurface solventAccessibleSurface(&reducedSurface);
         solventAccessibleSurface.compute();
-        double density = 1000/atoms.size();
+        double density = 1000.0 / atoms.size();
         BALL::TriangulatedSAS triangulatedSAS(&solventAccessibleSurface, density);
         triangulatedSAS.compute();
         triangulatedSAS.exportSurface(surface);
     }
-    for(unsigned int faceIndex=0;faceIndex < surface.getNumberOfTriangles();faceIndex++)
-    {
-        const BALL::Surface::Triangle &triangle=surface.getTriangle(faceIndex);
+    for (unsigned int faceIndex = 0; faceIndex < surface.getNumberOfTriangles(); faceIndex++) {
+        const BALL::Surface::Triangle &triangle = surface.getTriangle(faceIndex);
         Face face;
-        for(int coordIndex=0;coordIndex < 3;coordIndex++)
-        {
-            face.v[0][coordIndex]=surface.getVertex(triangle.v1)[coordIndex];
-            face.v[1][coordIndex]=surface.getVertex(triangle.v2)[coordIndex];
-            face.v[2][coordIndex]=surface.getVertex(triangle.v3)[coordIndex];
-            face.n[0][coordIndex]=surface.getNormal(triangle.v1)[coordIndex];
-            face.n[1][coordIndex]=surface.getNormal(triangle.v2)[coordIndex];
-            face.n[2][coordIndex]=surface.getNormal(triangle.v3)[coordIndex];
+        for (int coordIndex = 0; coordIndex < 3; coordIndex++) {
+            face.v[0][coordIndex] = surface.getVertex(triangle.v1)[coordIndex];
+            face.v[1][coordIndex] = surface.getVertex(triangle.v2)[coordIndex];
+            face.v[2][coordIndex] = surface.getVertex(triangle.v3)[coordIndex];
+            face.n[0][coordIndex] = surface.getNormal(triangle.v1)[coordIndex];
+            face.n[1][coordIndex] = surface.getNormal(triangle.v2)[coordIndex];
+            face.n[2][coordIndex] = surface.getNormal(triangle.v3)[coordIndex];
         }
         faces.append(face);
     }
 }
 
-qint64 SolventAccessibleSurface::estimateMemoryUsage( int )
-{
+qint64 SolventAccessibleSurface::estimateMemoryUsage(int) {
     return 0;
 }
 
-
-
 // SolventAccessibleSurfaceFactory
 
-MolecularSurface *SolventAccessibleSurfaceFactory::createInstance() const
-{
+MolecularSurface *SolventAccessibleSurfaceFactory::createInstance() const {
     return new SolventAccessibleSurface();
 }
 
-} // namespace
+}    // namespace U2

--- a/src/plugins_3rdparty/ball/src/SAS.h
+++ b/src/plugins_3rdparty/ball/src/SAS.h
@@ -24,23 +24,20 @@
 
 #include <U2Algorithm/MolecularSurface.h>
 
-namespace U2
-{
+namespace U2 {
 
-class SolventAccessibleSurface : public MolecularSurface
-{
+class SolventAccessibleSurface : public MolecularSurface {
 public:
     SolventAccessibleSurface();
     virtual qint64 estimateMemoryUsage(int numberOfAtoms);
-    virtual void calculate(const QList<SharedAtom>& atoms, int& progress);
+    virtual void calculate(const QList<SharedAtom> &atoms, int &progress);
 };
 
-class SolventAccessibleSurfaceFactory : public MolecularSurfaceFactory
-{
+class SolventAccessibleSurfaceFactory : public MolecularSurfaceFactory {
 public:
-    virtual MolecularSurface *createInstance()const;
+    virtual MolecularSurface *createInstance() const;
 };
 
-} // namespace
+}    // namespace U2
 
-#endif // SAS_H
+#endif    // SAS_H

--- a/src/plugins_3rdparty/ball/src/SES.cpp
+++ b/src/plugins_3rdparty/ball/src/SES.cpp
@@ -19,53 +19,53 @@
  * MA 02110-1301, USA.
  */
 
-#include <U2Core/Counter.h>
 #include <U2Algorithm/MolecularSurface.h>
+
+#include <U2Core/Counter.h>
+
+#ifdef __GNUC__
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wdeprecated"
+#endif
 #include <BALL/STRUCTURE/triangulatedSES.h>
+#ifdef __GNUC__
+#    pragma GCC diagnostic pop
+#endif
 
 #include "SES.h"
 
-
-namespace U2
-{
-
+namespace U2 {
 
 // SolventExcludedSurface
 
-SolventExcludedSurface::SolventExcludedSurface()
-{
-    GCOUNTER( cvar, "SolventExcludedSurface" );
+SolventExcludedSurface::SolventExcludedSurface() {
+    GCOUNTER(cvar, "SolventExcludedSurface");
 }
 
-
-static void calcSES( BALL::Surface& surface, const QList<SharedAtom>& atoms, double TOLERANCE )
-{
-    std::vector<BALL::TSphere3<double> > spheres;
-    foreach(const SharedAtom a, atoms)
-    {
-        Vector3D coord=a->coord3d;
+static void calcSES(BALL::Surface &surface, const QList<SharedAtom> &atoms, double TOLERANCE) {
+    std::vector<BALL::TSphere3<double>> spheres;
+    foreach (const SharedAtom a, atoms) {
+        Vector3D coord = a->coord3d;
         double radius = AtomConstants::getAtomCovalentRadius(a->atomicNumber) + TOLERANCE;
-        spheres.push_back(BALL::TSphere3<double>(BALL::TVector3<double>(coord.x,coord.y,coord.z),radius));
+        spheres.push_back(BALL::TSphere3<double>(BALL::TVector3<double>(coord.x, coord.y, coord.z), radius));
     }
 
-    double probeRadius=1.4;
+    double probeRadius = 1.4;
     double density = 1000. / atoms.size();
 
-    BALL::ReducedSurface* reduced_surface = new BALL::ReducedSurface(spheres, probeRadius);
+    BALL::ReducedSurface *reduced_surface = new BALL::ReducedSurface(spheres, probeRadius);
     reduced_surface->compute();
 
     {
-        BALL::SolventExcludedSurface* ses = new BALL::SolventExcludedSurface(reduced_surface);
+        BALL::SolventExcludedSurface *ses = new BALL::SolventExcludedSurface(reduced_surface);
         ses->compute();
         double diff = 0.01;
         uint i = 0;
         bool ok = false;
-        while (!ok && (i < 10))
-        {
+        while (!ok && (i < 10)) {
             i++;
             ok = ses->check();
-            if (!ok)
-            {
+            if (!ok) {
                 delete ses;
                 delete reduced_surface;
                 probeRadius += diff;
@@ -75,9 +75,8 @@ static void calcSES( BALL::Surface& surface, const QList<SharedAtom>& atoms, dou
                 ses->compute();
             }
         }
-        if (ok)
-        {
-            BALL::TriangulatedSES* tSurface = new BALL::TriangulatedSES(ses, density);
+        if (ok) {
+            BALL::TriangulatedSES *tSurface = new BALL::TriangulatedSES(ses, density);
             tSurface->compute();
             tSurface->exportSurface(surface);
             delete tSurface;
@@ -86,82 +85,67 @@ static void calcSES( BALL::Surface& surface, const QList<SharedAtom>& atoms, dou
     }
 
     delete reduced_surface;
-
 }
 
-
-void SolventExcludedSurface::calculate(const QList<SharedAtom>& atoms, int& /*progress*/)
-{
-//        std::vector<BALL::TSphere3<double> > spheres;
-//         foreach(const SharedAtom a, atoms)
-//         {
-//             Vector3D coord=a->coord3d;
-//             double radius=PDBFormat::getAtomCovalentRadius(a->atomicNumber)+TOLERANCE;
-//             spheres.push_back(BALL::TSphere3<double>(BALL::TVector3<double>(coord.x,coord.y,coord.z),radius));
-//         }
-//         double probeRadius=1.4;
-//         double density = 1000. / atoms.size();
-//         for(int attempt=0;attempt < 10;attempt++)
-//         {
-//             progress = 0;
-//             BALL::ReducedSurface* reducedSurface = new BALL::ReducedSurface(spheres,probeRadius);
-//             reducedSurface->compute();
-//             BALL::SolventExcludedSurface solventExcludedSurface(&reducedSurface);
-//             solventExcludedSurface.compute();
-//             if(solventExcludedSurface.check())
-//             {
-//                  BALL::TriangulatedSES triangulatedSES(&solventExcludedSurface,density);
-//                  triangulatedSES.compute(progress);
-//                  triangulatedSES.exportSurface(surface);
-//                 break;
-//             }
-//             probeRadius+=0.01;
-//         }
-//
-//
+void SolventExcludedSurface::calculate(const QList<SharedAtom> &atoms, int & /*progress*/) {
+    //        std::vector<BALL::TSphere3<double> > spheres;
+    //         foreach(const SharedAtom a, atoms)
+    //         {
+    //             Vector3D coord=a->coord3d;
+    //             double radius=PDBFormat::getAtomCovalentRadius(a->atomicNumber)+TOLERANCE;
+    //             spheres.push_back(BALL::TSphere3<double>(BALL::TVector3<double>(coord.x,coord.y,coord.z),radius));
+    //         }
+    //         double probeRadius=1.4;
+    //         double density = 1000. / atoms.size();
+    //         for(int attempt=0;attempt < 10;attempt++)
+    //         {
+    //             progress = 0;
+    //             BALL::ReducedSurface* reducedSurface = new BALL::ReducedSurface(spheres,probeRadius);
+    //             reducedSurface->compute();
+    //             BALL::SolventExcludedSurface solventExcludedSurface(&reducedSurface);
+    //             solventExcludedSurface.compute();
+    //             if(solventExcludedSurface.check())
+    //             {
+    //                  BALL::TriangulatedSES triangulatedSES(&solventExcludedSurface,density);
+    //                  triangulatedSES.compute(progress);
+    //                  triangulatedSES.exportSurface(surface);
+    //                 break;
+    //             }
+    //             probeRadius+=0.01;
+    //         }
+    //
+    //
     BALL::Surface surface;
     calcSES(surface, atoms, TOLERANCE);
 
-    for(unsigned int faceIndex=0;faceIndex < surface.getNumberOfTriangles();faceIndex++)
-    {
-        const BALL::Surface::Triangle &triangle=surface.getTriangle(faceIndex);
+    for (unsigned int faceIndex = 0; faceIndex < surface.getNumberOfTriangles(); faceIndex++) {
+        const BALL::Surface::Triangle &triangle = surface.getTriangle(faceIndex);
         Face face;
-        for(int coordIndex=0;coordIndex < 3;coordIndex++)
-        {
-            face.v[0][coordIndex]=surface.getVertex(triangle.v1)[coordIndex];
-            face.v[1][coordIndex]=surface.getVertex(triangle.v2)[coordIndex];
-            face.v[2][coordIndex]=surface.getVertex(triangle.v3)[coordIndex];
-            face.n[0][coordIndex]=surface.getNormal(triangle.v1)[coordIndex];
-            face.n[1][coordIndex]=surface.getNormal(triangle.v2)[coordIndex];
-            face.n[2][coordIndex]=surface.getNormal(triangle.v3)[coordIndex];
+        for (int coordIndex = 0; coordIndex < 3; coordIndex++) {
+            face.v[0][coordIndex] = surface.getVertex(triangle.v1)[coordIndex];
+            face.v[1][coordIndex] = surface.getVertex(triangle.v2)[coordIndex];
+            face.v[2][coordIndex] = surface.getVertex(triangle.v3)[coordIndex];
+            face.n[0][coordIndex] = surface.getNormal(triangle.v1)[coordIndex];
+            face.n[1][coordIndex] = surface.getNormal(triangle.v2)[coordIndex];
+            face.n[2][coordIndex] = surface.getNormal(triangle.v3)[coordIndex];
         }
         faces.append(face);
     }
-
-
 }
 
-qint64 SolventExcludedSurface::estimateMemoryUsage( int )
-{
+qint64 SolventExcludedSurface::estimateMemoryUsage(int) {
     return 0;
 }
 
-
-
-
-
-
 // SolventExcludedSurfaceFactory
 
-MolecularSurface *SolventExcludedSurfaceFactory::createInstance() const
-{
+MolecularSurface *SolventExcludedSurfaceFactory::createInstance() const {
     return new SolventExcludedSurface();
 }
 
 #define MAX_ATOMS_NUMBER 10000
 
-bool SolventExcludedSurfaceFactory::hasConstraints( const BioStruct3D& biostruc ) const
-{
+bool SolventExcludedSurfaceFactory::hasConstraints(const BioStruct3D &biostruc) const {
     if (biostruc.getNumberOfAtoms() > MAX_ATOMS_NUMBER) {
         return true;
     } else {
@@ -169,5 +153,4 @@ bool SolventExcludedSurfaceFactory::hasConstraints( const BioStruct3D& biostruc 
     }
 }
 
-
-} // namespace
+}    // namespace U2

--- a/src/plugins_3rdparty/ball/src/SES.h
+++ b/src/plugins_3rdparty/ball/src/SES.h
@@ -24,26 +24,23 @@
 
 #include <U2Algorithm/MolecularSurface.h>
 
-namespace U2
-{
+namespace U2 {
 
 class Surface;
 
-class SolventExcludedSurface : public MolecularSurface
-{
+class SolventExcludedSurface : public MolecularSurface {
 public:
     SolventExcludedSurface();
-    virtual void calculate(const QList<SharedAtom>& atoms, int& progress);
+    virtual void calculate(const QList<SharedAtom> &atoms, int &progress);
     virtual qint64 estimateMemoryUsage(int numberOfAtoms);
 };
 
-class SolventExcludedSurfaceFactory : public MolecularSurfaceFactory
-{
+class SolventExcludedSurfaceFactory : public MolecularSurfaceFactory {
 public:
-    virtual MolecularSurface *createInstance()const;
-    bool hasConstraints(const BioStruct3D& biostruc) const;
+    virtual MolecularSurface *createInstance() const;
+    bool hasConstraints(const BioStruct3D &biostruc) const;
 };
 
-} // namespace
+}    // namespace U2
 
-#endif // SOLVENTEXCLUDEDSURFACE_H
+#endif    // SOLVENTEXCLUDEDSURFACE_H

--- a/src/plugins_3rdparty/ball/src/include/BALL/COMMON/version.h
+++ b/src/plugins_3rdparty/ball/src/include/BALL/COMMON/version.h
@@ -6,7 +6,14 @@
 #define BALL_COMMON_VERSION_H
 
 #ifndef BALL_COMMON_EXCEPTION_H
-#	include <BALL/COMMON/exception.h>
+#ifdef __GNUC__
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wdeprecated"
+#endif
+#	 include <BALL/COMMON/exception.h>
+#ifdef __GNUC__
+#    pragma GCC diagnostic pop
+#endif
 #endif
 
 #ifndef BALL_COMMON_GLOBAL_H

--- a/src/plugins_3rdparty/ball/src/source/COMMON/exception.cpp
+++ b/src/plugins_3rdparty/ball/src/source/COMMON/exception.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/ball/src/source/CONCEPT/predicate.cpp
+++ b/src/plugins_3rdparty/ball/src/source/CONCEPT/predicate.cpp
@@ -4,4 +4,4 @@
 // $Id: predicate.C,v 1.2 2005/10/23 12:02:28 oliver Exp $
 //
 
-#include <BALL/CONCEPT/predicate.h>
+//#include <BALL/CONCEPT/predicate.h>

--- a/src/plugins_3rdparty/ball/src/source/CONCEPT/processor.cpp
+++ b/src/plugins_3rdparty/ball/src/source/CONCEPT/processor.cpp
@@ -3,4 +3,4 @@
 //
 // $Id: processor.C,v 1.2 2002/02/27 12:21:10 sturm Exp $
 
-#include <BALL/CONCEPT/processor.h>
+//#include <BALL/CONCEPT/processor.h>

--- a/src/plugins_3rdparty/ball/src/source/CONCEPT/visitor.cpp
+++ b/src/plugins_3rdparty/ball/src/source/CONCEPT/visitor.cpp
@@ -3,4 +3,4 @@
 //
 // $Id: visitor.C,v 1.2 2002/02/27 12:21:11 sturm Exp $
 
-#include <BALL/CONCEPT/visitor.h>
+//#include <BALL/CONCEPT/visitor.h>

--- a/src/plugins_3rdparty/ball/src/source/MATHS/analyticalGeometry.cpp
+++ b/src/plugins_3rdparty/ball/src/source/MATHS/analyticalGeometry.cpp
@@ -3,4 +3,4 @@
 //
 // $Id: analyticalGeometry.C,v 1.2 2002/02/27 12:21:26 sturm Exp $
 
-#include <BALL/MATHS/analyticalGeometry.h>
+//#include <BALL/MATHS/analyticalGeometry.h>

--- a/src/plugins_3rdparty/ball/src/source/MATHS/angle.cpp
+++ b/src/plugins_3rdparty/ball/src/source/MATHS/angle.cpp
@@ -3,4 +3,4 @@
 //
 // $Id: angle.C,v 1.2 2002/02/27 12:21:26 sturm Exp $
 
-#include <BALL/MATHS/angle.h>
+//#include <BALL/MATHS/angle.h>

--- a/src/plugins_3rdparty/ball/src/source/MATHS/circle3.cpp
+++ b/src/plugins_3rdparty/ball/src/source/MATHS/circle3.cpp
@@ -3,4 +3,4 @@
 //
 // $Id: circle3.C,v 1.2 2002/02/27 12:21:26 sturm Exp $
 
-#include <BALL/MATHS/circle3.h>
+//#include <BALL/MATHS/circle3.h>

--- a/src/plugins_3rdparty/ball/src/source/MATHS/common.cpp
+++ b/src/plugins_3rdparty/ball/src/source/MATHS/common.cpp
@@ -3,4 +3,4 @@
 //
 // $Id: common.C,v 1.2 2005/12/23 17:02:42 amoll Exp $
 
-#include <BALL/MATHS/common.h>
+//#include <BALL/MATHS/common.h>

--- a/src/plugins_3rdparty/ball/src/source/MATHS/line3.cpp
+++ b/src/plugins_3rdparty/ball/src/source/MATHS/line3.cpp
@@ -3,4 +3,4 @@
 //
 // $Id: line3.C,v 1.2 2002/02/27 12:21:27 sturm Exp $
 
-#include <BALL/MATHS/line3.h>
+//#include <BALL/MATHS/line3.h>

--- a/src/plugins_3rdparty/ball/src/source/MATHS/matrix44.cpp
+++ b/src/plugins_3rdparty/ball/src/source/MATHS/matrix44.cpp
@@ -3,4 +3,4 @@
 //
 // $Id: matrix44.C,v 1.2 2002/02/27 12:21:27 sturm Exp $ 
 
-#include <BALL/MATHS/matrix44.h>
+//#include <BALL/MATHS/matrix44.h>

--- a/src/plugins_3rdparty/ball/src/source/MATHS/plane3.cpp
+++ b/src/plugins_3rdparty/ball/src/source/MATHS/plane3.cpp
@@ -3,4 +3,4 @@
 //
 // $Id: plane3.C,v 1.2 2002/02/27 12:21:28 sturm Exp $
 
-#include <BALL/MATHS/plane3.h>
+//#include <BALL/MATHS/plane3.h>

--- a/src/plugins_3rdparty/ball/src/source/MATHS/quaternion.cpp
+++ b/src/plugins_3rdparty/ball/src/source/MATHS/quaternion.cpp
@@ -3,6 +3,6 @@
 //
 // $Id: quaternion.C,v 1.2 2002-02-27 12:21:28 sturm Exp $
 
-#include <BALL/MATHS/quaternion.h>
+//#include <BALL/MATHS/quaternion.h>
 
 

--- a/src/plugins_3rdparty/ball/src/source/MATHS/simpleBox3.cpp
+++ b/src/plugins_3rdparty/ball/src/source/MATHS/simpleBox3.cpp
@@ -3,4 +3,4 @@
 //
 // $Id: simpleBox3.C,v 1.2 2003/08/19 16:34:51 amoll Exp $
 
-#include <BALL/MATHS/simpleBox3.h>
+//#include <BALL/MATHS/simpleBox3.h>

--- a/src/plugins_3rdparty/ball/src/source/MATHS/sphere3.cpp
+++ b/src/plugins_3rdparty/ball/src/source/MATHS/sphere3.cpp
@@ -3,4 +3,4 @@
 //
 // $Id: sphere3.C,v 1.2 2002/02/27 12:21:28 sturm Exp $
 
-#include <BALL/MATHS/sphere3.h>
+//#include <BALL/MATHS/sphere3.h>

--- a/src/plugins_3rdparty/ball/src/source/MATHS/surface.cpp
+++ b/src/plugins_3rdparty/ball/src/source/MATHS/surface.cpp
@@ -3,4 +3,4 @@
 //
 // $Id: surface.C,v 1.10 2002/02/27 12:21:28 sturm Exp $
 
-#include <BALL/MATHS/surface.h>
+//#include <BALL/MATHS/surface.h>

--- a/src/plugins_3rdparty/ball/src/source/MATHS/vector3.cpp
+++ b/src/plugins_3rdparty/ball/src/source/MATHS/vector3.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/ball/src/source/MATHS/vector4.cpp
+++ b/src/plugins_3rdparty/ball/src/source/MATHS/vector4.cpp
@@ -3,4 +3,4 @@
 //
 // $Id: vector4.C,v 1.2 2002/02/27 12:21:29 sturm Exp $
 
-#include <BALL/MATHS/vector4.h>
+//#include <BALL/MATHS/vector4.h>

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/RSEdge.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/RSEdge.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/RSFace.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/RSFace.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/RSVertex.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/RSVertex.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/SASEdge.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/SASEdge.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/SASFace.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/SASFace.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/SASVertex.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/SASVertex.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/SESEdge.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/SESEdge.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/SESFace.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/SESFace.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/SESVertex.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/SESVertex.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/graphEdge.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/graphEdge.cpp
@@ -2,4 +2,4 @@
 // vi: set ts=2:
 //
 
-#include <BALL/STRUCTURE/graphEdge.h>
+//#include <BALL/STRUCTURE/graphEdge.h>

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/graphFace.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/graphFace.cpp
@@ -2,4 +2,4 @@
 // vi: set ts=2:
 //
 
-#include <BALL/STRUCTURE/graphFace.h>
+//#include <BALL/STRUCTURE/graphFace.h>

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/graphVertex.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/graphVertex.cpp
@@ -2,4 +2,4 @@
 // vi: set ts=2:
 //
 
-#include <BALL/STRUCTURE/graphVertex.h>
+//#include <BALL/STRUCTURE/graphVertex.h>

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/reducedSurface.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/reducedSurface.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/solventAccessibleSurface.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/solventAccessibleSurface.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/solventExcludedSurface.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/solventExcludedSurface.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/triangle.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/triangle.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/triangleEdge.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/triangleEdge.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/trianglePoint.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/trianglePoint.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/triangulatedSAS.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/triangulatedSAS.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/triangulatedSES.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/triangulatedSES.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/ball/src/source/STRUCTURE/triangulatedSurface.cpp
+++ b/src/plugins_3rdparty/ball/src/source/STRUCTURE/triangulatedSurface.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 // -*- Mode: C++; tab-width: 2; -*-
 // vi: set ts=2:
 //

--- a/src/plugins_3rdparty/hmm2/src/hmmer2/masks.cpp
+++ b/src/plugins_3rdparty/hmm2/src/hmmer2/masks.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 /************************************************************
 * HMMER - Biological sequence analysis with profile HMMs
 * Copyright (C) 1992-2003 Washington University School of Medicine

--- a/src/plugins_3rdparty/hmm2/src/hmmer2/mathsupport.cpp
+++ b/src/plugins_3rdparty/hmm2/src/hmmer2/mathsupport.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 /************************************************************
 * HMMER - Biological sequence analysis with profile HMMs
 * Copyright (C) 1992-2003 Washington University School of Medicine

--- a/src/plugins_3rdparty/hmm2/src/hmmer2/modelmakers.cpp
+++ b/src/plugins_3rdparty/hmm2/src/hmmer2/modelmakers.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 /*****************************************************************
 * HMMER - Biological sequence analysis with profile HMMs
 * Copyright (C) 1992-2003 Washington University School of Medicine

--- a/src/plugins_3rdparty/hmm2/src/hmmer2/sre_string.cpp
+++ b/src/plugins_3rdparty/hmm2/src/hmmer2/sre_string.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 /*****************************************************************
 * HMMER - Biological sequence analysis with profile HMMs
 * Copyright (C) 1992-2003 Washington University School of Medicine

--- a/src/plugins_3rdparty/hmm2/src/hmmer2/trace.cpp
+++ b/src/plugins_3rdparty/hmm2/src/hmmer2/trace.cpp
@@ -1,3 +1,5 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
 /************************************************************
 * HMMER - Biological sequence analysis with profile HMMs
 * Copyright (C) 1992-2003 Washington University School of Medicine

--- a/src/plugins_3rdparty/hmm2/src/u_build/uhmmbuild.cpp
+++ b/src/plugins_3rdparty/hmm2/src/u_build/uhmmbuild.cpp
@@ -1,49 +1,43 @@
 #include "uhmmbuild.h"
-
 #include <hmmer2/funcs.h>
-
-#include <U2Core/Task.h>
 
 #include <QByteArray>
 #include <QVector>
-#include <QFile>
 
+#include <U2Core/Task.h>
 
 namespace U2 {
 
-static void maximum_entropy(struct alphabet_s* al, struct plan7_s *hmm, unsigned char **dsq, MSA *msa, float eff_nseq, struct p7prior_s *prior, struct p7trace_s **tr);
+static void maximum_entropy(struct alphabet_s *al, struct plan7_s *hmm, unsigned char **dsq, MSA *msa, float eff_nseq, struct p7prior_s *prior, struct p7trace_s **tr);
 
-// weighting strategy 
-enum p7_weight {      
-    WGT_NONE, 
-    WGT_GSC, 
-    WGT_BLOSUM, 
-    WGT_PB, 
-    WGT_VORONOI, 
+// weighting strategy
+enum p7_weight {
+    WGT_NONE,
+    WGT_GSC,
+    WGT_BLOSUM,
+    WGT_PB,
+    WGT_VORONOI,
     WGT_ME
 };
 
+plan7_s *UHMMBuild::build(msa_struct *msa, int atype, const UHMMBuildSettings &s, TaskStateInfo &si) {
+    p7_construction c_strategy = P7_MAP_CONSTRUCTION;    // construction strategy choice
+    p7_weight w_strategy = WGT_GSC;    // weighting strategy
+    float blosumlevel = 0.62;    // BLOSUM frac id filtering level [0.62]
+    float gapmax = 0.5;    // max frac gaps in mat col for -k
+    float archpri = 0.85;    // "architecture" prior on model size
+    float swentry = 0.5;    // S/W aggregate entry probability
+    float swexit = 0.5;    // S/W aggregate exit probability
+    int do_eff = TRUE;    // TRUE to set an effective seq number
+    int pbswitch = 1000;    // nseq >= this, switchover to PB weights
+    p7trace_s **trace = NULL;    // fake tracebacks for aseq's
+    plan7_s *hmm = NULL;    //result
 
-plan7_s* UHMMBuild::build(msa_struct* msa, int atype, const UHMMBuildSettings& s, TaskStateInfo& si) {
+    //get HMMERTaskLocalData
+    HMMERTaskLocalData *tld = getHMMERTaskLocalData();
+    alphabet_s &al = tld->al;
 
-    
-    p7_construction c_strategy  = P7_MAP_CONSTRUCTION; // construction strategy choice
-    p7_weight w_strategy        = WGT_GSC;  // weighting strategy 
-    float blosumlevel       = 0.62;         // BLOSUM frac id filtering level [0.62]
-    float gapmax            = 0.5;          // max frac gaps in mat col for -k
-    float archpri           = 0.85;         // "architecture" prior on model size    
-    float swentry           = 0.5;          // S/W aggregate entry probability       
-    float swexit            = 0.5;          // S/W aggregate exit probability 
-    int   do_eff            = TRUE;         // TRUE to set an effective seq number   
-    int   pbswitch          = 1000;         // nseq >= this, switchover to PB weights
-    p7trace_s  **trace      = NULL;         // fake tracebacks for aseq's
-    plan7_s* hmm            = NULL;         //result
-    
-	//get HMMERTaskLocalData
-	HMMERTaskLocalData *tld = getHMMERTaskLocalData();
-	alphabet_s &al = tld->al;
-    
-	assert(atype == hmmAMINO || atype == hmmNUCLEIC);
+    assert(atype == hmmAMINO || atype == hmmNUCLEIC);
     SetAlphabet(atype);
 
     // Get alignment(s), build HMMs one at a time
@@ -51,42 +45,42 @@ plan7_s* UHMMBuild::build(msa_struct* msa, int atype, const UHMMBuildSettings& s
     // Do some initialization the first time through.
     // This code must be delayed until after we've seen the
     // first alignment, because we have to see the alphabet type first
-    
+
     //Set up Dirichlet priors
     p7prior_s *pri = P7DefaultPrior();
 
-    // Set up the null/random seq model 
-    float   randomseq[MAXABET];    // null sequence model
-    float   p1;                    // null sequence model p1 transition
+    // Set up the null/random seq model
+    float randomseq[MAXABET];    // null sequence model
+    float p1;    // null sequence model p1 transition
     P7DefaultNullModel(randomseq, &p1);
 
-    // Prepare unaligned digitized sequences for internal use 
-    unsigned char **dsq;  // digitized unaligned aseq's
+    // Prepare unaligned digitized sequences for internal use
+    unsigned char **dsq;    // digitized unaligned aseq's
     DigitizeAlignment(msa, &dsq);
 
     // In some respects we treat DNA more crudely for now;
     // for example, we can't do eff seq #, because it's
     // calibrated for protein.
 
-    if (al.Alphabet_type == hmmNUCLEIC)  {
-        do_eff = FALSE; 
+    if (al.Alphabet_type == hmmNUCLEIC) {
+        do_eff = FALSE;
     }
 
     // Determine "effective sequence number".
     // The BlosumWeights() routine is now an efficient O(N)
     // memory clustering algorithm that doesn't blow up on,
     // say, Pfam's GP120 alignment (13000+ sequences)
-    
-    float eff_nseq = (float) msa->nseq;
+
+    float eff_nseq = (float)msa->nseq;
     if (do_eff) {
         QVector<float> wgt(msa->nseq, 0);
         BlosumWeights(msa->aseq, msa->nseq, msa->alen, blosumlevel, wgt.data());
         eff_nseq = FSum(wgt.data(), msa->nseq);
     }
-    
+
     // Weight the sequences (optional),
-    
-    if (w_strategy == WGT_GSC || w_strategy == WGT_BLOSUM  || w_strategy == WGT_VORONOI || w_strategy == WGT_PB) {
+
+    if (w_strategy == WGT_GSC || w_strategy == WGT_BLOSUM || w_strategy == WGT_VORONOI || w_strategy == WGT_PB) {
         if (w_strategy != WGT_PB && msa->nseq >= pbswitch) {
             PositionBasedWeights(msa->aseq, msa->nseq, msa->alen, msa->wgt);
         } else if (w_strategy == WGT_GSC) {
@@ -95,14 +89,14 @@ plan7_s* UHMMBuild::build(msa_struct* msa, int atype, const UHMMBuildSettings& s
             BlosumWeights(msa->aseq, msa->nseq, msa->alen, blosumlevel, msa->wgt);
         } else if (w_strategy == WGT_PB) {
             PositionBasedWeights(msa->aseq, msa->nseq, msa->alen, msa->wgt);
-        } else if (w_strategy ==  WGT_VORONOI) {
-            VoronoiWeights(msa->aseq, msa->nseq, msa->alen, msa->wgt); 
+        } else if (w_strategy == WGT_VORONOI) {
+            VoronoiWeights(msa->aseq, msa->nseq, msa->alen, msa->wgt);
         }
     }
 
     //Set the effective sequence number (if do_eff is FALSE, eff_nseq was set to nseq).
-    
-    FNorm(msa->wgt,  msa->nseq);
+
+    FNorm(msa->wgt, msa->nseq);
     FScale(msa->wgt, msa->nseq, eff_nseq);
 
     // Build a model architecture.
@@ -113,7 +107,7 @@ plan7_s* UHMMBuild::build(msa_struct* msa, int atype, const UHMMBuildSettings& s
     // gap characters in the alignment, we have to calculate the
     // alignment checksum before we enter the algorithms.
 
-    int checksum = GCGMultchecksum(msa->aseq, msa->nseq); // checksum of the alignment
+    int checksum = GCGMultchecksum(msa->aseq, msa->nseq);    // checksum of the alignment
     if (c_strategy == P7_FAST_CONSTRUCTION) {
         P7Fastmodelmaker(msa, dsq, gapmax, &hmm, &trace);
     } else if (c_strategy == P7_HAND_CONSTRUCTION) {
@@ -123,7 +117,6 @@ plan7_s* UHMMBuild::build(msa_struct* msa, int atype, const UHMMBuildSettings& s
     }
     hmm->checksum = checksum;
     hmm->atype = atype;
-
 
     // Record the null model in the HMM;
     // add prior contributions in pseudocounts and renormalize.
@@ -138,11 +131,11 @@ plan7_s* UHMMBuild::build(msa_struct* msa, int atype, const UHMMBuildSettings& s
     // configure the model into hmmsw mode. Later we'll
     // configure the model according to how the user wants to
     // use it.
-    
+
     Plan7SWConfig(hmm, 0.5, 0.5);
 
     // Do model-dependent "weighting" strategies.
-    
+
     if (w_strategy == WGT_ME) {
         maximum_entropy(&al, hmm, dsq, msa, eff_nseq, pri, trace);
     }
@@ -154,34 +147,54 @@ plan7_s* UHMMBuild::build(msa_struct* msa, int atype, const UHMMBuildSettings& s
     }
     QByteArray nameArr = name.toLatin1();
     Plan7SetName(hmm, nameArr.constData());
-    
+
     // Transfer other information from the alignment to
     // the HMM. This typically only works for Stockholm or SELEX format
     //  alignments, so these things are conditional/optional.
 
-    if (msa->acc  != NULL) Plan7SetAccession(hmm,   msa->acc);
-    if (msa->desc != NULL) Plan7SetDescription(hmm, msa->desc);
+    if (msa->acc != NULL)
+        Plan7SetAccession(hmm, msa->acc);
+    if (msa->desc != NULL)
+        Plan7SetDescription(hmm, msa->desc);
 
-    if (msa->cutoff_is_set[MSA_CUTOFF_GA1] && msa->cutoff_is_set[MSA_CUTOFF_GA2])
-    { hmm->flags |= PLAN7_GA; hmm->ga1 = msa->cutoff[MSA_CUTOFF_GA1]; hmm->ga2 = msa->cutoff[MSA_CUTOFF_GA2]; }
-    if (msa->cutoff_is_set[MSA_CUTOFF_TC1] && msa->cutoff_is_set[MSA_CUTOFF_TC2])
-    { hmm->flags |= PLAN7_TC; hmm->tc1 = msa->cutoff[MSA_CUTOFF_TC1]; hmm->tc2 = msa->cutoff[MSA_CUTOFF_TC2]; }
-    if (msa->cutoff_is_set[MSA_CUTOFF_NC1] && msa->cutoff_is_set[MSA_CUTOFF_NC2])
-    { hmm->flags |= PLAN7_NC; hmm->nc1 = msa->cutoff[MSA_CUTOFF_NC1]; hmm->nc2 = msa->cutoff[MSA_CUTOFF_NC2]; }
+    if (msa->cutoff_is_set[MSA_CUTOFF_GA1] && msa->cutoff_is_set[MSA_CUTOFF_GA2]) {
+        hmm->flags |= PLAN7_GA;
+        hmm->ga1 = msa->cutoff[MSA_CUTOFF_GA1];
+        hmm->ga2 = msa->cutoff[MSA_CUTOFF_GA2];
+    }
+    if (msa->cutoff_is_set[MSA_CUTOFF_TC1] && msa->cutoff_is_set[MSA_CUTOFF_TC2]) {
+        hmm->flags |= PLAN7_TC;
+        hmm->tc1 = msa->cutoff[MSA_CUTOFF_TC1];
+        hmm->tc2 = msa->cutoff[MSA_CUTOFF_TC2];
+    }
+    if (msa->cutoff_is_set[MSA_CUTOFF_NC1] && msa->cutoff_is_set[MSA_CUTOFF_NC2]) {
+        hmm->flags |= PLAN7_NC;
+        hmm->nc1 = msa->cutoff[MSA_CUTOFF_NC1];
+        hmm->nc2 = msa->cutoff[MSA_CUTOFF_NC2];
+    }
 
     // Record some other miscellaneous information in the HMM,
     // like how/when we built it.
     Plan7SetCtime(hmm);
     hmm->nseq = msa->nseq;
 
-
     // Configure the model for chosen algorithm
     switch (s.strategy) {
-        case P7_BASE_CONFIG:  Plan7GlobalConfig(hmm);              break;
-        case P7_SW_CONFIG:    Plan7SWConfig(hmm, swentry, swexit); break;
-        case P7_LS_CONFIG:    Plan7LSConfig(hmm);                  break;
-        case P7_FS_CONFIG:    Plan7FSConfig(hmm, swentry, swexit); break;
-        default:              si.setError(  tr("bogus configuration choice") ); break;
+        case P7_BASE_CONFIG:
+            Plan7GlobalConfig(hmm);
+            break;
+        case P7_SW_CONFIG:
+            Plan7SWConfig(hmm, swentry, swexit);
+            break;
+        case P7_LS_CONFIG:
+            Plan7LSConfig(hmm);
+            break;
+        case P7_FS_CONFIG:
+            Plan7FSConfig(hmm, swentry, swexit);
+            break;
+        default:
+            si.setError(tr("bogus configuration choice"));
+            break;
     }
 
     // Clean up trace
@@ -189,26 +202,25 @@ plan7_s* UHMMBuild::build(msa_struct* msa, int atype, const UHMMBuildSettings& s
         P7FreeTrace(trace[idx]);
     }
     free(trace);
-    Free2DArray((void **) dsq, msa->nseq); 
+    Free2DArray((void **)dsq, msa->nseq);
 
     P7FreePrior(pri);
     return hmm;
 }
 
-
 // Function: position_average_score()
 // Date:     Wed Dec 31 09:36:35 1997 [StL]
-// 
+//
 // Purpose:  Calculate scores from tracebacks, keeping them
 //           in a position specific array. The final array
 //           is normalized position-specifically too, according
 //           to how many sequences contributed data to this
-//           position. Used for compensating for sequence 
-//           fragments in ME and MD score optimization. 
+//           position. Used for compensating for sequence
+//           fragments in ME and MD score optimization.
 //           Very much ad hoc.
-//           
+//
 //           Code related to (derived from) TraceScore().
-//           
+//
 // Args:     hmm       - HMM structure, scores valid
 //           dsq       - digitized unaligned sequences
 //           wgt       - weights on the sequences
@@ -216,32 +228,30 @@ plan7_s* UHMMBuild::build(msa_struct* msa, int atype, const UHMMBuildSettings& s
 //           tr        - array of nseq tracebacks that aligns each dsq to hmm
 //           pernode   - RETURN: [0]1..M array of position-specific avg scores
 //           ret_avg   - RETURN: overall average full-length, one-domain score
-//           
-// Return:   1 on success, 0 on failure.          
+//
+// Return:   1 on success, 0 on failure.
 //           pernode is MallocOrDie'ed [0]1..M by CALLER and filled here.
 
-static void position_average_score(struct plan7_s* hmm, unsigned char **dsq, float *wgt, int nseq, 
-struct p7trace_s **tr, float *pernode, float *ret_avg)
-{
+static void position_average_score(struct plan7_s *hmm, unsigned char **dsq, float *wgt, int nseq, struct p7trace_s **tr, float *pernode, float *ret_avg) {
     unsigned char sym;
-    int    pos;                   //position in seq
-    int    tpos;                  // position in trace/state sequence
-    float *counts;                //counts at each position
-    float  avg;                   // RETURN: average overall
-    int    k;                     // counter for model position
-    int    idx;                   // counter for sequence number
+//    int pos;    //position in seq
+    int tpos;    // position in trace/state sequence
+    float *counts;    //counts at each position
+    float avg;    // RETURN: average overall
+    int k;    // counter for model position
+    int idx;    // counter for sequence number
 
     // Allocations
-    counts = (float*)MallocOrDie ((hmm->M+1) * sizeof(float));
-    FSet(pernode, hmm->M+1, 0.);
-    FSet(counts,  hmm->M+1, 0.);
+    counts = (float *)MallocOrDie((hmm->M + 1) * sizeof(float));
+    FSet(pernode, hmm->M + 1, 0.);
+    FSet(counts, hmm->M + 1, 0.);
 
     // Loop over traces, accumulate weighted scores per position
     for (idx = 0; idx < nseq; idx++) {
         for (tpos = 0; tpos < tr[idx]->tlen; tpos++) {
-            pos = tr[idx]->pos[tpos];
+//            pos = tr[idx]->pos[tpos];
             sym = dsq[idx][tr[idx]->pos[tpos]];
-            k   = tr[idx]->nodeidx[tpos];
+            k = tr[idx]->nodeidx[tpos];
 
             // Counts: how many times did we use this model position 1..M?(weighted)
             if (tr[idx]->statetype[tpos] == STM || tr[idx]->statetype[tpos] == STD) {
@@ -251,18 +261,16 @@ struct p7trace_s **tr, float *pernode, float *ret_avg)
             // Emission scores.
             if (tr[idx]->statetype[tpos] == STM) {
                 pernode[k] += wgt[idx] * Scorify(hmm->msc[sym][k]);
-            } else if (tr[idx]->statetype[tpos] == STI)  {
+            } else if (tr[idx]->statetype[tpos] == STI) {
                 pernode[k] += wgt[idx] * Scorify(hmm->isc[sym][k]);
             }
 
             // Transition scores.
             if (tr[idx]->statetype[tpos] == STM ||
                 tr[idx]->statetype[tpos] == STD ||
-                tr[idx]->statetype[tpos] == STI)
-            {
-                pernode[k] += wgt[idx] * 
-                   Scorify(TransitionScoreLookup(hmm, tr[idx]->statetype[tpos], tr[idx]->nodeidx[tpos],
-                   tr[idx]->statetype[tpos+1],tr[idx]->nodeidx[tpos+1]));
+                tr[idx]->statetype[tpos] == STI) {
+                pernode[k] += wgt[idx] *
+                              Scorify(TransitionScoreLookup(hmm, tr[idx]->statetype[tpos], tr[idx]->nodeidx[tpos], tr[idx]->statetype[tpos + 1], tr[idx]->nodeidx[tpos + 1]));
             }
         }
     }
@@ -278,24 +286,21 @@ struct p7trace_s **tr, float *pernode, float *ret_avg)
     *ret_avg = avg;
 }
 
-
-
 // Function: frag_trace_score()
 // Date:     SRE, Wed Dec 31 10:03:47 1997 [StL]
-// 
+//
 // Purpose:  Allow MD/ME optimization to be used for alignments
 //           that include fragments and multihits -- estimate a full-length
 //           per-domain score.
-//          
 //
-//           
+//
+//
 // Return:   "corrected" score.
 
-static float frag_trace_score(struct plan7_s *hmm, unsigned char *dsq, struct p7trace_s *tr,  float *pernode, float expected)
-{
-    float sc;         // corrected score
+static float frag_trace_score(struct plan7_s *hmm, unsigned char *dsq, struct p7trace_s *tr, float *pernode, float expected) {
+    float sc;    // corrected score
     float fragexp;    // expected score for a trace like this
-    int   tpos;       // position in trace */
+    int tpos;    // position in trace */
 
     // get uncorrected score
     sc = P7TraceScore(hmm, dsq, tr);
@@ -309,18 +314,16 @@ static float frag_trace_score(struct plan7_s *hmm, unsigned char *dsq, struct p7
     }
 
     // correct for multihits
-    fragexp /= (float) TraceDomainNumber(tr);
+    fragexp /= (float)TraceDomainNumber(tr);
 
     // extrapolate to full-length, one-hit score
     sc = sc * expected / fragexp;
     return sc;
 }
 
-
-
 // Function: maximum_entropy()
 // Date:     SRE, Fri Jan  2 10:56:00 1998 [StL]
-// 
+//
 // Purpose:  Optimizes a model according to maximum entropy weighting.
 //           See Krogh and Mitchison (1995).
 //
@@ -328,57 +331,55 @@ static float frag_trace_score(struct plan7_s *hmm, unsigned char *dsq, struct p7
 //           maximum entropy. Same thing, though we refer to "ME"
 //           weights and models. The optimization is a steepest
 //           descents minimization of the relative entropy.]
-//           
+//
 //           Expects to be called shortly after a Maxmodelmaker()
 //           or Handmodelmaker(), so that both a new model architecture
 //           (with MAP parameters) and fake tracebacks are available.
-//           
+//
 //           Prints a summary of optimization progress to stdout.
-//           
+//
 // Args:     hmm     - model. allocated, set with initial MAP parameters.
 //           dsq     - dealigned digitized seqs the model is based on
 //           ainfo   - extra info for aseqs
 //           nseq    - number of aseqs
 //           eff_nseq- effective sequence number; weights normalize up to this.
 //           prior   - prior distributions for parameterizing model
-//           tr      - array of fake traces for each sequence        
-//           
+//           tr      - array of fake traces for each sequence
+//
 // Return:   (void)
 //           hmm changed to an ME HMM
-//           ainfo changed, contains ME weights          
+//           ainfo changed, contains ME weights
 
-static void maximum_entropy(struct alphabet_s* /*al*/, struct plan7_s *hmm, unsigned char **dsq, MSA *msa,
-                            float eff_nseq, struct p7prior_s *prior, struct p7trace_s **tr)
-{
-    float *wgt;                 // current best set of ME weights
-    float *new_wgt;             // new set of ME weights to try
-    float *sc;                  // log-odds score of each sequence
-    float *grad;                // gradient
-    float  epsilon;             // steepness of descent 
-    float  relative_entropy;    // current best relative entropy
-    float  new_entropy;         // relative entropy at new weights
-    float  last_new_entropy;    // last new_entropy we calc'ed 
-    float  use_epsilon;         // current epsilon value in use
-    int    idx;                 // counter over sequences
-    int    i1, i2;              // counters for iterations 
+static void maximum_entropy(struct alphabet_s * /*al*/, struct plan7_s *hmm, unsigned char **dsq, MSA *msa, float eff_nseq, struct p7prior_s *prior, struct p7trace_s **tr) {
+    float *wgt;    // current best set of ME weights
+    float *new_wgt;    // new set of ME weights to try
+    float *sc;    // log-odds score of each sequence
+    float *grad;    // gradient
+    float epsilon;    // steepness of descent
+    float relative_entropy;    // current best relative entropy
+    float new_entropy;    // relative entropy at new weights
+    float last_new_entropy;    // last new_entropy we calc'ed
+    float use_epsilon;    // current epsilon value in use
+    int idx;    // counter over sequences
+    int i1, i2;    // counters for iterations
 
-    float  converge_criterion;
-    float  minw, maxw;            // min, max weight               
-    int    posw, highw;           // number of positive weights     
-    float  mins, maxs, avgs;      // min, max, avg score            
-    float *pernode;               // expected score per node of HMM 
-    float  expscore;              // expected score of complete HMM 
-    int    max_iter;              // bulletproof against infinite loop bugs 
+    float converge_criterion;
+    float minw, maxw;    // min, max weight
+    int posw, highw;    // number of positive weights
+    float mins, maxs, avgs;    // min, max, avg score
+    float *pernode;    // expected score per node of HMM
+    float expscore;    // expected score of complete HMM
+    int max_iter;    // bulletproof against infinite loop bugs
 
-    epsilon  = 0.2;                // works fine
+    epsilon = 0.2;    // works fine
     max_iter = 666;
 
     // Allocations
-    sc      = (float*)MallocOrDie(sizeof(float) * msa->nseq);
-    wgt     = (float*)MallocOrDie (sizeof(float) * msa->nseq);
-    new_wgt = (float*)MallocOrDie (sizeof(float) * msa->nseq);
-    grad    = (float*)MallocOrDie (sizeof(float) * msa->nseq);
-    pernode = (float*)MallocOrDie (sizeof(float) * (hmm->M+1));
+    sc = (float *)MallocOrDie(sizeof(float) * msa->nseq);
+    wgt = (float *)MallocOrDie(sizeof(float) * msa->nseq);
+    new_wgt = (float *)MallocOrDie(sizeof(float) * msa->nseq);
+    grad = (float *)MallocOrDie(sizeof(float) * msa->nseq);
+    pernode = (float *)MallocOrDie(sizeof(float) * (hmm->M + 1));
 
     // Initialization. Start with all weights == 1.0.
     // Find relative entropy and gradient.
@@ -386,19 +387,17 @@ static void maximum_entropy(struct alphabet_s* /*al*/, struct plan7_s *hmm, unsi
     P7Logoddsify(hmm, TRUE);
 
     FSet(wgt, msa->nseq, 1.0);
-    position_average_score(hmm, dsq, wgt, msa->nseq, tr, pernode,&expscore);
-    for (idx = 0; idx < msa->nseq; idx++) 
+    position_average_score(hmm, dsq, wgt, msa->nseq, tr, pernode, &expscore);
+    for (idx = 0; idx < msa->nseq; idx++)
         sc[idx] = frag_trace_score(hmm, dsq[idx], tr[idx], pernode, expscore);
-    relative_entropy = FSum(sc, msa->nseq) / (float) msa->nseq;
+    relative_entropy = FSum(sc, msa->nseq) / (float)msa->nseq;
     for (idx = 0; idx < msa->nseq; idx++)
         grad[idx] = relative_entropy - sc[idx];
-
 
     // Steepest descents optimization;
     // iterate until relative entropy converges.
     i1 = 0;
-    while (++i1 < max_iter)
-    {
+    while (++i1 < max_iter) {
         // Gradient gives us a line of steepest descents.
         // (Roughly speaking, anyway. We actually have a constraint
         // that weights are nonnegative and normalized, and the
@@ -408,19 +407,20 @@ static void maximum_entropy(struct alphabet_s* /*al*/, struct plan7_s *hmm, unsi
         // move back along the line by half the distance and re-evaluate.
 
         use_epsilon = epsilon;
-        new_entropy = relative_entropy + 1.0;    /* just ensure new > old */
+        new_entropy = relative_entropy + 1.0; /* just ensure new > old */
 
-        i2 = 0; 
+        i2 = 0;
         while (new_entropy > relative_entropy && ++i2 < max_iter) {
             last_new_entropy = new_entropy;
 
             // find a new point in weight space */
             for (idx = 0; idx < msa->nseq; idx++) {
                 new_wgt[idx] = wgt[idx] + use_epsilon * grad[idx];
-                if (new_wgt[idx] < 0.) new_wgt[idx] = 0.0;
+                if (new_wgt[idx] < 0.)
+                    new_wgt[idx] = 0.0;
             }
             FNorm(new_wgt, msa->nseq);
-            FScale(new_wgt, msa->nseq, (float) msa->nseq);
+            FScale(new_wgt, msa->nseq, (float)msa->nseq);
 
             // Make new HMM using these weights
             ZeroPlan7(hmm);
@@ -429,32 +429,34 @@ static void maximum_entropy(struct alphabet_s* /*al*/, struct plan7_s *hmm, unsi
             }
             P7PriorifyHMM(hmm, prior);
 
-
             // Evaluate new point
             Plan7SWConfig(hmm, 0.5, 0.5);
             P7Logoddsify(hmm, TRUE);
             position_average_score(hmm, dsq, new_wgt, msa->nseq, tr, pernode, &expscore);
-            for (idx = 0; idx < msa->nseq; idx++)  {
+            for (idx = 0; idx < msa->nseq; idx++) {
                 sc[idx] = frag_trace_score(hmm, dsq[idx], tr[idx], pernode, expscore);
             }
-            new_entropy = FDot(sc, new_wgt, msa->nseq) / (float) msa->nseq;
+            new_entropy = FDot(sc, new_wgt, msa->nseq) / (float)msa->nseq;
 
             use_epsilon /= 2.0;
             // Failsafe: we're not converging. Set epsilon to zero,
             // do one more round.
-            if (use_epsilon < 1e-6) use_epsilon = 0.0; 
-            if (use_epsilon == 0.0) break;
+            if (use_epsilon < 1e-6)
+                use_epsilon = 0.0;
+            if (use_epsilon == 0.0)
+                break;
 
             // Failsafe: avoid infinite loops. Sometimes the
-            // new entropy converges without ever being better 
+            // new entropy converges without ever being better
             // than the previous point, probably as a result
             // of minor roundoff error
-            if (last_new_entropy == new_entropy) break;
+            if (last_new_entropy == new_entropy)
+                break;
         }
 
         // Evaluate convergence before accepting the new weights;
         // then, accept the new point and evaluate the gradient there.
-        converge_criterion = qAbs((relative_entropy-new_entropy)/relative_entropy);
+        converge_criterion = qAbs((relative_entropy - new_entropy) / relative_entropy);
         relative_entropy = new_entropy;
         FCopy(wgt, new_wgt, msa->nseq);
         for (idx = 0; idx < msa->nseq; idx++) {
@@ -467,20 +469,27 @@ static void maximum_entropy(struct alphabet_s* /*al*/, struct plan7_s *hmm, unsi
         posw = (wgt[0] > 0.0) ? 1 : 0;
         highw = (wgt[0] > 1.0) ? 1 : 0;
         for (idx = 1; idx < msa->nseq; idx++) {
-            if (sc[idx] < mins) mins = sc[idx];
-            if (sc[idx] > maxs) maxs = sc[idx];
-            if (wgt[idx] < minw) minw = wgt[idx];
-            if (wgt[idx] > maxw) maxw = wgt[idx];
-            if (wgt[idx] > 0.0)  posw++;
-            if (wgt[idx] > 1.0)  highw++;
+            if (sc[idx] < mins)
+                mins = sc[idx];
+            if (sc[idx] > maxs)
+                maxs = sc[idx];
+            if (wgt[idx] < minw)
+                minw = wgt[idx];
+            if (wgt[idx] > maxw)
+                maxw = wgt[idx];
+            if (wgt[idx] > 0.0)
+                posw++;
+            if (wgt[idx] > 1.0)
+                highw++;
             avgs += sc[idx];
         }
-        if (converge_criterion < 1e-5) break;
+        if (converge_criterion < 1e-5)
+            break;
     }
 
     // Renormalize weights to sum to eff_nseq, and save.
     FNorm(wgt, msa->nseq);
-    FScale(wgt, msa->nseq, (float) eff_nseq);
+    FScale(wgt, msa->nseq, (float)eff_nseq);
     FCopy(msa->wgt, wgt, msa->nseq);
     // Make final HMM using these adjusted weights */
     ZeroPlan7(hmm);
@@ -497,4 +506,4 @@ static void maximum_entropy(struct alphabet_s* /*al*/, struct plan7_s *hmm, unsi
     free(sc);
 }
 
-}//namespace
+}    // namespace U2

--- a/src/plugins_3rdparty/hmm2/src/u_search/uhmmsearch_sse.cpp
+++ b/src/plugins_3rdparty/hmm2/src/u_search/uhmmsearch_sse.cpp
@@ -216,13 +216,13 @@ inline int maxComponent( const __m128i& a ) {
     return max;
 }
 
-void p ( const char * name, __m128i arg ) {
-    printf( "%s: {%d, %d, %d, %d}\n", name,
-        at0(arg),
-        at1(arg),
-        at2(arg),
-        at3(arg) );
-}
+//void p ( const char * name, __m128i arg ) {
+//    printf( "%s: {%d, %d, %d, %d}\n", name,
+//        at0(arg),
+//        at1(arg),
+//        at2(arg),
+//        at3(arg) );
+//}
 
 
 float viterbiSSE( hmm_opt* hmm, const unsigned char * seq, int seqLength, int* mscoreC, int* mscoreP, int* iscoreC, int *iscoreP, int* dscoreC, int *dscoreP ){

--- a/src/plugins_3rdparty/kalign/src/kalign_tests/KalignTests.cpp
+++ b/src/plugins_3rdparty/kalign/src/kalign_tests/KalignTests.cpp
@@ -256,7 +256,6 @@ void GTest_Kalign_Load_Align_Compare::init(XMLTestFormat*, const QDomElement& el
 void GTest_Kalign_Load_Align_Compare::prepare() {
 
     KalignTaskSettings mSettings;
-    bool ok = false;
     QFileInfo inFile(env->getVar("COMMON_DATA_DIR")+"/"+inFileURL);
     if(!inFile.exists()) {
         stateInfo.setError(  QString("file not exist %1").arg(inFile.absoluteFilePath()) );
@@ -329,8 +328,6 @@ void GTest_Kalign_Load_Align_QScore::init(XMLTestFormat*, const QDomElement& el)
 }
 
 void GTest_Kalign_Load_Align_QScore::prepare() {
-
-    bool ok = false;
     QFileInfo inFile(env->getVar("COMMON_DATA_DIR")+"/"+inFileURL);
     if(!inFile.exists()) {
         stateInfo.setError(  QString("file not exist %1").arg(inFile.absoluteFilePath()) );

--- a/src/plugins_3rdparty/phylip/src/DistanceMatrix.cpp
+++ b/src/plugins_3rdparty/phylip/src/DistanceMatrix.cpp
@@ -20,20 +20,27 @@
  */
 
 #include "DistanceMatrix.h"
-#include "U2Core/global.h"
-#include <U2Core/DNAAlphabet.h>
 
 #include <QSharedData>
 
+#include "U2Core/global.h"
+
+#ifdef __GNUC__
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
 #include "dnadist.h"
 #include "protdist.h"
+#ifdef __GNUC__
+#    pragma GCC diagnostic pop
+#endif
 
-#include <iostream>
 #include <float.h>
+#include <iostream>
 
-namespace U2{
+namespace U2 {
 
-void DistanceMatrix::calculateOutOfAlignment( const MultipleSequenceAlignment& ma, const CreatePhyTreeSettings& settings ) {
+void DistanceMatrix::calculateOutOfAlignment(const MultipleSequenceAlignment &ma, const CreatePhyTreeSettings &settings) {
     try {
         malignment = &ma;
         int index = 0;
@@ -41,21 +48,21 @@ void DistanceMatrix::calculateOutOfAlignment( const MultipleSequenceAlignment& m
         this->size = size;
         printdata = false;
 
-        foreach(const MultipleSequenceAlignmentRow& r, ma->getMsaRows()) {
-            const QString& str = r->getName();
+        foreach (const MultipleSequenceAlignmentRow &r, ma->getMsaRows()) {
+            const QString &str = r->getName();
             index_map.insert(str, index);
             index++;
             unprocessed_taxa.append(str);
         }
-        if(!memoryLocker.tryAcquire(size*(sizeof(matrixrow) + sizeof(float)*size))) {
+        if (!memoryLocker.tryAcquire(size * (sizeof(matrixrow) + sizeof(float) * size))) {
             errorMessage = memoryLocker.getError();
             return;
         }
 
-        for(int i=0; i<size; i++){
+        for (int i = 0; i < size; i++) {
             matrixrow row;
 
-            for(int j=0; j<size; j++){
+            for (int j = 0; j < size; j++) {
                 row.append(0);
             }
 
@@ -64,7 +71,7 @@ void DistanceMatrix::calculateOutOfAlignment( const MultipleSequenceAlignment& m
         spp = ma->getNumRows();
         sites = ma->getLength();
         chars = sites;
-        nonodes = 2*sites - 1;
+        nonodes = 2 * sites - 1;
         DNAAlphabetType alphabetType = ma->getAlphabet()->getType();
 
         ibmpc = IBMCRT;
@@ -73,19 +80,18 @@ void DistanceMatrix::calculateOutOfAlignment( const MultipleSequenceAlignment& m
         datasets = 1;
         firstset = true;
 
-        if ((alphabetType == DNAAlphabet_RAW) || (alphabetType == DNAAlphabet_NUCL)){
-
+        if ((alphabetType == DNAAlphabet_RAW) || (alphabetType == DNAAlphabet_NUCL)) {
             setDNADistSettings(settings);
             doinit(memoryLocker);
-            if(memoryLocker.hasError()) {
+            if (memoryLocker.hasError()) {
                 errorMessage = memoryLocker.getError();
                 return;
-            } 
+            }
             //ttratio = ttratio0;
             inputoptions();
 
-            for (int k=0; k<spp; k++){
-                for(int j=0; j<sites; j++) {
+            for (int k = 0; k < spp; k++) {
+                for (int j = 0; j < sites; j++) {
                     y[k][j] = ma->getMsaRow(k)->charAt(j);
                 }
             }
@@ -93,20 +99,18 @@ void DistanceMatrix::calculateOutOfAlignment( const MultipleSequenceAlignment& m
             dnadist_makevalues();
             dnadist_empiricalfreqs();
 
-            getbasefreqs(freqa, freqc, freqg, freqt, &freqr, &freqy, &freqar, &freqcy,
-                &freqgr, &freqty, &ttratio, &xi, &xv, &fracchange, freqsfrom, printdata);
+            getbasefreqs(freqa, freqc, freqg, freqt, &freqr, &freqy, &freqar, &freqcy, &freqgr, &freqty, &ttratio, &xi, &xv, &fracchange, freqsfrom, printdata);
             makedists();
 
         } else {
-
             prot_doinit(settings, memoryLocker);
-            if(memoryLocker.hasError()) {
+            if (memoryLocker.hasError()) {
                 errorMessage = memoryLocker.getError();
                 return;
-            } 
+            }
             if (!(kimura || similarity))
                 code();
-            if (!(usejtt || usepmb || usepam ||  kimura || similarity)) {
+            if (!(usejtt || usepmb || usepam || kimura || similarity)) {
                 protdist_cats();
                 maketrans();
                 qreigen(prob, 20L);
@@ -129,8 +133,8 @@ void DistanceMatrix::calculateOutOfAlignment( const MultipleSequenceAlignment& m
             Phylip_Char charstate;
             aas aa = (aas)0;
 
-            for (int k=0; k<spp; k++){
-                for(int j=0; j<sites; j++){
+            for (int k = 0; k < spp; k++) {
+                for (int j = 0; j < sites; j++) {
                     charstate = ma->getMsaRow(k)->charAt(j);
                     switch (charstate) {
                         case 'A':
@@ -248,14 +252,14 @@ void DistanceMatrix::calculateOutOfAlignment( const MultipleSequenceAlignment& m
                 free(gnode[i]);
             }
         }
-        for (int i=0; i<spp; i++){
-            for(int j=0; j<spp; j++){
+        for (int i = 0; i < spp; i++) {
+            for (int j = 0; j < spp; j++) {
                 rawMatrix[i][j] = d[i][j];
             }
         }
-    } catch(const std::bad_alloc &) {
+    } catch (const std::bad_alloc &) {
         errorMessage = QString("Not enough memory to calculate distance matrix for alignment \"%1\"").arg(ma->getName());
-        if(NULL != gnode) {
+        if (NULL != gnode) {
             for (int i = 0; i < spp; i++) {
                 free(gnode[i]);
             }
@@ -268,21 +272,19 @@ DistanceMatrix::DistanceMatrix()
     : rawdata(NULL),
       size(),
       malignment(NULL),
-      treedata(NULL)
-{
-
+      treedata(NULL) {
 }
 
-DistanceMatrix::~DistanceMatrix(){
-    if(NULL != y) {
+DistanceMatrix::~DistanceMatrix() {
+    if (NULL != y) {
         for (int i = 0; i < spp; i++) {
-            free(y[i]); 
+            free(y[i]);
         }
         free(y);
         y = NULL;
     }
 
-    if(NULL != nodep) {
+    if (NULL != nodep) {
         for (int i = 0; i < spp; i++) {
             for (int j = 0; j < endsite; j++) {
                 free(nodep[i]->x[j]);
@@ -314,7 +316,7 @@ DistanceMatrix::~DistanceMatrix(){
     free(weightrat);
     weightrat = NULL;
 
-    if(NULL != d) {
+    if (NULL != d) {
         for (int i = 0; i < spp; i++) {
             free(d[i]);
         }
@@ -323,109 +325,106 @@ DistanceMatrix::~DistanceMatrix(){
     }
 }
 
-void DistanceMatrix::printPhyTree(){
+void DistanceMatrix::printPhyTree() {
     DistanceMatrix::printPhyTree(treedata);
-
 }
-void DistanceMatrix::calculateQMatrix(){
-    for(int i=0; i<size; i++){
+void DistanceMatrix::calculateQMatrix() {
+    for (int i = 0; i < size; i++) {
         matrixrow row;
 
-        for(int j=0; j<size; j++){
+        for (int j = 0; j < size; j++) {
             row.append(0);
         }
 
         qdata.append(row);
     }
 
-    for(int i=0; i<size; i++){
+    for (int i = 0; i < size; i++) {
         qdata[i].reserve(size);
-
     }
-    for(int i=0; i<size; i++){
-        for(int j=0; j<size; j++){
-            if(i==j){
+    for (int i = 0; i < size; i++) {
+        for (int j = 0; j < size; j++) {
+            if (i == j) {
                 qdata[i][j] = 0.0;
-            }else{
+            } else {
                 float dij = rawMatrix[i][j];
                 float ri = calculateRawDivergence(i);
                 float rj = calculateRawDivergence(j);
-                float q = dij - (ri + rj)/(size-2);
+                float q = dij - (ri + rj) / (size - 2);
                 qdata[i][j] = q;
             }
         }
     }
 }
 
-
-void DistanceMatrix::dumpRawData(matrix& m){
-    std::cout<<"Distance Matrix "<<std::endl;
-    for (int i=0; i< size; i++){
-        for(int j=0; j<size; j++){
+void DistanceMatrix::dumpRawData(matrix &m) {
+    std::cout << "Distance Matrix " << std::endl;
+    for (int i = 0; i < size; i++) {
+        for (int j = 0; j < size; j++) {
             float distance = m[i][j];
-            std::cout<<distance<<" ";
+            std::cout << distance << " ";
         }
-        std::cout<<std::endl;
+        std::cout << std::endl;
     }
 }
 
-void DistanceMatrix::dumpQData(){
-    std::cout<<"Q Matrix "<<std::endl;
-    for (int i=0; i< size; i++){
-        for(int j=0; j<size; j++){
+void DistanceMatrix::dumpQData() {
+    std::cout << "Q Matrix " << std::endl;
+    for (int i = 0; i < size; i++) {
+        for (int j = 0; j < size; j++) {
             float distance = qdata[i][j];
-            std::cout<<distance<<" ";
+            std::cout << distance << " ";
         }
-        std::cout<<std::endl;
+        std::cout << std::endl;
     }
 }
-QString DistanceMatrix::generateNodeName(QString name1, QString name2){
+QString DistanceMatrix::generateNodeName(QString name1, QString name2) {
     QString r = "___";
     r.append(name1);
     r = r.append("___");
     r = r.append(name2);
     return r;
 }
-void DistanceMatrix::switchName(PhyNode* node){
+void DistanceMatrix::switchName(PhyNode *node) {
     QString str = node->getName();
-    if(str.startsWith("ROOT")){
+    if (str.startsWith("ROOT")) {
         node->setName("");
     }
-    if(str.startsWith("___")){
+    if (str.startsWith("___")) {
         node->setName("");
     }
-    for(int i=0; i<node->branchCount(); i++){
+    for (int i = 0; i < node->branchCount(); i++) {
         node->setBranchesDistance(i, abs(node->getBranchesDistance(i)));
-        if(node->getBranchesDistance(i) != node->getBranchesDistance(i)){
+        if (node->getBranchesDistance(i) != node->getBranchesDistance(i)) {
             node->setBranchesDistance(i, 1.0);
         }
     }
 }
 
-void DistanceMatrix::addPairToTree(QPair<int, int>* location){
+void DistanceMatrix::addPairToTree(QPair<int, int> *location) {
     //        treedata->rootNode->dumpBranches();
     QString name1 = getTaxaName(location->first);
-    if(unprocessed_taxa.contains(name1)){
+    if (unprocessed_taxa.contains(name1)) {
         unprocessed_taxa.removeAll(name1);
     }
-    PhyNode* oldnode1 = getNodeByName(name1);
-    if(oldnode1==0){
+    PhyNode *oldnode1 = getNodeByName(name1);
+    if (oldnode1 == 0) {
         return;
     }
-    PhyNode* rootnode1 = oldnode1->getParentNode();
+    PhyNode *rootnode1 = oldnode1->getParentNode();
 
     treedata->removeBranch(rootnode1, oldnode1);
 
     //printPhyTree();
 
-    QString name2 = getTaxaName(location->second);   
-    if(unprocessed_taxa.contains(name2)){
+    QString name2 = getTaxaName(location->second);
+    if (unprocessed_taxa.contains(name2)) {
         unprocessed_taxa.removeAll(name2);
     }
-    PhyNode* oldnode2 = getNodeByName(name2);
-    PhyNode* rootnode2 = oldnode2->getParentNode();
+    PhyNode *oldnode2 = getNodeByName(name2);
+    PhyNode *rootnode2 = oldnode2->getParentNode();
     treedata->removeBranch(rootnode2, oldnode2);
-    if (oldnode1==oldnode2){
+    if (oldnode1 == oldnode2) {
         return;
     }
     //printPhyTree();
@@ -433,48 +432,45 @@ void DistanceMatrix::addPairToTree(QPair<int, int>* location){
     float distance1 = calculateRootDistance(location->first, location->second);
     float distance2 = calculateAdjacentDistance(location->first, location->second, distance1);
 
-    PhyNode* new_node = new PhyNode();
+    PhyNode *new_node = new PhyNode();
     QString new_name = generateNodeName(name1, name2);
     new_node->setName(new_name);
     treedata->addBranch(new_node, oldnode1, distance1);
-    if(!new_node->isConnected(oldnode2)){
+    if (!new_node->isConnected(oldnode2)) {
         treedata->addBranch(new_node, oldnode2, distance2);
     }
-    if(!rootnode1->isConnected(new_node)){
+    if (!rootnode1->isConnected(new_node)) {
         treedata->addBranch(rootnode1, new_node, 1);
     }
     //printPhyTree();
 
-    for(int j=0; j<this->size; j++){
+    for (int j = 0; j < this->size; j++) {
         middlematrix.append(rawMatrix[j]);
     }
     //dumpRawData();
     //        dumpRawData(middlematrix);
 
-    for(int j=0; j<size; j++){
+    for (int j = 0; j < size; j++) {
         rawMatrix[j].remove(location->first);
         rawMatrix[j].remove(location->second);
-
     }
     rawMatrix.remove(location->first);
     rawMatrix.remove(location->second);
-    this->size-=2;
+    this->size -= 2;
 
     //        dumpRawData(rawMatrix);
     QMap<QString, int> old_map;
     QList<QString> namelist = index_map.uniqueKeys();
-    for(int j = 0; j<index_map.size(); j++){
+    for (int j = 0; j < index_map.size(); j++) {
         int index = index_map[namelist[j]];
         old_map.insert(namelist[j], index);
     }
 
-
-
     QList<QString> names = index_map.uniqueKeys();
     index_map.clear();
-    for(int j =0; j<names.size(); j++){
+    for (int j = 0; j < names.size(); j++) {
         QString cur_name = names[j];
-        if(cur_name!=name1 && cur_name!=name2){
+        if (cur_name != name1 && cur_name != name2) {
             int index = getNewIndex(cur_name, *location, old_map);
             index_map.insert(cur_name, index);
         }
@@ -484,8 +480,8 @@ void DistanceMatrix::addPairToTree(QPair<int, int>* location){
     index_map.insert(new_name, index_map.size());
     //printIndex();
 
-    for(int j =0; j<size; j++){
-        QString name  = getTaxaName(j);
+    for (int j = 0; j < size; j++) {
+        QString name = getTaxaName(j);
         int old_index = old_map[name];
         float distance = calculateNewDistance(location, old_index);
         rawMatrix[j].append(distance);
@@ -494,13 +490,11 @@ void DistanceMatrix::addPairToTree(QPair<int, int>* location){
     this->size++;
 
     matrixrow row;
-    for(int j=0; j<size-1; j++){
-        float distance = rawMatrix[j][size-1];
+    for (int j = 0; j < size - 1; j++) {
+        float distance = rawMatrix[j][size - 1];
         row.append(distance);
-
     }
     row.append(0);
-
 
     rawMatrix.append(row);
     middlematrix.clear();
@@ -509,22 +503,22 @@ void DistanceMatrix::addPairToTree(QPair<int, int>* location){
     //treedata->rootNode->dumpBranches();
 }
 
-PhyNode *DistanceMatrix::getNodeByName(QString name){
+PhyNode *DistanceMatrix::getNodeByName(QString name) {
     visited_list.clear();
-    PhyNode* rootNode = treedata->getRootNode();
+    PhyNode *rootNode = treedata->getRootNode();
     return findNode(rootNode, name);
 }
 
-PhyNode* DistanceMatrix::findNode(PhyNode* startnode, QString name){
+PhyNode *DistanceMatrix::findNode(PhyNode *startnode, QString name) {
     visited_list.append(startnode->getName());
-    if(startnode->getName() == name){
+    if (startnode->getName() == name) {
         return startnode;
-    }else{
-        for (int i=0; i<startnode->branchCount(); i++) {
+    } else {
+        for (int i = 0; i < startnode->branchCount(); i++) {
             PhyBranch *branch = startnode->getBranch(i);
-            if(!visited_list.contains(branch->node2->getName())){
-                PhyNode* node2 = findNode(branch->node2, name);
-                if(node2!=0){
+            if (!visited_list.contains(branch->node2->getName())) {
+                PhyNode *node2 = findNode(branch->node2, name);
+                if (node2 != 0) {
                     return node2;
                 }
             }
@@ -533,179 +527,172 @@ PhyNode* DistanceMatrix::findNode(PhyNode* startnode, QString name){
     return 0;
 }
 
-float DistanceMatrix::calculateRootDistance(int i, int j){
-    //S(AU) =d(AB) / 2 + [r(A)-r(B)] / 2(N-2) = 1 
-    float distance = rawMatrix[i][j]/2;
+float DistanceMatrix::calculateRootDistance(int i, int j) {
+    //S(AU) =d(AB) / 2 + [r(A)-r(B)] / 2(N-2) = 1
+    float distance = rawMatrix[i][j] / 2;
 
     float num1 = calculateRawDivergence(i);
     float num2 = calculateRawDivergence(j);
 
-    float div = (num1 - num2)/(2*(size-2));
-    float result = distance+div;
+    float div = (num1 - num2) / (2 * (size - 2));
+    float result = distance + div;
     return result;
 }
 
-float DistanceMatrix::calculateAdjacentDistance(int i, int j, float rootDistance){
+float DistanceMatrix::calculateAdjacentDistance(int i, int j, float rootDistance) {
     float result = rawMatrix[i][j] - rootDistance;
     return result;
 }
 
-float DistanceMatrix::calculateNewDistance(QPair<int, int>* location, int current){
+float DistanceMatrix::calculateNewDistance(QPair<int, int> *location, int current) {
     float a = middlematrix[current][location->first];
     float b = middlematrix[current][location->second];
-    float c = middlematrix[location->first][location->second]/2; 
-    return a + b - c; 
+    float c = middlematrix[location->first][location->second] / 2;
+    return a + b - c;
 }
 
-float DistanceMatrix::calculateRawDivergence(int index){
+float DistanceMatrix::calculateRawDivergence(int index) {
     float divergence = 0;
-    for (int i=0; i<index; i++){
-        divergence+=rawMatrix[i][index];
+    for (int i = 0; i < index; i++) {
+        divergence += rawMatrix[i][index];
     }
-    for(int j=index; j<size; j++){
-        divergence+=rawMatrix[index][j];
+    for (int j = index; j < size; j++) {
+        divergence += rawMatrix[index][j];
     }
     return divergence;
 }
 
-QString DistanceMatrix::getTaxaName(int index){
+QString DistanceMatrix::getTaxaName(int index) {
     QMap<QString, int>::iterator i;
-    for (i = index_map.begin(); i != index_map.end(); ++i){
-        if(i.value()==index){
+    for (i = index_map.begin(); i != index_map.end(); ++i) {
+        if (i.value() == index) {
             return i.key();
         }
-
     }
     return " ";
 }
 
-void DistanceMatrix::printPhyTree(PhyTreeData* data){
+void DistanceMatrix::printPhyTree(PhyTreeData *data) {
     data->print();
 }
 
-void DistanceMatrix::printPhyNode(PhyNode* node, int tab, QList<PhyNode*>& nodes){
-    if(node==0 || nodes.contains(node)){
+void DistanceMatrix::printPhyNode(PhyNode *node, int tab, QList<PhyNode *> &nodes) {
+    if (node == 0 || nodes.contains(node)) {
         return;
     }
     nodes.append(node);
-    for(int i=0; i<tab; i++){
-        std::cout<<" ";
+    for (int i = 0; i < tab; i++) {
+        std::cout << " ";
     }
     tab++;
-    std::cout<<"name: "<<node->getName().toLatin1().constData()<<std::endl;
-    for (int i=0; i<node->branchCount(); i++) {
+    std::cout << "name: " << node->getName().toLatin1().constData() << std::endl;
+    for (int i = 0; i < node->branchCount(); i++) {
         PhyBranch *branch = node->getBranch(i);
         printPhyNode(branch->node2, tab, nodes);
     }
 }
-bool DistanceMatrix::areTreesEqual(PhyTree* tree1, PhyTree* tree2){
+bool DistanceMatrix::areTreesEqual(PhyTree *tree1, PhyTree *tree2) {
     QMap<QString, int> nodes1;
     QMap<QString, int> nodes2;
 
-    QList<PhyNode* > list1;
-    QList<PhyNode* > list2;
+    QList<PhyNode *> list1;
+    QList<PhyNode *> list2;
 
-    QList<PhyBranch* > branches1;
-    QList<PhyBranch* > branches2;
+    QList<PhyBranch *> branches1;
+    QList<PhyBranch *> branches2;
 
     addNodeToList(list1, nodes1, branches1, tree1->data()->getRootNode());
     addNodeToList(list2, nodes2, branches2, tree2->data()->getRootNode());
 
     QList<QString> keys1 = nodes1.keys();
 
-    if(nodes1.count()!=nodes2.count())
+    if (nodes1.count() != nodes2.count())
         return false;
 
-    for(int i=0; i<keys1.size(); i++){
+    for (int i = 0; i < keys1.size(); i++) {
         QString name = keys1[i];
         //int d1 = nodes1[name];
-        if(!nodes2.contains(name)){
+        if (!nodes2.contains(name)) {
             return false;
         }
 
-        if(!nodes2.contains(name)){
+        if (!nodes2.contains(name)) {
             return false;
         }
         /*int d2 = nodes2[name];
         if(d1!=d2){
         return false;
         }*/
-
     }
 
     return true;
 }
 
-void DistanceMatrix::addNodeToList(QList<PhyNode*>& nodelist, QMap<QString, int>& nodemap, QList<PhyBranch*>& branches,  PhyNode* node){
-    if ((node==0) ||(nodelist.contains(node))){
+void DistanceMatrix::addNodeToList(QList<PhyNode *> &nodelist, QMap<QString, int> &nodemap, QList<PhyBranch *> &branches, PhyNode *node) {
+    if ((node == 0) || (nodelist.contains(node))) {
         return;
-    }else{
+    } else {
         nodelist.append(node);
-        if(node->getName()!="ROOT" && node->getName()!="" && !node->getName().startsWith("___")){
-            for (int i=0; i<node->branchCount(); i++) {
+        if (node->getName() != "ROOT" && node->getName() != "" && !node->getName().startsWith("___")) {
+            for (int i = 0; i < node->branchCount(); i++) {
                 PhyBranch *branch = node->getBranch(i);
-                if(branch->node2 == node){
+                if (branch->node2 == node) {
                     int d = branch->distance;
                     nodemap.insert(node->getName(), d);
                 }
             }
         }
-        for (int i=0; i<node->branchCount(); i++) {
+        for (int i = 0; i < node->branchCount(); i++) {
             PhyBranch *branch = node->getBranch(i);
-            if(!branches.contains(branch)){
+            if (!branches.contains(branch)) {
                 branches.append(branch);
                 addNodeToList(nodelist, nodemap, branches, branch->node2);
             }
         }
     }
-
 }
 
-void DistanceMatrix::switchNamesToAllNodes(){
-    QList<PhyNode* > nodes;
-    QList<PhyBranch* > branches;
-    QMap <QString, int> mmap;
-    addNodeToList(nodes,mmap, branches, treedata->getRootNode());
+void DistanceMatrix::switchNamesToAllNodes() {
+    QList<PhyNode *> nodes;
+    QList<PhyBranch *> branches;
+    QMap<QString, int> mmap;
+    addNodeToList(nodes, mmap, branches, treedata->getRootNode());
     int size = nodes.size();
 
-    for(int i=0; i<size; i++){
+    for (int i = 0; i < size; i++) {
         switchName(nodes[i]);
     }
 }
 
-
-int DistanceMatrix::getNewIndex(QString name, QPair<int, int> loc, QMap<QString, int>& old_map){
+int DistanceMatrix::getNewIndex(QString name, QPair<int, int> loc, QMap<QString, int> &old_map) {
     int old_index = old_map[name];
-    if(old_index > loc.first && old_index > loc.second){
-        int new_index = old_index-2;
+    if (old_index > loc.first && old_index > loc.second) {
+        int new_index = old_index - 2;
         return new_index;
-    }else if(old_index > loc.first || old_index>loc.second){
-        int new_index = old_index-1;
+    } else if (old_index > loc.first || old_index > loc.second) {
+        int new_index = old_index - 1;
         return new_index;
     }
     return old_index;
 }
-void DistanceMatrix::printIndex(){
-
-    for(int i=0; i<index_map.size(); i++){
+void DistanceMatrix::printIndex() {
+    for (int i = 0; i < index_map.size(); i++) {
         QList<QString> names = index_map.keys(i);
-        std::cout<<"Value :"<<i<<" Keys:";
-        for(int j=0; j<names.size(); j++){
-            std::cout<<" "<<names[j].toLatin1().constData();
+        std::cout << "Value :" << i << " Keys:";
+        for (int j = 0; j < names.size(); j++) {
+            std::cout << " " << names[j].toLatin1().constData();
         }
-        std::cout<<std::endl;
+        std::cout << std::endl;
     }
-    std::cout<<std::endl;
-
+    std::cout << std::endl;
 }
-void DistanceMatrix::dumpRawData(){
+void DistanceMatrix::dumpRawData() {
     dumpRawData(rawMatrix);
 }
 
-inline bool isFiniteNumber(double x) 
-{
-    return (x <= DBL_MAX && x >= -DBL_MAX); 
-}    
+inline bool isFiniteNumber(double x) {
+    return (x <= DBL_MAX && x >= -DBL_MAX);
+}
 
 bool DistanceMatrix::isValid() {
     int sz = rawMatrix.count();
@@ -724,11 +711,10 @@ bool DistanceMatrix::isValid() {
             if (value == 0) {
                 ++zeroCounter;
             }
-
         }
     }
 
-    if (zeroCounter == sz*sz) {
+    if (zeroCounter == sz * sz) {
         // All numbers are zeroes!
         return false;
     }
@@ -736,4 +722,4 @@ bool DistanceMatrix::isValid() {
     return true;
 }
 
-} //namespace
+}    // namespace U2

--- a/src/plugins_3rdparty/phylip/src/NeighborJoinWidget.cpp
+++ b/src/plugins_3rdparty/phylip/src/NeighborJoinWidget.cpp
@@ -19,6 +19,8 @@
 * MA 02110-1301, USA.
 */
 
+#include "NeighborJoinWidget.h"
+
 #include <U2Core/AppContext.h>
 #include <U2Core/AppResources.h>
 #include <U2Core/AppSettings.h>
@@ -26,9 +28,15 @@
 #include <U2Core/MultipleSequenceAlignment.h>
 #include <U2Core/Settings.h>
 
-#include "NeighborJoinWidget.h"
+#ifdef __GNUC__
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
 #include "dnadist.h"
 #include "protdist.h"
+#ifdef __GNUC__
+#    pragma GCC diagnostic pop
+#endif
 
 namespace U2 {
 
@@ -62,9 +70,8 @@ QList<QString> ConsensusModelTypes::getConsensusModelTypes() {
     return list;
 }
 
-NeighborJoinWidget::NeighborJoinWidget(const MultipleSequenceAlignment &ma, QWidget *parent) :
-    CreatePhyTreeWidget(parent)
-{
+NeighborJoinWidget::NeighborJoinWidget(const MultipleSequenceAlignment &ma, QWidget *parent)
+    : CreatePhyTreeWidget(parent) {
     setupUi(this);
     init(ma);
     connectSignals();
@@ -128,11 +135,11 @@ bool NeighborJoinWidget::checkMemoryEstimation(QString &msg, const MultipleSeque
 
     //****description******
     //dnadist_makevalues()
-//     for (i = 0; i < spp; i++) {
-//         nodep[i]->x = (phenotype)Malloc(endsite*sizeof(ratelike));
-//         for (j = 0; j < endsite; j++)
-//             nodep[i]->x[j]  = (ratelike)Malloc(rcategs*sizeof(sitelike));
-//     }
+    //     for (i = 0; i < spp; i++) {
+    //         nodep[i]->x = (phenotype)Malloc(endsite*sizeof(ratelike));
+    //         for (j = 0; j < endsite; j++)
+    //             nodep[i]->x[j]  = (ratelike)Malloc(rcategs*sizeof(sitelike));
+    //     }
 
     //rcategs = 1
     //sizeof(sitelike) = 32
@@ -145,8 +152,9 @@ bool NeighborJoinWidget::checkMemoryEstimation(QString &msg, const MultipleSeque
 
     if (minMemoryForDistanceMatrixMb > appMemMb - ugeneLowestMemoryUsageMb) {
         msg = tr("Probably, for that alignment there is no enough memory to run PHYLIP dnadist module."
-            "The module will require more than %1 MB in the estimation."
-            "\nIt could cause an error. Do you want to continue?").arg(minMemoryForDistanceMatrixMb);
+                 "The module will require more than %1 MB in the estimation."
+                 "\nIt could cause an error. Do you want to continue?")
+                  .arg(minMemoryForDistanceMatrixMb);
         return false;
     } else {
         return displayOptions->checkMemoryEstimation(msg, msa, settings);
@@ -154,7 +162,7 @@ bool NeighborJoinWidget::checkMemoryEstimation(QString &msg, const MultipleSeque
 }
 
 bool NeighborJoinWidget::checkSettings(QString &msg, const CreatePhyTreeSettings &settings) {
-    if (!((settings.seed >= SEED_MIN) && (settings.seed <= SEED_MAX) && (settings.seed%2 == 1))) {
+    if (!((settings.seed >= SEED_MIN) && (settings.seed <= SEED_MAX) && (settings.seed % 2 == 1))) {
         msg = tr("Seed must be odd");
         return false;
     }
@@ -222,7 +230,7 @@ void NeighborJoinWidget::connectSignals() {
 
 int NeighborJoinWidget::getRandomSeed() {
     int seed = 0;
-    qsrand(QTime(0,0,0).secsTo(QTime::currentTime()));
+    qsrand(QTime(0, 0, 0).secsTo(QTime::currentTime()));
     seed = qAbs(qrand());
 
     while (!checkSeed(seed)) {
@@ -239,4 +247,4 @@ bool NeighborJoinWidget::checkSeed(int seed) {
     return (seed >= SEED_MIN) && (seed <= SEED_MAX) && ((seed - 1) % 4 == 0);
 }
 
-}   // namespace U2
+}    // namespace U2

--- a/src/plugins_3rdparty/phylip/src/SeqBootAdapter.h
+++ b/src/plugins_3rdparty/phylip/src/SeqBootAdapter.h
@@ -18,8 +18,16 @@
 * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 * MA 02110-1301, USA.
 */
+#ifdef __GNUC__
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
 #include "seqboot.h"
 #include "cons.h"
+#ifdef __GNUC__
+#    pragma GCC diagnostic pop
+#endif
+
 
 #include <U2Core/MultipleSequenceAlignment.h>
 #include <U2Core/PhyTree.h>

--- a/src/plugins_3rdparty/phylip/src/dnadist.cpp
+++ b/src/plugins_3rdparty/phylip/src/dnadist.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 //#include "phylip.h"
 //#include "seq.h"
 #include "dnadist.h"

--- a/src/plugins_3rdparty/phylip/src/neighbor.cpp
+++ b/src/plugins_3rdparty/phylip/src/neighbor.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 /* version 3.696.
 Written by Mary Kuhner, Jon Yamato, Joseph Felsenstein, Akiko Fuseki,
 Sean Lamont, and Andrew Keeffe.

--- a/src/plugins_3rdparty/phylip/src/protdist.cpp
+++ b/src/plugins_3rdparty/phylip/src/protdist.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "phylip.h"
 #include "seq.h"
 #include "protdist.h"

--- a/src/plugins_3rdparty/phylip/src/seqboot.cpp
+++ b/src/plugins_3rdparty/phylip/src/seqboot.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 /* version 3.696.
 Written by Joseph Felsenstein, Akiko Fuseki, Sean Lamont, and Andrew Keeffe.
 

--- a/src/plugins_3rdparty/primer3/src/primer3_core/oligotm.c
+++ b/src/plugins_3rdparty/primer3/src/primer3_core/oligotm.c
@@ -86,7 +86,7 @@ All rights reserved.
  */
 
 /* Table 1 (old parameters):
- * See table 2 in the paper [Breslauer KJ, Frank R, Bl�cker H and
+ * See table 2 in the paper [Breslauer KJ, Frank R, Blöcker H and
  * Marky LA (1986) "Predicting DNA duplex stability from the base
  * sequence" Proc Natl Acad Sci 83:4746-50
  * http://dx.doi.org/10.1073/pnas.83.11.3746]

--- a/src/plugins_3rdparty/primer3/src/primer3_core/oligotm.c
+++ b/src/plugins_3rdparty/primer3/src/primer3_core/oligotm.c
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 /*
 Copyright (c) 1996,1997,1998,1999,2000,2001,2004,2006,2007
 Whitehead Institute for Biomedical Research, Steve Rozen
@@ -83,7 +86,7 @@ All rights reserved.
  */
 
 /* Table 1 (old parameters):
- * See table 2 in the paper [Breslauer KJ, Frank R, Blöcker H and
+ * See table 2 in the paper [Breslauer KJ, Frank R, Blï¿½cker H and
  * Marky LA (1986) "Predicting DNA duplex stability from the base
  * sequence" Proc Natl Acad Sci 83:4746-50
  * http://dx.doi.org/10.1073/pnas.83.11.3746]

--- a/src/plugins_3rdparty/umuscle/src/muscle/blosumla.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/blosumla.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 
 #define GAPVAL		0.3

--- a/src/plugins_3rdparty/umuscle/src/muscle/estring.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/estring.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "pwpath.h"
 #include "estring.h"

--- a/src/plugins_3rdparty/umuscle/src/muscle/fastdistmafft.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/fastdistmafft.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "distfunc.h"
 #include "seqvect.h"

--- a/src/plugins_3rdparty/umuscle/src/muscle/finddiags.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/finddiags.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "profile.h"
 #include "diaglist.h"

--- a/src/plugins_3rdparty/umuscle/src/muscle/finddiagsn.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/finddiagsn.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "profile.h"
 #include "diaglist.h"

--- a/src/plugins_3rdparty/umuscle/src/muscle/gonnet.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/gonnet.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "gonnet.h"
 

--- a/src/plugins_3rdparty/umuscle/src/muscle/objscore2.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/objscore2.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "msa.h"
 #include "profile.h"

--- a/src/plugins_3rdparty/umuscle/src/muscle/pam200mafft.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/pam200mafft.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 
 // Adjusted PAM200 scoring matrix as used by default in MAFFT.

--- a/src/plugins_3rdparty/umuscle/src/muscle/phy3.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/phy3.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "tree.h"
 #include "edgelist.h"

--- a/src/plugins_3rdparty/umuscle/src/muscle/progress.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/progress.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include <stdio.h>
 #include <time.h>

--- a/src/plugins_3rdparty/umuscle/src/muscle/scorepp.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/scorepp.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "profile.h"
 #include "muscle_context.h"

--- a/src/plugins_3rdparty/umuscle/src/refinehorizP.cpp
+++ b/src/plugins_3rdparty/umuscle/src/refinehorizP.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 /**
  * UGENE - Integrated Bioinformatics Tools.
  * Copyright (C) 2008-2021 UniPro <ugene@unipro.ru>
@@ -178,7 +181,7 @@ namespace U2 {
             
             unsigned i = workpool->refineGetJob(&msaIn, workerID);
 
-            MuscleContext *ctx = workpool->ctx;
+//            MuscleContext *ctx = workpool->ctx;
 //            unsigned &g_uTreeSplitNode1 = ctx->muscle.g_uTreeSplitNode1;
 //            unsigned &g_uTreeSplitNode2 = ctx->muscle.g_uTreeSplitNode2;
 //            unsigned &g_uRefineHeightSubtree = ctx->refinehoriz.g_uRefineHeightSubtree;

--- a/src/ugene_globals.pri
+++ b/src/ugene_globals.pri
@@ -63,7 +63,6 @@ linux-g++ {
     QMAKE_CXXFLAGS += -Wno-ignored-attributes
     QMAKE_CXXFLAGS += -Wno-implicit-fallthrough
     QMAKE_CXXFLAGS += -Wno-sign-compare
-    QMAKE_CXXFLAGS += -Wno-unused-variable
 
     # QT 5.4 sources produce this warning when compiled with gcc9. Re-check after QT upgrade.
     QMAKE_CXXFLAGS += -Wno-cast-function-type

--- a/src/ugene_version.pri
+++ b/src/ugene_version.pri
@@ -14,7 +14,7 @@ U2_DISTRIBUTION_INFO=sources
 # int version levels for executables
 UGENE_VER_MAJOR=39
 UGENE_VER_MINOR=0
-UGENE_VER_SUFFIX=-div
+UGENE_VER_SUFFIX=-dev
 
 # product version
 UGENE_VERSION=$${UGENE_VER_MAJOR}.$${UGENE_VER_MINOR}$${UGENE_VER_SUFFIX}


### PR DESCRIPTION
The logic behind the warnings enabling/suppression
1) Is it UGENE code? Enable the warning, fix issues (if any). Reformat the file if needed.
2) Is it a 3rd party code? Disable all warnings. Do not reformat to keep diffs with the original tool simple.