### PR TITLE
UGENE-7177. Disable 'deprecated-declarations' warnings

### DIFF
--- a/src/corelibs/U2Formats/src/StockholmFormat.cpp
+++ b/src/corelibs/U2Formats/src/StockholmFormat.cpp
@@ -227,40 +227,41 @@ static QString getAnnotationName(Annotation *ann) {
 
     AnnotationType t = ann->type;
     switch (t) {
-    case UNI_ANNOTATION:
-        return QString(StockholmFormat::UNI_ANNOTATION_MARK);
-    case FILE_ANNOTATION: {
-        AnnotationTag tag = ann->tag;
-        switch (tag) {
-        case ID:
-            return QString(StockholmFormat::FILE_ANNOTATION_ID);
-        case AC:
-            return QString(StockholmFormat::FILE_ANNOTATION_AC);
-        case DE:
-            return QString(StockholmFormat::FILE_ANNOTATION_DE);
-        case GA:
-            return QString(StockholmFormat::FILE_ANNOTATION_GA);
-        case NC:
-            return QString(StockholmFormat::FILE_ANNOTATION_NC);
-        case TC:
-            return QString(StockholmFormat::FILE_ANNOTATION_TC);
+        case UNI_ANNOTATION:
+            return QString(StockholmFormat::UNI_ANNOTATION_MARK);
+        case FILE_ANNOTATION: {
+            AnnotationTag tag = ann->tag;
+            switch (tag) {
+                case ID:
+                    return QString(StockholmFormat::FILE_ANNOTATION_ID);
+                case AC:
+                    return QString(StockholmFormat::FILE_ANNOTATION_AC);
+                case DE:
+                    return QString(StockholmFormat::FILE_ANNOTATION_DE);
+                case GA:
+                    return QString(StockholmFormat::FILE_ANNOTATION_GA);
+                case NC:
+                    return QString(StockholmFormat::FILE_ANNOTATION_NC);
+                case TC:
+                    return QString(StockholmFormat::FILE_ANNOTATION_TC);
+                default:
+                    assert(false);
+                    break;
+            }
+        }
+        case COLUMN_ANNOTATION: {
+            AnnotationTag tag = ann->tag;
+            switch (tag) {
+                case SS_CONS:
+                    return QString(StockholmFormat::COLUMN_ANNOTATION_SS_CONS);
+                case RF:
+                    return QString(StockholmFormat::COLUMN_ANNOTATION_RF);
+                default:
+                    assert(false);
+            }
+        }
         default:
             assert(false);
-        }
-    }
-    case COLUMN_ANNOTATION: {
-        AnnotationTag tag = ann->tag;
-        switch (tag) {
-        case SS_CONS:
-            return QString(StockholmFormat::COLUMN_ANNOTATION_SS_CONS);
-        case RF:
-            return QString(StockholmFormat::COLUMN_ANNOTATION_RF);
-        default:
-            assert(false);
-        }
-    }
-    default:
-        assert(false);
     }
     return QString();
 }
@@ -630,9 +631,7 @@ static void load(IOAdapter *io, const U2DbiRef &dbiRef, QList<GObject *> &l, con
         uni_file = uni_file || isUniFile(ann_bank);
 
         name = getMsaName(ann_bank);
-        name = (QString::null == name || names_list.contains(name)) ?
-                   filename + "_" + QString::number(l.size()) :
-                   name;
+        name = (QString::null == name || names_list.contains(name)) ? filename + "_" + QString::number(l.size()) : name;
         names_list.append(name);
         msa->setName(name);
 

--- a/src/ugene_globals.pri
+++ b/src/ugene_globals.pri
@@ -57,6 +57,7 @@ linux-g++ {
     # A few UGENE headers (like U2Location) emits thousands of deprecated-copy warnings.
     # TODO: Fix UGENE code and remove the suppression.
     QMAKE_CXXFLAGS += -Wno-deprecated-copy
+    QMAKE_CXXFLAGS += -Wno-deprecated-declarations
 
     # These warnings must be errors:
     QMAKE_CXXFLAGS += -Werror=maybe-uninitialized


### PR DESCRIPTION
This suppression is not permanent, see https://ugene.dev/tracker/browse/UGENE-7177.

I'm testing UGENE with 5.15 LTS on Linux and these warnings spoils the log and hide other issues. 
Any our users who try building UGENE from sources also see these warnings: we should either address them or suppress them.

With Qt 5.12 we have no single warning like this,: we have them only with Qt 5.15.
The correct fix is to fix the cause of these warning, but this will take some time and until then I'm disabling it.