### PR TITLE
UGENE-7224 Fix type conversions error in SW

### DIFF
--- a/src/plugins/smith_waterman/src/SmithWatermanAlgorithm.cpp
+++ b/src/plugins/smith_waterman/src/SmithWatermanAlgorithm.cpp
@@ -172,8 +172,9 @@ void SmithWatermanAlgorithm::calculateMatrixForMultipleAlignmentResult() {
     unsigned char *src = (unsigned char *)searchSeq.data(), *pat = (unsigned char *)patternSeq.data();
 
     n = pat_n * 2;
-    int dirn = (4 + pat_n + 3) >> 2;
-    int *buf, *matrix = (int *)malloc(n * sizeof(int) + pat_n * 0x80 + matrixLength * dirn);
+    unsigned int dirn = (4 + pat_n + 3) >> 2;
+    unsigned int memory = n * sizeof(int) + pat_n * 0x80 + matrixLength * dirn;
+    int* buf, * matrix = (int*)malloc(memory);
     if (matrix == NULL) {
         std::bad_alloc e;
         throw e;


### PR DESCRIPTION
https://ugene.dev/tracker/browse/UGENE-7224

I didn't write any tests on this issue because when I run this task on my computer, it eat almost 10GB RAM and was processing extremally long time. It's happens, because Smith-Waterman algorithm isn't supposed to be run on a such big data (sequence 100 000 bases), but it's another question, which isn't relates to this very type conversation error