### PR TITLE
UGENE-7148. "Recent files" list has been cleaned after update

### DIFF
--- a/src/ugeneui/src/project_support/ProjectLoaderImpl.cpp
+++ b/src/ugeneui/src/project_support/ProjectLoaderImpl.cpp
@@ -692,13 +692,13 @@ QString ProjectLoaderImpl::getLastProjectURL() {
 void ProjectLoaderImpl::prependToRecentItems(const QString &url) {
     SAFE_POINT(!url.isEmpty(), "Invalid URL string!", );
     CHECK(GUrl(url).isLocalFile(), );
-    QStringList recentFiles = AppContext::getSettings()->getValue(SETTINGS_DIR + RECENT_ITEMS_SETTINGS_NAME, QStringList(), true).toStringList();
+    QStringList recentFiles = AppContext::getSettings()->getValue(SETTINGS_DIR + RECENT_ITEMS_SETTINGS_NAME).toStringList();
     recentFiles.removeAll(url);
     recentFiles.prepend(url);
     while (recentFiles.size() > MAX_RECENT_FILES) {
         recentFiles.pop_back();
     }
-    AppContext::getSettings()->setValue(SETTINGS_DIR + RECENT_ITEMS_SETTINGS_NAME, recentFiles, true);
+    AppContext::getSettings()->setValue(SETTINGS_DIR + RECENT_ITEMS_SETTINGS_NAME, recentFiles);
     emit si_recentListChanged();
 }
 
@@ -710,7 +710,7 @@ void ProjectLoaderImpl::sl_updateRecentItemsMenu() {
 void ProjectLoaderImpl::updateRecentItemsMenu() {
     assert(recentItemsMenu != NULL);
     recentItemsMenu->clear();
-    QStringList recentFiles = AppContext::getSettings()->getValue(SETTINGS_DIR + RECENT_ITEMS_SETTINGS_NAME, QStringList(), true).toStringList();
+    QStringList recentFiles = AppContext::getSettings()->getValue(SETTINGS_DIR + RECENT_ITEMS_SETTINGS_NAME).toStringList();
     recentItemsMenu->menuAction()->setEnabled(!recentFiles.isEmpty());
     Project *p = AppContext::getProject();
     foreach (QString f, recentFiles) {

--- a/src/ugeneui/src/welcome_page/WelcomePageMdiController.cpp
+++ b/src/ugeneui/src/welcome_page/WelcomePageMdiController.cpp
@@ -73,8 +73,8 @@ void WelcomePageMdiController::sl_onMdiClose(MWMDIWindow *mdi) {
 void WelcomePageMdiController::sl_onRecentChanged() {
     CHECK(welcomePage != nullptr, );
     auto settings = AppContext::getSettings();
-    QStringList recentProjects = settings->getValue(SETTINGS_DIR + RECENT_PROJECTS_SETTINGS_NAME, QStringList(), true).toStringList();
-    QStringList recentFiles = settings->getValue(SETTINGS_DIR + RECENT_ITEMS_SETTINGS_NAME, QStringList(), true).toStringList();
+    QStringList recentProjects = settings->getValue(SETTINGS_DIR + RECENT_PROJECTS_SETTINGS_NAME).toStringList();
+    QStringList recentFiles = settings->getValue(SETTINGS_DIR + RECENT_ITEMS_SETTINGS_NAME).toStringList();
     welcomePage->updateRecent(recentProjects, recentFiles);
 }
 


### PR DESCRIPTION
The fix will work only for the version after the current:

Unfortunately it is unsafe to treat all old versioned values (most of them are versioned for a good reason) as non-versioned. So UGENE will start writing versioned values starting from v39 and these values will be available only in releases after v39.

As a temporary (for 2-3 years) workaround we can consider hardcoding 'recent*' keys into SettingsImpl and return "the-latest-versioned-value" from settings in UGENE v39 and all later.
