### PR TITLE
UGENE-7141. Remove trivial GCC warnings suppression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,13 +48,7 @@ if (CMAKE_COMPILER_IS_GNUCXX)
             " -Werror=return-type"
             " -Werror=uninitialized"
             " -Werror=unused-parameter"
-            " -Wno-catch-value"
-            " -Wno-class-memaccess"
-            " -Wno-deprecated-copy"
-            " -Wno-expansion-to-defined"
-            " -Wno-ignored-attributes"
-            " -Wno-implicit-fallthrough"
-            " -Wno-sign-compare"
+            " -Werror=unused-variable"
             )
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_WARNING_FLAGS}")
 endif ()

--- a/src/corelibs/U2Algorithm/U2Algorithm.pri
+++ b/src/corelibs/U2Algorithm/U2Algorithm.pri
@@ -9,8 +9,6 @@ use_opencl(){
 
 DEFINES+= QT_FATAL_ASSERT BUILDING_U2ALGORITHM_DLL
 
-unix: QMAKE_CXXFLAGS += -Wno-char-subscripts
-
 LIBS += -L../../$$out_dir()
 LIBS += -lU2Core$$D -lsamtools$$D
 LIBS += $$add_z_lib()

--- a/src/corelibs/U2Core/U2Core.pri
+++ b/src/corelibs/U2Core/U2Core.pri
@@ -13,8 +13,6 @@ LIBS += -L../../$$out_dir()
 
 DESTDIR = ../../$$out_dir()
 
-unix: QMAKE_CXXFLAGS += -Wno-char-subscripts
-
 # Special compiler flags for windows configuration
 win32 {
     LIBS += User32.lib

--- a/src/corelibs/U2Core/src/datatype/msa/MultipleChromatogramAlignment.cpp
+++ b/src/corelibs/U2Core/src/datatype/msa/MultipleChromatogramAlignment.cpp
@@ -604,7 +604,7 @@ MultipleChromatogramAlignment MultipleChromatogramAlignmentData::getExplicitCopy
 void MultipleChromatogramAlignmentData::copy(const MultipleAlignmentData &other) {
     try {
         copy(dynamic_cast<const MultipleChromatogramAlignmentData &>(other));
-    } catch (std::bad_cast) {
+    } catch (std::bad_cast &) {
         FAIL("Can't cast MultipleAlignmentData to MultipleChromatogramAlignmentData", );
     }
 }

--- a/src/corelibs/U2Core/src/datatype/msa/MultipleChromatogramAlignmentRow.cpp
+++ b/src/corelibs/U2Core/src/datatype/msa/MultipleChromatogramAlignmentRow.cpp
@@ -393,7 +393,7 @@ bool MultipleChromatogramAlignmentRowData::operator==(const MultipleChromatogram
 bool MultipleChromatogramAlignmentRowData::operator==(const MultipleAlignmentRowData &maRowData) const {
     try {
         return (*this == dynamic_cast<const MultipleChromatogramAlignmentRowData &>(maRowData));
-    } catch (std::bad_cast) {
+    } catch (std::bad_cast &) {
         FAIL("Can't cast MultipleAlignmentRowData to MultipleChromatogramAlignmentRowData", true);
     }
 }

--- a/src/corelibs/U2Core/src/datatype/msa/MultipleSequenceAlignment.cpp
+++ b/src/corelibs/U2Core/src/datatype/msa/MultipleSequenceAlignment.cpp
@@ -602,7 +602,7 @@ MultipleSequenceAlignment MultipleSequenceAlignmentData::getExplicitCopy() const
 void MultipleSequenceAlignmentData::copy(const MultipleAlignmentData &other) {
     try {
         copy(dynamic_cast<const MultipleSequenceAlignmentData &>(other));
-    } catch (std::bad_cast) {
+    } catch (std::bad_cast&) {
         FAIL("Can't cast MultipleAlignmentData to MultipleSequenceAlignmentData", );
     }
 }

--- a/src/corelibs/U2Core/src/datatype/msa/MultipleSequenceAlignmentRow.cpp
+++ b/src/corelibs/U2Core/src/datatype/msa/MultipleSequenceAlignmentRow.cpp
@@ -368,7 +368,7 @@ bool MultipleSequenceAlignmentRowData::operator==(const MultipleSequenceAlignmen
 bool MultipleSequenceAlignmentRowData::operator==(const MultipleAlignmentRowData &maRowData) const {
     try {
         return (*this == dynamic_cast<const MultipleSequenceAlignmentRowData &>(maRowData));
-    } catch (std::bad_cast) {
+    } catch (std::bad_cast&) {
         FAIL("Can't cast MultipleAlignmentRowData to MultipleSequenceAlignmentRowData", true);
     }
 }

--- a/src/corelibs/U2Core/src/globals/disable-warnings.h
+++ b/src/corelibs/U2Core/src/globals/disable-warnings.h
@@ -34,14 +34,21 @@
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wbool-compare"
 #    pragma GCC diagnostic ignored "-Wdeprecated"
+#    pragma GCC diagnostic ignored "-Wclass-memaccess"
 #    pragma GCC diagnostic ignored "-Wmisleading-indentation"
 #    pragma GCC diagnostic ignored "-Wpointer-compare"
+#    pragma GCC diagnostic ignored "-Wsign-compare"
 #    pragma GCC diagnostic ignored "-Wsizeof-pointer-memaccess"
 #    pragma GCC diagnostic ignored "-Wswitch"
 #    pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #    pragma GCC diagnostic ignored "-Wunused-function"
 #    pragma GCC diagnostic ignored "-Wunused-parameter"
 #    pragma GCC diagnostic ignored "-Wunused-variable"
+#
+#    ifndef __cplusplus    // The macros below are not valid in C++ context but are needed for plain C files.
+#        pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
+#        pragma GCC diagnostic ignored "-Wimplicit-int"
+#    endif
 #endif
 
 /**

--- a/src/corelibs/U2Core/src/tasks/LoadDocumentTask.cpp
+++ b/src/corelibs/U2Core/src/tasks/LoadDocumentTask.cpp
@@ -434,7 +434,7 @@ void LoadDocumentTask::run() {
         } else {
             resultDocument = format->loadDocument(iof, url, hints, stateInfo);
         }
-    } catch (std::bad_alloc) {
+    } catch (std::bad_alloc &) {
         resultDocument = NULL;
         setError(tr("Not enough memory to load document %1").arg(url.getURLString()));
     }

--- a/src/corelibs/U2View/U2View.pri
+++ b/src/corelibs/U2View/U2View.pri
@@ -7,8 +7,6 @@ DEFINES+= QT_FATAL_ASSERT BUILDING_U2VIEW_DLL
 LIBS += -L../../$$out_dir()
 LIBS += -lU2Core$$D -lU2Algorithm$$D -lU2Formats$$D -lU2Lang$$D -lU2Gui$$D
 
-unix: QMAKE_CXXFLAGS += -Wno-char-subscripts
-
 DESTDIR = ../../$$out_dir()
 
 unix {

--- a/src/libs_3rdparty/samtools/samtools.pri
+++ b/src/libs_3rdparty/samtools/samtools.pri
@@ -58,13 +58,3 @@ unix: {
         QMAKE_LFLAGS += "-Wl,-rpath,\'\$$ORIGIN\'"
     }
 }
-
-linux-g++ {
-    # Original samtools package has multiple warnings like this.
-    QMAKE_CXXFLAGS += -Wno-sign-compare
-}
-
-#unix {
-#    target.path = $$UGENE_INSTALL_DIR/
-#    INSTALLS += target
-#}

--- a/src/libs_3rdparty/samtools/src/samtools/bam_rmdup.c
+++ b/src/libs_3rdparty/samtools/src/samtools/bam_rmdup.c
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/src/libs_3rdparty/samtools/src/samtools/kseq.h
+++ b/src/libs_3rdparty/samtools/src/samtools/kseq.h
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 /* The MIT License
 
    Copyright (c) 2008, 2009, 2011 Attractive Chaos <attractor@live.co.uk>

--- a/src/plugins/CoreTests/src/BinaryFindOpenCLTests.h
+++ b/src/plugins/CoreTests/src/BinaryFindOpenCLTests.h
@@ -41,11 +41,11 @@ public:
     Task::ReportResult report();
 
 private:
-    QVector<NumberType> numbers;
-    QVector<NumberType> findNumbers;
+    QVector<int64_t> numbers;
+    QVector<int64_t> findNumbers;
     QVector<int> windowSizes;
-    QVector<NumberType> expectedResults;
-    NumberType *results;
+    QVector<int64_t> expectedResults;
+    int64_t *results;
 };
 
 class BinaryFindOpenCLTests {

--- a/src/plugins/smith_waterman/src/SmithWatermanAlgorithmSSE2.cpp
+++ b/src/plugins/smith_waterman/src/SmithWatermanAlgorithmSSE2.cpp
@@ -58,6 +58,11 @@ inline __m128i xmm_load8(__m64 *m) {
 
 using namespace std;
 
+#ifdef __GNUC__
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
+
 namespace U2 {
 
 quint64 SmithWatermanAlgorithmSSE2::estimateNeededRamAmount(const QByteArray
@@ -104,25 +109,25 @@ void SmithWatermanAlgorithmSSE2::launch(const SMatrix &_substitutionMatrix, cons
         if (minScore <= maxScore) {
             if (maxScore >= 0x8000 || matrixLength >= 0x10000) {
                 switch (resultView) {
-                case SmithWatermanSettings::MULTIPLE_ALIGNMENT:
-                    calculateMatrixForMultipleAlignmentResultWithInt();
-                    break;
-                case SmithWatermanSettings::ANNOTATIONS:
-                    calculateMatrixForAnnotationsResultWithInt();
-                    break;
-                default:
-                    assert(false);
+                    case SmithWatermanSettings::MULTIPLE_ALIGNMENT:
+                        calculateMatrixForMultipleAlignmentResultWithInt();
+                        break;
+                    case SmithWatermanSettings::ANNOTATIONS:
+                        calculateMatrixForAnnotationsResultWithInt();
+                        break;
+                    default:
+                        assert(false);
                 }
             } else {
                 switch (resultView) {
-                case SmithWatermanSettings::MULTIPLE_ALIGNMENT:
-                    calculateMatrixForMultipleAlignmentResultWithShort();
-                    break;
-                case SmithWatermanSettings::ANNOTATIONS:
-                    calculateMatrixForAnnotationsResultWithShort();
-                    break;
-                default:
-                    assert(false);
+                    case SmithWatermanSettings::MULTIPLE_ALIGNMENT:
+                        calculateMatrixForMultipleAlignmentResultWithShort();
+                        break;
+                    case SmithWatermanSettings::ANNOTATIONS:
+                        calculateMatrixForAnnotationsResultWithShort();
+                        break;
+                    default:
+                        assert(false);
                 }
             }
         }

--- a/src/plugins/weight_matrix/weight_matrix.pri
+++ b/src/plugins/weight_matrix/weight_matrix.pri
@@ -3,5 +3,3 @@ PLUGIN_NAME=Weight matrix
 PLUGIN_VENDOR=Unipro
 
 include( ../../ugene_plugin_common.pri )
-
-unix: QMAKE_CXXFLAGS += -Wno-char-subscripts

--- a/src/plugins_3rdparty/ball/src/SES.cpp
+++ b/src/plugins_3rdparty/ball/src/SES.cpp
@@ -26,6 +26,7 @@
 #ifdef __GNUC__
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wdeprecated"
+#    pragma GCC diagnostic ignored "-Wsign-compare"
 #endif
 #include <BALL/STRUCTURE/triangulatedSES.h>
 #ifdef __GNUC__

--- a/src/plugins_3rdparty/primer3/CMakeLists.txt
+++ b/src/plugins_3rdparty/primer3/CMakeLists.txt
@@ -1,3 +1,2 @@
 set(UGENE_PLUGIN_NAME primer3)
-set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wno-implicit-int -Wno-implicit-function-declaration")
 include(../../Plugin.cmake)

--- a/src/plugins_3rdparty/primer3/src/primer3_core/dpal.c
+++ b/src/plugins_3rdparty/primer3/src/primer3_core/dpal.c
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 /*
 Copyright (c) 1996,1997,1998,1999,2000,2001,2004,2006
 Whitehead Institute for Biomedical Research, Steve Rozen

--- a/src/plugins_3rdparty/primer3/src/primer3_core/primer3_main.c
+++ b/src/plugins_3rdparty/primer3/src/primer3_core/primer3_main.c
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 /*
 Copyright (c) 1996,1997,1998,1999,2000,2001,2004,2006
 Whitehead Institute for Biomedical Research, Steve Rozen

--- a/src/plugins_3rdparty/umuscle/CMakeLists.txt
+++ b/src/plugins_3rdparty/umuscle/CMakeLists.txt
@@ -1,6 +1,3 @@
 set(UGENE_PLUGIN_NAME umuscle)
 
-# TODO: this are the real UGENE bugs -> fix them
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-conversion-null")
-
 include(../../Plugin.cmake)

--- a/src/plugins_3rdparty/umuscle/src/muscle/muscle_context.cpp
+++ b/src/plugins_3rdparty/umuscle/src/muscle/muscle_context.cpp
@@ -1,3 +1,6 @@
+#include <U2Core/disable-warnings.h>
+U2_DISABLE_WARNINGS
+
 #include "muscle.h"
 #include "muscle_context.h"
 

--- a/src/ugene_globals.pri
+++ b/src/ugene_globals.pri
@@ -54,18 +54,17 @@ linux-g++ {
     # See https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
     QMAKE_CXXFLAGS += -Wall
 
-    # We have a lot of such warning from QT.
-    # Disable them now and recheck every time we increase the minimal supported version of QT.
-    QMAKE_CXXFLAGS += -Wno-catch-value
-    QMAKE_CXXFLAGS += -Wno-class-memaccess
-    QMAKE_CXXFLAGS += -Wno-deprecated-copy
-    QMAKE_CXXFLAGS += -Wno-expansion-to-defined
-    QMAKE_CXXFLAGS += -Wno-ignored-attributes
-    QMAKE_CXXFLAGS += -Wno-implicit-fallthrough
-    QMAKE_CXXFLAGS += -Wno-sign-compare
-
-    # QT 5.4 sources produce this warning when compiled with gcc9. Re-check after QT upgrade.
+    # QtScript produces this warning when qScriptRegisterMetadata is used. QT rejects to fix it: QtScript is deprecated.
+    # TODO: Wrap QtScript includes with the warning suppression and remove the global suppression.
     QMAKE_CXXFLAGS += -Wno-cast-function-type
+
+    # A few UGENE headers (like U2Location) emits thousands of deprecated warnings about deprecated copy.
+    # TODO: Fix UGENE code and remove the suppression.
+    QMAKE_CXXFLAGS += -Wno-deprecated-copy
+
+    # Some of UGENE code uses fallthrough in switch blocks.
+    # TODO: Fix and remove the suppression. Find the way to keep 'fallthrough' with no warnings when needed.
+    QMAKE_CXXFLAGS += -Wno-implicit-fallthrough
 
     # These warnings must be errors:
     QMAKE_CXXFLAGS += -Werror=maybe-uninitialized
@@ -73,6 +72,7 @@ linux-g++ {
     QMAKE_CXXFLAGS += -Werror=return-type
     QMAKE_CXXFLAGS += -Werror=uninitialized
     QMAKE_CXXFLAGS += -Werror=unused-parameter
+    QMAKE_CXXFLAGS += -Werror=unused-variable
 
     # build with coverage (gcov) support, now for Linux only
     equals(UGENE_GCOV_ENABLE, 1) {


### PR DESCRIPTION
The final goal is to remove suppression for all warnings, so UGENE will be warning free and our GCC-warning-check build  in the Teamcity can alert when new warnings are found.

The warnings that left after this PR require UGENE code modification and will be done in dedicated PRs.
