### PR TITLE
UGENE-7230. UGENE Genome alignment reports that reads can't be mapped.

### DIFF
--- a/src/plugins/genome_aligner/src/GenomeAlignerIO.cpp
+++ b/src/plugins/genome_aligner/src/GenomeAlignerIO.cpp
@@ -251,6 +251,8 @@ GenomeAlignerDbiWriter::GenomeAlignerDbiWriter(const QString &dbiFilePath,
 }
 
 void GenomeAlignerDbiWriter::write(SearchQuery *seq, SAType offset) {
+    writtenReadsCount++;
+
     U2AssemblyRead read(new U2AssemblyReadData());
 
     read->name = seq->getName().toLatin1();

--- a/src/plugins/genome_aligner/src/GenomeAlignerTask.cpp
+++ b/src/plugins/genome_aligner/src/GenomeAlignerTask.cpp
@@ -45,6 +45,7 @@
 
 namespace U2 {
 
+//TODO: calling tr() int static context! Translator is not initialized yet!
 const QString GenomeAlignerTask::taskName(QObject::tr("UGENE Genome Aligner"));
 const QString GenomeAlignerTask::OPTION_ALIGN_REVERSED("align_reversed");
 const QString GenomeAlignerTask::OPTION_OPENCL("use_gpu_optimization");
@@ -53,7 +54,6 @@ const QString GenomeAlignerTask::OPTION_MISMATCHES("mismatches_allowed");
 const QString GenomeAlignerTask::OPTION_PERCENTAGE_MISMATCHES("mismatches_percentage_allowed");
 const QString GenomeAlignerTask::OPTION_INDEX_DIR("dir_of_the_index_file");
 const QString GenomeAlignerTask::OPTION_BEST("best_mode");
-const QString GenomeAlignerTask::OPTION_DBI_IO("dbi_io");
 const QString GenomeAlignerTask::OPTION_QUAL_THRESHOLD("quality_threshold");
 const QString GenomeAlignerTask::OPTION_READS_MEMORY_SIZE("reads_mem_size");
 const QString GenomeAlignerTask::OPTION_SEQ_PART_SIZE("seq_part_size");
@@ -70,7 +70,6 @@ GenomeAlignerTask::GenomeAlignerTask(const DnaAssemblyToRefTaskSettings &_settin
       seqReader(NULL),
       seqWriter(NULL),
       justBuildIndex(_justBuildIndex),
-      bunchSize(0),
       index(NULL),
       lastQuery(NULL) {
     GCOUNTER(cvar, "GenomeAlignerTask");
@@ -80,7 +79,6 @@ GenomeAlignerTask::GenomeAlignerTask(const DnaAssemblyToRefTaskSettings &_settin
     readsAligned = 0;
     shortreadLoadTime = 0;
     resultWriteTime = 0;
-    searchTime = 0;
     indexLoadTime = 0;
     shortreadIOTime = 0;
     currentProgress = 0.0f;
@@ -287,7 +285,7 @@ QList<Task *> GenomeAlignerTask::onSubTaskFinished(Task *subTask) {
 
             alignContext.minReadLength = INT_MAX;
             alignContext.maxReadLength = 0;
-            readTask = new ReadShortReadsSubTask(&lastQuery, seqReader, settings, alignContext, readMemSize * 1000 * 1000);
+            readTask = new ReadShortReadsSubTask(seqReader, settings, alignContext, readMemSize * 1000 * 1000);
             readTask->setSubtaskProgressWeight(0.0f);
             subTasks.append(readTask);
             findTask = new GenomeAlignerFindTask(index, &alignContext, pWriteTask);

--- a/src/plugins/genome_aligner/src/GenomeAlignerTask.h
+++ b/src/plugins/genome_aligner/src/GenomeAlignerTask.h
@@ -66,7 +66,6 @@ public:
     static const QString OPTION_INDEX_DIR;
     static const QString OPTION_QUAL_THRESHOLD;
     static const QString OPTION_BEST;
-    static const QString OPTION_DBI_IO;
     static const QString OPTION_READS_MEMORY_SIZE;
     static const QString OPTION_SEQ_PART_SIZE;
     static const int MIN_SHORT_READ_LENGTH = 30;
@@ -89,7 +88,6 @@ private:
     QTemporaryFile temp;
 
     bool justBuildIndex;
-    uint bunchSize;
 
     bool alignReversed;
     bool dbiIO;
@@ -97,17 +95,16 @@ private:
     bool prebuiltIndex;
     GenomeAlignerIndex *index;
     int qualityThreshold;
-    quint64 readMemSize;
+    qint64 readMemSize;
     int seqPartSize;
     SearchQuery *lastQuery;
     bool noDataToAlign;
 
     //statistics
-    quint64 readsCount;
-    quint64 readsAligned;
+    qint64 readsCount;
+    qint64 readsAligned;
     qint64 shortreadLoadTime;
     qint64 resultWriteTime;
-    qint64 searchTime;
     qint64 indexLoadTime;
     qint64 shortreadIOTime;
     float currentProgress;

--- a/src/plugins/genome_aligner/src/ReadShortReadsSubTask.cpp
+++ b/src/plugins/genome_aligner/src/ReadShortReadsSubTask.cpp
@@ -85,16 +85,13 @@ static SearchQuery *createRevComplQuery(SearchQuery *query, DNATranslation *tran
     return rQu;
 }
 
-ReadShortReadsSubTask::ReadShortReadsSubTask(SearchQuery **_lastQuery,
-                                             GenomeAlignerReader *_seqReader,
+ReadShortReadsSubTask::ReadShortReadsSubTask(GenomeAlignerReader *_seqReader,
                                              const DnaAssemblyToRefTaskSettings &_settings,
                                              AlignContext &_alignContext,
-                                             quint64 m)
-    : Task("ReadShortReadsSubTask", TaskFlag_None), lastQuery(_lastQuery),
+                                             qint64 m)
+    : Task("ReadShortReadsSubTask", TaskFlag_None),
       seqReader(_seqReader), settings(_settings), alignContext(_alignContext),
       freeMemorySize(m), prevMemoryHint(0), dataBunch(NULL) {
-    minReadLength = INT_MAX;
-    maxReadLength = 0;
 }
 
 void ReadShortReadsSubTask::readingFinishedWakeAll() {

--- a/src/plugins/genome_aligner/src/ReadShortReadsSubTask.h
+++ b/src/plugins/genome_aligner/src/ReadShortReadsSubTask.h
@@ -38,23 +38,19 @@ class GenomeAlignerReader;
 class ReadShortReadsSubTask : public Task {
     Q_OBJECT
 public:
-    ReadShortReadsSubTask(SearchQuery **lastQuery,
-                          GenomeAlignerReader *seqReader,
+    ReadShortReadsSubTask(GenomeAlignerReader *seqReader,
                           const DnaAssemblyToRefTaskSettings &settings,
                           AlignContext &alignContext,
-                          quint64 freeMemorySize);
-    virtual void run();
+                          qint64 freeMemorySize);
+    void run() override;
 
-    uint bunchSize;
-    int minReadLength;
-    int maxReadLength;
+    int bunchSize = 0;
 
 private:
-    SearchQuery **lastQuery;
     GenomeAlignerReader *seqReader;
     const DnaAssemblyToRefTaskSettings &settings;
     AlignContext &alignContext;
-    quint64 freeMemorySize;
+    qint64 freeMemorySize;
     qint64 prevMemoryHint;
 
     DataBunch *dataBunch;

--- a/src/plugins/genome_aligner/src/WriteAlignedReadsSubTask.cpp
+++ b/src/plugins/genome_aligner/src/WriteAlignedReadsSubTask.cpp
@@ -23,7 +23,7 @@
 
 namespace U2 {
 
-WriteAlignedReadsSubTask::WriteAlignedReadsSubTask(QReadWriteLock &_listM, QMutex &_writeLock, GenomeAlignerWriter *_seqWriter, QList<DataBunch *> &_data, quint64 &r)
+WriteAlignedReadsSubTask::WriteAlignedReadsSubTask(QReadWriteLock &_listM, QMutex &_writeLock, GenomeAlignerWriter *_seqWriter, QList<DataBunch *> &_data, qint64 &r)
     : Task("WriteAlignedReadsSubTask", TaskFlag_None), seqWriter(_seqWriter), data(_data), readsAligned(r), listM(_listM), writeLock(_writeLock) {
 }
 

--- a/src/plugins/genome_aligner/src/WriteAlignedReadsSubTask.h
+++ b/src/plugins/genome_aligner/src/WriteAlignedReadsSubTask.h
@@ -27,20 +27,19 @@
 #include <U2Core/Task.h>
 
 #include "GenomeAlignerIndex.h"
-#include "WriteAlignedReadsSubTask.h"
 
 namespace U2 {
 
 class WriteAlignedReadsSubTask : public Task {
     Q_OBJECT
 public:
-    WriteAlignedReadsSubTask(QReadWriteLock &listM, QMutex &_writeLock, GenomeAlignerWriter *seqWriter, QList<DataBunch *> &data, quint64 &readsAligned);
-    virtual void run();
+    WriteAlignedReadsSubTask(QReadWriteLock &listM, QMutex &_writeLock, GenomeAlignerWriter *seqWriter, QList<DataBunch *> &data, qint64 &readsAligned);
+    void run() override;
 
 private:
     GenomeAlignerWriter *seqWriter;
     QList<DataBunch *> &data;
-    quint64 &readsAligned;
+    qint64 &readsAligned;
 
     inline void setReadWritten(SearchQuery *read, SearchQuery *revCompl);
     QReadWriteLock &listM;


### PR DESCRIPTION
The fix itself is 1-liner:  writtenReadsCount++; in GenomeAlignerIO.cpp
but I also removed dead code from the related code & checked that all required fields are initialized.
See JIRA issue for more details: https://ugene.dev/tracker/browse/UGENE-7230