### PR TITLE
UGENE-7176. Fix flaky  GUITest_regression_scenarios_test_2352

### DIFF
--- a/src/libs_3rdparty/QSpec/src/primitives/GTWidget.cpp
+++ b/src/libs_3rdparty/QSpec/src/primitives/GTWidget.cpp
@@ -69,7 +69,7 @@ void GTWidget::click(GUITestOpStatus &os, QWidget *widget, Qt::MouseButton mouse
 
 #define GT_METHOD_NAME "setFocus"
 void GTWidget::setFocus(GUITestOpStatus &os, QWidget *w) {
-    GT_CHECK(w != NULL, "widget is NULL");
+    GT_CHECK(w != nullptr, "widget is NULL");
 
 #ifdef Q_OS_MAC
     GTUtilsMac fakeClock;
@@ -93,7 +93,7 @@ void GTWidget::setFocus(GUITestOpStatus &os, QWidget *w) {
 #undef GT_METHOD_NAME
 
 #define GT_METHOD_NAME "findWidget"
-QWidget *GTWidget::findWidget(GUITestOpStatus &os, const QString &widgetName, QWidget const *const parentWidget, const GTGlobals::FindOptions &options) {
+QWidget *GTWidget::findWidget(GUITestOpStatus &os, const QString &widgetName, const QWidget *parentWidget, const GTGlobals::FindOptions &options) {
     QWidget *widget = nullptr;
     for (int time = 0; time < GT_OP_WAIT_MILLIS && widget == nullptr; time += GT_OP_CHECK_MILLIS) {
         GTGlobals::sleep(time > 0 ? GT_OP_CHECK_MILLIS : 0);
@@ -116,6 +116,27 @@ QWidget *GTWidget::findWidget(GUITestOpStatus &os, const QString &widgetName, QW
         GT_CHECK_RESULT(widget != nullptr, QString("Widget '%1' not found").arg(widgetName), NULL);
     }
     return widget;
+}
+#undef GT_METHOD_NAME
+
+#define GT_CLASS_NAME "GTWidget"
+#define GT_METHOD_NAME "findLineEdit"
+QLineEdit *GTWidget::findLineEdit(GUITestOpStatus &os, const QString &widgetName, const QWidget *parentWidget, const GTGlobals::FindOptions &options) {
+    return findExactWidget<QLineEdit *>(os, widgetName, parentWidget, options);
+}
+#undef GT_METHOD_NAME
+
+#define GT_CLASS_NAME "GTWidget"
+#define GT_METHOD_NAME "findCheckBox"
+QCheckBox *GTWidget::findCheckBox(GUITestOpStatus &os, const QString &widgetName, const QWidget *parentWidget, const GTGlobals::FindOptions &options) {
+    return findExactWidget<QCheckBox *>(os, widgetName, parentWidget, options);
+}
+#undef GT_METHOD_NAME
+
+#define GT_CLASS_NAME "GTWidget"
+#define GT_METHOD_NAME "findSpinBox"
+QSpinBox *GTWidget::findSpinBox(GUITestOpStatus &os, const QString &widgetName, const QWidget *parentWidget, const GTGlobals::FindOptions &options) {
+    return findExactWidget<QSpinBox *>(os, widgetName, parentWidget, options);
 }
 #undef GT_METHOD_NAME
 
@@ -476,7 +497,7 @@ void GTWidget::checkEnabled(GUITestOpStatus &os, QWidget *widget, bool expectedE
 #undef GT_METHOD_NAME
 
 #define GT_METHOD_NAME "checkEnabled"
-void GTWidget::checkEnabled(GUITestOpStatus &os, const QString &widgetName, bool expectedEnabledState, QWidget const *const parent) {
+void GTWidget::checkEnabled(GUITestOpStatus &os, const QString &widgetName, bool expectedEnabledState, const QWidget *parent) {
     checkEnabled(os, GTWidget::findWidget(os, widgetName, parent), expectedEnabledState);
 }
 #undef GT_METHOD_NAME

--- a/src/libs_3rdparty/QSpec/src/primitives/GTWidget.cpp
+++ b/src/libs_3rdparty/QSpec/src/primitives/GTWidget.cpp
@@ -119,32 +119,21 @@ QWidget *GTWidget::findWidget(GUITestOpStatus &os, const QString &widgetName, co
 }
 #undef GT_METHOD_NAME
 
-#define GT_CLASS_NAME "GTWidget"
-#define GT_METHOD_NAME "findLineEdit"
 QLineEdit *GTWidget::findLineEdit(GUITestOpStatus &os, const QString &widgetName, const QWidget *parentWidget, const GTGlobals::FindOptions &options) {
     return findExactWidget<QLineEdit *>(os, widgetName, parentWidget, options);
 }
-#undef GT_METHOD_NAME
 
-#define GT_CLASS_NAME "GTWidget"
-#define GT_METHOD_NAME "findCheckBox"
 QCheckBox *GTWidget::findCheckBox(GUITestOpStatus &os, const QString &widgetName, const QWidget *parentWidget, const GTGlobals::FindOptions &options) {
     return findExactWidget<QCheckBox *>(os, widgetName, parentWidget, options);
 }
-#undef GT_METHOD_NAME
 
-#define GT_CLASS_NAME "GTWidget"
-#define GT_METHOD_NAME "findSpinBox"
 QSpinBox *GTWidget::findSpinBox(GUITestOpStatus &os, const QString &widgetName, const QWidget *parentWidget, const GTGlobals::FindOptions &options) {
     return findExactWidget<QSpinBox *>(os, widgetName, parentWidget, options);
 }
-#undef GT_METHOD_NAME
 
-#define GT_METHOD_NAME "getWidgetCenter"
 QPoint GTWidget::getWidgetCenter(QWidget *widget) {
     return widget->mapToGlobal(widget->rect().center());
 }
-#undef GT_METHOD_NAME
 
 #define GT_METHOD_NAME "findButtonByText"
 QAbstractButton *GTWidget::findButtonByText(GUITestOpStatus &os, const QString &text, QWidget *parentWidget, const GTGlobals::FindOptions &options) {

--- a/src/libs_3rdparty/QSpec/src/primitives/GTWidget.h
+++ b/src/libs_3rdparty/QSpec/src/primitives/GTWidget.h
@@ -24,9 +24,12 @@
 
 #include <QAbstractButton>
 #include <QAbstractItemView>
+#include <QCheckBox>
 #include <QLabel>
+#include <QLineEdit>
 #include <QMenu>
 #include <QPushButton>
+#include <QSpinBox>
 #include <QWidget>
 
 #include "GTGlobals.h"
@@ -44,11 +47,11 @@ public:
     static void setFocus(GUITestOpStatus &os, QWidget *w);
 
     // finds widget with the given object name using given FindOptions. Parent widget is QMainWindow, if not set
-    static QWidget *findWidget(GUITestOpStatus &os, const QString &widgetName, const QWidget *const parentWidget = NULL, const GTGlobals::FindOptions & = GTGlobals::FindOptions());
+    static QWidget *findWidget(GUITestOpStatus &os, const QString &widgetName, const QWidget *const parentWidget = nullptr, const GTGlobals::FindOptions & = GTGlobals::FindOptions());
     static QPoint getWidgetCenter(QWidget *widget);
 
-    static QAbstractButton *findButtonByText(GUITestOpStatus &os, const QString &text, QWidget *parentWidget = NULL, const GTGlobals::FindOptions & = GTGlobals::FindOptions());
-    static QList<QLabel *> findLabelByText(GUITestOpStatus &os, const QString &text, QWidget *parentWidget = NULL, const GTGlobals::FindOptions & = GTGlobals::FindOptions());
+    static QAbstractButton *findButtonByText(GUITestOpStatus &os, const QString &text, QWidget *parentWidget = nullptr, const GTGlobals::FindOptions & = GTGlobals::FindOptions());
+    static QList<QLabel *> findLabelByText(GUITestOpStatus &os, const QString &text, QWidget *parentWidget = nullptr, const GTGlobals::FindOptions & = GTGlobals::FindOptions());
 
     //returns color of point p in widget w coordinates
     static QColor getColor(GUITestOpStatus &os, QWidget *widget, const QPoint &point);
@@ -89,24 +92,33 @@ public:
     static QMenu *getActivePopupMenu(GUITestOpStatus &os);
 
     static void checkEnabled(GUITestOpStatus &os, QWidget *widget, bool expectedEnabledState = true);
-    static void checkEnabled(GUITestOpStatus &os, const QString &widgetName, bool expectedEnabledState = true, QWidget const *const parent = NULL);
+    static void checkEnabled(GUITestOpStatus &os, const QString &widgetName, bool expectedEnabledState = true, const QWidget *parent = nullptr);
 
     static void scrollToIndex(GUITestOpStatus &os, QAbstractItemView *itemView, const QModelIndex &index);
 
 #define GT_CLASS_NAME "GTWidget"
 #define GT_METHOD_NAME "findExactWidget"
     template<class T>
-    static T findExactWidget(GUITestOpStatus &os, const QString &widgetName, QWidget const *const parentWidget = NULL, const GTGlobals::FindOptions &options = GTGlobals::FindOptions()) {
-        T result = NULL;
+    static T findExactWidget(GUITestOpStatus &os, const QString &widgetName, const QWidget *parentWidget = nullptr, const GTGlobals::FindOptions &options = GTGlobals::FindOptions()) {
+        T result = nullptr;
         QWidget *w = findWidget(os, widgetName, parentWidget, options);
         result = qobject_cast<T>(w);
         if (options.failIfNotFound) {
-            GT_CHECK_RESULT(w != NULL, "widget " + widgetName + " not found", result);
-            GT_CHECK_RESULT(result != NULL, "widget of specefied class not found, but there is another widget with the same name, its class is: " + QString(w->metaObject()->className()), result);
+            GT_CHECK_RESULT(w != nullptr, "widget " + widgetName + " not found", result);
+            GT_CHECK_RESULT(result != nullptr, "widget of specified class not found, but there is another widget with the same name, its class is: " + QString(w->metaObject()->className()), result);
         }
         return result;
     }
 #undef GT_METHOD_NAME
+
+    /** Calls findExactWidget with QLineEdit type. Shortcut method. */
+    static QLineEdit *findLineEdit(GUITestOpStatus &os, const QString &widgetName, const QWidget *parentWidget = nullptr, const GTGlobals::FindOptions &options = GTGlobals::FindOptions());
+
+    /** Calls findExactWidget with QCheckBox type. Shortcut method. */
+    static QCheckBox *findCheckBox(GUITestOpStatus &os, const QString &widgetName, const QWidget *parentWidget = nullptr, const GTGlobals::FindOptions &options = GTGlobals::FindOptions());
+
+    /** Calls findExactWidget with QSpinBox type. Shortcut method. */
+    static QSpinBox *findSpinBox(GUITestOpStatus &os, const QString &widgetName, const QWidget *parentWidget = nullptr, const GTGlobals::FindOptions &options = GTGlobals::FindOptions());
 
 #define GT_METHOD_NAME "findWidgetByType"
     /** Finds a child widget with the given type. Fails is widget can't be found. */

--- a/src/plugins/GUITestBase/src/runnables/ugene/plugins/dotplot/BuildDotPlotDialogFiller.cpp
+++ b/src/plugins/GUITestBase/src/runnables/ugene/plugins/dotplot/BuildDotPlotDialogFiller.cpp
@@ -57,14 +57,14 @@ void BuildDotPlotFiller::commonScenario() {
 
     GTCheckBox::setChecked(os, GTWidget::findCheckBox(os, "mergeFirstCheckBox", dialog), mergeFirstBoxChecked);
     if (mergeFirstBoxChecked) {
-        GTSpinBox::setValue(os, GTWidget::findExactWidget<QSpinBox *>(os, "gapFirst", dialog), firstGapSize);
+        GTSpinBox::setValue(os, GTWidget::findSpinBox(os, "gapFirst", dialog), firstGapSize);
     }
 
     if (!oneSequenceBoxChecked) {
         GTLineEdit::setText(os, GTWidget::findLineEdit(os, "secondFileEdit", dialog), secondFileName);
         GTCheckBox::setChecked(os, GTWidget::findCheckBox(os, "mergeSecondCheckBox", dialog), mergeSecondBoxChecked);
         if (mergeSecondBoxChecked) {
-            GTSpinBox::setValue(os, GTWidget::findExactWidget<QSpinBox *>(os, "gapSecond", dialog), secondGapSize);
+            GTSpinBox::setValue(os, GTWidget::findSpinBox(os, "gapSecond", dialog), secondGapSize);
         }
     }
     GTUtilsDialog::clickButtonBox(os, dialog, QDialogButtonBox::Ok);

--- a/src/plugins/GUITestBase/src/runnables/ugene/plugins/dotplot/BuildDotPlotDialogFiller.cpp
+++ b/src/plugins/GUITestBase/src/runnables/ugene/plugins/dotplot/BuildDotPlotDialogFiller.cpp
@@ -27,39 +27,49 @@
 
 #include <QApplication>
 #include <QDialogButtonBox>
-#include <QPushButton>
 
 #include "GTUtilsTaskTreeView.h"
 
 namespace U2 {
 
+BuildDotPlotFiller::BuildDotPlotFiller(HI::GUITestOpStatus &_os,
+                                       const QString &_firstFileName,
+                                       const QString &_secondFileName,
+                                       bool _mergeFirstBoxChecked,
+                                       bool _oneSequenceBoxChecked,
+                                       bool _mergeSecondBoxChecked,
+                                       int _gapFirstValue,
+                                       int _gapSecondValue,
+                                       bool cancel)
+    : Filler(_os, "DotPlotFilesDialog"), mergeFirstBoxChecked(_mergeFirstBoxChecked),
+      oneSequenceBoxChecked(_oneSequenceBoxChecked), mergeSecondBoxChecked(_mergeSecondBoxChecked),
+      firstFileName(_firstFileName), secondFileName(_secondFileName), firstGapSize(_gapFirstValue),
+      secondGapSize(_gapSecondValue), cancel(cancel) {
+}
+
 #define GT_CLASS_NAME "GTUtilsDialog::DotPlotFiller"
 #define GT_METHOD_NAME "commonScenario"
 void BuildDotPlotFiller::commonScenario() {
-    QWidget *dialog = QApplication::activeModalWidget();
-    GT_CHECK(dialog, "activeModalWidget is NULL");
+    QWidget *dialog = GTWidget::getActiveModalWidget(os);
 
-    GTCheckBox::setChecked(os, dialog->findChild<QCheckBox *>("oneSequenceCheckBox"), oneSequenceBoxChecked);
-    GTLineEdit::setText(os, dialog->findChild<QLineEdit *>("firstFileEdit"), firstFileEdit);
+    GTCheckBox::setChecked(os, GTWidget::findCheckBox(os, "oneSequenceCheckBox", dialog), oneSequenceBoxChecked);
+    GTLineEdit::setText(os, GTWidget::findLineEdit(os, "firstFileEdit", dialog), firstFileName);
 
-    GTCheckBox::setChecked(os, dialog->findChild<QCheckBox *>("mergeFirstCheckBox"), mergeFirstBoxChecked);
+    GTCheckBox::setChecked(os, GTWidget::findCheckBox(os, "mergeFirstCheckBox", dialog), mergeFirstBoxChecked);
     if (mergeFirstBoxChecked) {
-        GTSpinBox::setValue(os, dialog->findChild<QSpinBox *>("gapFirst"), gapFirstVal);
+        GTSpinBox::setValue(os, GTWidget::findExactWidget<QSpinBox *>(os, "gapFirst", dialog), firstGapSize);
     }
 
     if (!oneSequenceBoxChecked) {
-        GTLineEdit::setText(os, dialog->findChild<QLineEdit *>("secondFileEdit"), secondFileEdit);
-
-        GTCheckBox::setChecked(os, dialog->findChild<QCheckBox *>("mergeSecondCheckBox"), mergeSecondBoxChecked);
+        GTLineEdit::setText(os, GTWidget::findLineEdit(os, "secondFileEdit", dialog), secondFileName);
+        GTCheckBox::setChecked(os, GTWidget::findCheckBox(os, "mergeSecondCheckBox", dialog), mergeSecondBoxChecked);
         if (mergeSecondBoxChecked) {
-            GTSpinBox::setValue(os, dialog->findChild<QSpinBox *>("gapSecond"), gapSecondVal);
+            GTSpinBox::setValue(os, GTWidget::findExactWidget<QSpinBox *>(os, "gapSecond", dialog), secondGapSize);
         }
     }
-
     GTUtilsDialog::clickButtonBox(os, dialog, QDialogButtonBox::Ok);
     if (cancel) {
-        dialog = QApplication::activeModalWidget();
-        GT_CHECK(dialog, "activeModalWidget is NULL");
+        dialog = GTWidget::getActiveModalWidget(os);
         GTUtilsDialog::clickButtonBox(os, dialog, QDialogButtonBox::Cancel);
     }
 }

--- a/src/plugins/GUITestBase/src/runnables/ugene/plugins/dotplot/BuildDotPlotDialogFiller.h
+++ b/src/plugins/GUITestBase/src/runnables/ugene/plugins/dotplot/BuildDotPlotDialogFiller.h
@@ -29,23 +29,26 @@ using namespace HI;
 
 class BuildDotPlotFiller : public Filler {
 public:
-    BuildDotPlotFiller(HI::GUITestOpStatus &_os, const QString &_firstFileEdit, const QString &_secondFileEdit = "", bool _mergeFirstBoxChecked = false, bool _oneSequenceBoxChecked = false, bool _mergeSecondBoxChecked = false, int _gapFirstVal = 5, int _gapSecondVal = 5, bool cancel = false)
-        : Filler(_os, "DotPlotFilesDialog"),
-          mergeFirstBoxChecked(_mergeFirstBoxChecked),
-          oneSequenceBoxChecked(_oneSequenceBoxChecked),
-          mergeSecondBoxChecked(_mergeSecondBoxChecked),
-          firstFileEdit(_firstFileEdit),
-          secondFileEdit(_secondFileEdit),
-          gapFirstVal(_gapFirstVal), gapSecondVal(_gapSecondVal),
-          cancel(cancel) {
-    }
-    void commonScenario();
+    BuildDotPlotFiller(HI::GUITestOpStatus &_os,
+                       const QString &_firstFileName,
+                       const QString &_secondFileName = "",
+                       bool _mergeFirstBoxChecked = false,
+                       bool _oneSequenceBoxChecked = false,
+                       bool _mergeSecondBoxChecked = false,
+                       int _gapFirstValue = 5,
+                       int _gapSecondValue = 5,
+                       bool cancel = false);
+
+    void commonScenario() override;
 
 private:
-    bool mergeFirstBoxChecked, oneSequenceBoxChecked, mergeSecondBoxChecked;
-    const QString firstFileEdit;
-    const QString secondFileEdit;
-    int gapFirstVal, gapSecondVal;
+    bool mergeFirstBoxChecked;
+    bool oneSequenceBoxChecked;
+    bool mergeSecondBoxChecked;
+    QString firstFileName;
+    QString secondFileName;
+    int firstGapSize;
+    int secondGapSize;
     bool cancel;
 };
 }    // namespace U2

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_2001_3000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_2001_3000.cpp
@@ -2249,14 +2249,13 @@ GUI_TEST_CLASS_DEFINITION(test_2352) {
     //3. Select any binary file as first file in dialog
     //Expected state: file is not selected, no crash
 
-    QString bin = QCoreApplication::applicationFilePath();
-    GTUtilsDialog::waitForDialog(os, new BuildDotPlotFiller(os, bin, bin, false, false, false, 5, 5, true));
+    QString randomBinaryFile = QCoreApplication::applicationFilePath();
+
+    GTUtilsDialog::waitForDialog(os, new BuildDotPlotFiller(os, randomBinaryFile, randomBinaryFile, false, false, false, 5, 5, true));
     GTUtilsDialog::waitForDialog(os, new MessageBoxDialogFiller(os, QMessageBox::Ok));
+    GTMenu::clickMainMenuItem(os, {"Tools", "Build dotplot..."});
 
-    GTMenu::clickMainMenuItem(os, QStringList() << "Tools"
-                                                << "Build dotplot...");
-
-    GTGlobals::sleep();
+    GTUtilsDialog::waitAllFinished(os);
 }
 
 GUI_TEST_CLASS_DEFINITION(test_2360) {


### PR DESCRIPTION
The problem was that the DotPlot dialog adapter didn't wait for the dialog to re-appear after an error.
I fixed the adapter and cleaned up related code a little.
