### PR TITLE
UGENE-7238. Step 2. Extend available options to build popup menus in v…

### DIFF
--- a/src/corelibs/U2Gui/src/ObjectViewModel.cpp
+++ b/src/corelibs/U2Gui/src/ObjectViewModel.cpp
@@ -43,6 +43,8 @@ namespace U2 {
 
 const QString GObjectViewState::APP_CLOSING_STATE_NAME("Auto saved");
 const GObjectViewFactoryId GObjectViewFactory::SIMPLE_TEXT_FACTORY("SimpleTextView");
+const QString GObjectViewMenuType::CONTEXT("gobject-view-menu-type-context");
+const QString GObjectViewMenuType::STATIC("object-view-menu-type-static");
 
 void GObjectViewState::setViewName(const QString &newName) {
     // this method is not a real state modification: state caches view name as a reference, but not its internal data
@@ -221,6 +223,9 @@ void GObjectView::sl_onDocumentRemoved(Document *d) {
     }
 }
 
+void GObjectView::sl_onDocumentLoadedStateChanged() {
+}
+
 void GObjectView::sl_onObjectNameChanged(const QString &oldName) {
     CHECK(AppContext::getProject() != nullptr, );
     GObject *object = qobject_cast<GObject *>(sender());
@@ -248,8 +253,8 @@ void GObjectView::buildStaticToolbar(QToolBar *tb) {
     emit si_buildStaticToolbar(this, tb);
 }
 
-void GObjectView::buildStaticMenu(QMenu *m) {
-    emit si_buildStaticMenu(this, m);
+void GObjectView::buildMenu(QMenu *m, const QString &type) {
+    emit si_buildMenu(this, m, type);
 }
 
 // Returns true if view  contains this object
@@ -370,7 +375,7 @@ void GObjectViewWindow::setupMDIToolbar(QToolBar *tb) {
 }
 
 void GObjectViewWindow::setupViewMenu(QMenu *m) {
-    view->buildStaticMenu(m);
+    view->buildMenu(m, GObjectViewMenuType::STATIC);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -577,8 +582,7 @@ void GObjectViewWindowContext::sl_windowAdded(MWMDIWindow *w) {
 
     initViewContext(objectView);
 
-    connect(objectView, SIGNAL(si_buildPopupMenu(GObjectView *, QMenu *)), SLOT(sl_buildContextMenu(GObjectView *, QMenu *)));
-    connect(objectView, SIGNAL(si_buildStaticMenu(GObjectView *, QMenu *)), SLOT(sl_buildStaticMenu(GObjectView *, QMenu *)));
+    connect(objectView, SIGNAL(si_buildMenu(GObjectView *, QMenu *, const QString &)), SLOT(sl_buildMenu(GObjectView *, QMenu *, const QString &)));
 }
 
 void GObjectViewWindowContext::sl_windowClosing(MWMDIWindow *w) {
@@ -590,15 +594,11 @@ void GObjectViewWindowContext::sl_windowClosing(MWMDIWindow *w) {
     disconnectView(objectView);
 }
 
-void GObjectViewWindowContext::sl_buildContextMenu(GObjectView *v, QMenu *m) {
-    buildMenu(v, m);
+void GObjectViewWindowContext::sl_buildMenu(GObjectView *v, QMenu *m, const QString &type) {
+    buildMenu(v, m, type);
 }
 
-void GObjectViewWindowContext::sl_buildStaticMenu(GObjectView *v, QMenu *m) {
-    buildMenu(v, m);
-}
-
-void GObjectViewWindowContext::buildMenu(GObjectView *, QMenu *) {
+void GObjectViewWindowContext::buildMenu(GObjectView *, QMenu *, const QString &) {
     // No menu by default.
 }
 
@@ -679,6 +679,19 @@ void GObjectViewAction::addToMenuWithOrder(QMenu *menu) {
         }
     }
     menu->addAction(this);
+}
+
+GObjectViewObjectHandler::~GObjectViewObjectHandler() {
+}
+
+bool GObjectViewObjectHandler::canHandle(GObjectView *, GObject *) {
+    return false;
+}
+
+void GObjectViewObjectHandler::onObjectAdded(GObjectView *, GObject *) {
+}
+
+void GObjectViewObjectHandler::onObjectRemoved(GObjectView *, GObject *) {
 }
 
 }    // namespace U2

--- a/src/corelibs/U2Gui/src/ObjectViewModel.cpp
+++ b/src/corelibs/U2Gui/src/ObjectViewModel.cpp
@@ -595,11 +595,29 @@ void GObjectViewWindowContext::sl_windowClosing(MWMDIWindow *w) {
 }
 
 void GObjectViewWindowContext::sl_buildMenu(GObjectView *v, QMenu *m, const QString &type) {
-    buildMenu(v, m, type);
+    if (type == GObjectViewMenuType::STATIC) {
+        buildStaticMenu(v, m);
+    } else if (type == GObjectViewMenuType::CONTEXT) {
+        buildContextMenu(v, m);
+    } else {
+        buildActionMenu(v, m, type);
+    }
 }
 
-void GObjectViewWindowContext::buildMenu(GObjectView *, QMenu *, const QString &) {
-    // No menu by default.
+void GObjectViewWindowContext::buildStaticMenu(GObjectView *view, QMenu *menu) {
+    buildStaticOrContextMenu(view, menu);
+}
+
+void GObjectViewWindowContext::buildContextMenu(GObjectView *view, QMenu *menu) {
+    buildStaticOrContextMenu(view, menu);
+}
+
+void GObjectViewWindowContext::buildStaticOrContextMenu(GObjectView *, QMenu *) {
+    // No extra static/context menu items by default.
+}
+
+void GObjectViewWindowContext::buildActionMenu(GObjectView *, QMenu *, const QString &) {
+    // No extra action menu items by default.
 }
 
 void GObjectViewWindowContext::disconnectView(GObjectView *v) {

--- a/src/corelibs/U2Gui/src/ObjectViewModel.cpp
+++ b/src/corelibs/U2Gui/src/ObjectViewModel.cpp
@@ -699,9 +699,6 @@ void GObjectViewAction::addToMenuWithOrder(QMenu *menu) {
     menu->addAction(this);
 }
 
-GObjectViewObjectHandler::~GObjectViewObjectHandler() {
-}
-
 bool GObjectViewObjectHandler::canHandle(GObjectView *, GObject *) {
     return false;
 }

--- a/src/corelibs/U2Gui/src/ObjectViewModel.h
+++ b/src/corelibs/U2Gui/src/ObjectViewModel.h
@@ -372,7 +372,7 @@ private:
  */
 class U2GUI_EXPORT GObjectViewObjectHandler {
 public:
-    virtual ~GObjectViewObjectHandler();
+    virtual ~GObjectViewObjectHandler() = default;
 
     /**
      * Checks if the handler can 'handle' the object.

--- a/src/corelibs/U2Gui/src/ObjectViewModel.h
+++ b/src/corelibs/U2Gui/src/ObjectViewModel.h
@@ -397,7 +397,7 @@ public:
 
     QList<GObjectViewAction *> getViewActions(GObjectView *view) const;
 
-    virtual void onObjectRemoved(GObjectView *v, GObject *obj);
+    void onObjectRemoved(GObjectView *v, GObject *obj) override;
 
 protected:
     /// init context associated with 'view'
@@ -414,12 +414,34 @@ protected slots:
 
 protected:
     /**
-     * Populates menu with a contextual actions.
-     * The menu type indicates type of the menu: 'context' string is a default contextual popup menu,
-     * 'static' is for the static menu shown in the application toolbar and other string values are specific values for the view.
-     * Example of custom menu types: 're-align-current-alignment', 'add-sequence-to-alignment', etc...
-     * */
-    virtual void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType);
+     * Populates static global application menu with actions added by the class instance.
+     * This method is called when the view builds GObjectViewMenuType::Static menu.
+     */
+    virtual void buildStaticMenu(GObjectView *view, QMenu *menu);
+
+    /**
+     * Populates context popup menu with actions added by the class instance.
+     * This method is called when the view builds GObjectViewMenuType::Context menu.
+     */
+    virtual void buildContextMenu(GObjectView *view, QMenu *menu);
+
+    /**
+     * Populates menu with type specific actions.
+     * This method is called during construction of the type specific popup menu in the view like 'Align' button menu in MSA Editor.
+     * The method is never called for the generic 'GObjectViewMenuType::Context' or 'GObjectViewMenuType::Static' menu types:
+     *  use 'buildContextMenu' or 'buildStaticMenu' for that types.
+     */
+    virtual void buildActionMenu(GObjectView *view, QMenu *menu, const QString &menuType);
+
+    /**
+     * Builds both 'GObjectViewMenuType::Static' and 'GObjectViewMenuType::Context' menus.
+     *
+     * This convenience method is called by default by the base impls of buildStaticMenu() and buildContextMenu() and
+     * exists because most of the UGENE plugins create equal static & context menus.
+     *
+     * This method is never called for menu types other than 'GObjectViewMenuType::Static' and 'GObjectViewMenuType::Context'.
+     */
+    virtual void buildStaticOrContextMenu(GObjectView *view, QMenu *menu);
 
     virtual void disconnectView(GObjectView *v);
 

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyBrowser.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyBrowser.cpp
@@ -23,7 +23,6 @@
 
 #include <QApplication>
 #include <QDesktopWidget>
-#include <QDialogButtonBox>
 #include <QDropEvent>
 #include <QEvent>
 #include <QMenu>
@@ -38,7 +37,6 @@
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DNASequenceObject.h>
 #include <U2Core/DocumentModel.h>
-#include <U2Core/FormatUtils.h>
 #include <U2Core/GObjectSelection.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/L10n.h>
@@ -50,11 +48,9 @@
 #include <U2Core/U2AssemblyDbi.h>
 #include <U2Core/U2AssemblyUtils.h>
 #include <U2Core/U2CrossDatabaseReferenceDbi.h>
-#include <U2Core/U2DbiRegistry.h>
 #include <U2Core/U2DbiUtils.h>
 #include <U2Core/U2ObjectDbi.h>
 #include <U2Core/U2SafePoints.h>
-#include <U2Core/U2SequenceDbi.h>
 #include <U2Core/U2Type.h>
 #include <U2Core/VariantTrackObject.h>
 
@@ -333,18 +329,22 @@ void AssemblyBrowser::sl_onPosChangeRequest(int pos) {
     setXOffsetInAssembly(normalizeXoffset(pos - 1));
     ui->getReadsArea()->setFocus();
 }
-void AssemblyBrowser::buildStaticMenu(QMenu *staticMenu) {
+void AssemblyBrowser::buildMenu(QMenu *menu, const QString &type) {
+    if (type != GObjectViewMenuType::STATIC) {
+        GObjectView::buildMenu(menu, type);
+        return;
+    }
     U2OpStatusImpl os;
     if (model->hasReads(os)) {
-        staticMenu->addAction(zoomInAction);
-        staticMenu->addAction(zoomOutAction);
-        staticMenu->addAction(saveScreenShotAction);
-        staticMenu->addAction(exportToSamAction);
-        staticMenu->addAction(extractAssemblyRegionAction);
-        staticMenu->addAction(setReferenceAction);
+        menu->addAction(zoomInAction);
+        menu->addAction(zoomOutAction);
+        menu->addAction(saveScreenShotAction);
+        menu->addAction(exportToSamAction);
+        menu->addAction(extractAssemblyRegionAction);
+        menu->addAction(setReferenceAction);
     }
-    GObjectView::buildStaticMenu(staticMenu);
-    GUIUtils::disableEmptySubmenus(staticMenu);
+    GObjectView::buildMenu(menu, type);
+    GUIUtils::disableEmptySubmenus(menu);
 }
 
 void AssemblyBrowser::setGlobalCoverageInfo(CoverageInfo newInfo) {

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyBrowser.h
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyBrowser.h
@@ -54,11 +54,12 @@ public:
     bool checkValid(U2OpStatus &os);
 
     // from GObjectView
-    virtual void buildStaticToolbar(QToolBar *tb);
-    virtual void buildStaticMenu(QMenu *m);
-    virtual QVariantMap saveState();
-    virtual Task *updateViewTask(const QString &stateName, const QVariantMap &stateData);
-    virtual OptionsPanel *getOptionsPanel();
+    void buildStaticToolbar(QToolBar *tb) override;
+    void buildMenu(QMenu *menu, const QString &type) override;
+
+    QVariantMap saveState() override;
+    Task *updateViewTask(const QString &stateName, const QVariantMap &stateData) override;
+    OptionsPanel *getOptionsPanel() override;
 
     void setGlobalCoverageInfo(CoverageInfo info);
     QList<CoveredRegion> getCoveredRegions() const;
@@ -247,9 +248,9 @@ private:
     QAction *posSelectorAction;
     PositionSelector *posSelector;
     QList<QAction *> overviewScaleTypeActions;
-    QAction *showCoordsOnRulerAction;
+    QAction *showCoordsOnRulerAction = nullptr;
     QAction *showCoverageOnRulerAction;
-    QAction *readHintEnabledAction;
+    QAction *readHintEnabledAction = nullptr;
     QAction *saveScreenShotAction;
     QAction *exportToSamAction;
     QAction *setReferenceAction;

--- a/src/corelibs/U2View/src/ov_msa/MSAEditor.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditor.cpp
@@ -210,7 +210,11 @@ void MSAEditor::buildStaticToolbar(QToolBar *tb) {
     GObjectView::buildStaticToolbar(tb);
 }
 
-void MSAEditor::buildStaticMenu(QMenu *m) {
+void MSAEditor::buildMenu(QMenu *m, const QString &type) {
+    if (type != GObjectViewMenuType::STATIC) {
+        GObjectView::buildMenu(m, type);
+        return;
+    }
     addAppearanceMenu(m);
 
     addNavigationMenu(m);
@@ -229,7 +233,7 @@ void MSAEditor::buildStaticMenu(QMenu *m) {
 
     addAdvancedMenu(m);
 
-    GObjectView::buildStaticMenu(m);
+    GObjectView::buildMenu(m, type);
 
     GUIUtils::disableEmptySubmenus(m);
 }
@@ -502,7 +506,7 @@ void MSAEditor::sl_onContextMenuRequested(const QPoint & /*pos*/) {
     }
     m.addSeparator();
 
-    emit si_buildPopupMenu(this, &m);
+    emit si_buildMenu(this, &m, GObjectViewMenuType::CONTEXT);
 
     GUIUtils::disableEmptySubmenus(&m);
 
@@ -587,7 +591,7 @@ void MSAEditor::initDragAndDropSupport() {
 }
 
 void MSAEditor::sl_align() {
-    QMenu m, *mm;
+    QMenu m;
 
     addLoadMenu(&m);
     addCopyPasteMenu(&m);
@@ -601,14 +605,14 @@ void MSAEditor::sl_align() {
     addExportMenu(&m);
     addAdvancedMenu(&m);
 
-    emit si_buildPopupMenu(this, &m);
+    emit si_buildMenu(this, &m, GObjectViewMenuType::CONTEXT);
 
     GUIUtils::disableEmptySubmenus(&m);
 
-    mm = GUIUtils::findSubMenu(&m, MSAE_MENU_ALIGN);
-    SAFE_POINT(mm != nullptr, "mm", );
+    QMenu *alignMenu = GUIUtils::findSubMenu(&m, MSAE_MENU_ALIGN);
+    SAFE_POINT(alignMenu != nullptr, "mm", );
 
-    mm->exec(QCursor::pos());
+    alignMenu->exec(QCursor::pos());
 }
 
 void MSAEditor::sl_addToAlignment() {

--- a/src/corelibs/U2View/src/ov_msa/MSAEditor.h
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditor.h
@@ -79,7 +79,7 @@ public:
 
     virtual void buildStaticToolbar(QToolBar *tb) override;
 
-    virtual void buildStaticMenu(QMenu *m) override;
+    void buildMenu(QMenu *m, const QString &type) override;
 
     MsaEditorWgt *getUI() const override;
 

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusArea.cpp
@@ -41,19 +41,14 @@ MSAEditorConsensusArea::MSAEditorConsensusArea(MsaEditorWgt *ui)
     initRenderer();
     setupFontAndHeight();
 
-    connect(editor, SIGNAL(si_buildStaticMenu(GObjectView *, QMenu *)), SLOT(sl_buildStaticMenu(GObjectView *, QMenu *)));
-    connect(editor, SIGNAL(si_buildPopupMenu(GObjectView *, QMenu *)), SLOT(sl_buildContextMenu(GObjectView *, QMenu *)));
+    connect(editor, SIGNAL(si_buildMenu(GObjectView *, QMenu *, const QString &)), SLOT(sl_buildMenu(GObjectView *, QMenu *, const QString &)));
 }
 
 QString MSAEditorConsensusArea::getConsensusPercentTip(int pos, int minReportPercent, int maxReportChars) const {
     return MSAConsensusUtils::getConsensusPercentTip(editor->getMaObject()->getMultipleAlignment(), pos, minReportPercent, maxReportChars);
 }
 
-void MSAEditorConsensusArea::sl_buildStaticMenu(GObjectView * /*view*/, QMenu *menu) {
-    buildMenu(menu);
-}
-
-void MSAEditorConsensusArea::sl_buildContextMenu(GObjectView * /*view*/, QMenu *menu) {
+void MSAEditorConsensusArea::sl_buildMenu(GObjectView * /*view*/, QMenu *menu, const QString &) {
     buildMenu(menu);
 }
 
@@ -64,8 +59,8 @@ void MSAEditorConsensusArea::initRenderer() {
 QString MSAEditorConsensusArea::getLastUsedAlgoSettingsKey() const {
     const DNAAlphabet *al = editor->getMaObject()->getAlphabet();
     SAFE_POINT(al != nullptr, "Alphabet is NULL", "");
-    const char *suffix = al->isAmino() ? "_protein" : al->isNucleic() ? "_nucleic" :
-                                                                        "_raw";
+    const char *suffix = al->isAmino() ? "_protein" : al->isNucleic() ? "_nucleic"
+                                                                      : "_raw";
     return editor->getSettingsRoot() + "_consensus_algorithm_" + suffix;
 }
 

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusArea.h
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusArea.h
@@ -51,8 +51,7 @@ private:
     void buildMenu(QMenu *menu);
 
 private slots:
-    void sl_buildStaticMenu(GObjectView *view, QMenu *menu);
-    void sl_buildContextMenu(GObjectView *view, QMenu *menu);
+    void sl_buildMenu(GObjectView *view, QMenu *menu, const QString &type);
 };
 
 }    // namespace U2

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.cpp
@@ -84,8 +84,7 @@ MSAEditorSequenceArea::MSAEditorSequenceArea(MaEditorWgt *_ui, GScrollBar *hb, G
 
     initRenderer();
 
-    connect(editor, SIGNAL(si_buildPopupMenu(GObjectView *, QMenu *)), SLOT(sl_buildContextMenu(GObjectView *, QMenu *)));
-    connect(editor, SIGNAL(si_buildStaticMenu(GObjectView *, QMenu *)), SLOT(sl_buildStaticMenu(GObjectView *, QMenu *)));
+    connect(editor, SIGNAL(si_buildMenu(GObjectView *, QMenu *, const QString &)), SLOT(sl_buildMenu(GObjectView *, QMenu *, const QString &)));
     connect(editor, SIGNAL(si_buildStaticToolbar(GObjectView *, QToolBar *)), SLOT(sl_buildStaticToolbar(GObjectView *, QToolBar *)));
 
     selectionColor = Qt::black;
@@ -278,13 +277,11 @@ void MSAEditorSequenceArea::sl_buildStaticToolbar(GObjectView *v, QToolBar *t) {
     t->addSeparator();
 }
 
-void MSAEditorSequenceArea::sl_buildStaticMenu(GObjectView *, QMenu *m) {
+void MSAEditorSequenceArea::sl_buildMenu(GObjectView *, QMenu *m, const QString &type) {
     buildMenu(m);
-}
-
-void MSAEditorSequenceArea::sl_buildContextMenu(GObjectView *, QMenu *m) {
-    buildMenu(m);
-
+    if (type == GObjectViewMenuType::STATIC) {
+        return;
+    }
     QMenu *editMenu = GUIUtils::findSubMenu(m, MSAE_MENU_EDIT);
     SAFE_POINT(editMenu != nullptr, "editMenu is null", );
 

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.h
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.h
@@ -160,9 +160,8 @@ protected:
     void focusInEvent(QFocusEvent *fe) override;
 
 private slots:
-    void sl_buildStaticMenu(GObjectView *v, QMenu *m);
+    void sl_buildMenu(GObjectView *v, QMenu *m, const QString &type);
     void sl_buildStaticToolbar(GObjectView *v, QToolBar *t);
-    void sl_buildContextMenu(GObjectView *v, QMenu *m);
     void sl_lockedStateChanged();
     void sl_addSeqFromFile();
     void sl_addSeqFromProject();

--- a/src/corelibs/U2View/src/ov_msa/McaEditor.cpp
+++ b/src/corelibs/U2View/src/ov_msa/McaEditor.cpp
@@ -86,7 +86,11 @@ void McaEditor::buildStaticToolbar(QToolBar *tb) {
     GObjectView::buildStaticToolbar(tb);
 }
 
-void McaEditor::buildStaticMenu(QMenu *menu) {
+void McaEditor::buildMenu(QMenu *menu, const QString &type) {
+    if (type != GObjectViewMenuType::STATIC) {
+        GObjectView::buildMenu(menu, type);
+        return;
+    }
     addAlignmentMenu(menu);
     addAppearanceMenu(menu);
     addNavigationMenu(menu);
@@ -95,7 +99,7 @@ void McaEditor::buildStaticMenu(QMenu *menu) {
     menu->addAction(showConsensusTabAction);
     menu->addSeparator();
 
-    GObjectView::buildStaticMenu(menu);
+    GObjectView::buildMenu(menu, type);
     GUIUtils::disableEmptySubmenus(menu);
 }
 
@@ -128,8 +132,8 @@ SequenceObjectContext *McaEditor::getReferenceContext() const {
 
 void McaEditor::sl_onContextMenuRequested(const QPoint & /*pos*/) {
     QMenu menu;
-    buildStaticMenu(&menu);
-    emit si_buildPopupMenu(this, &menu);
+    buildMenu(&menu, GObjectViewMenuType::STATIC);    // TODO: this call triggers extra signal for static menu.
+    emit si_buildMenu(this, &menu, GObjectViewMenuType::CONTEXT);
     menu.exec(QCursor::pos());
 }
 
@@ -229,7 +233,7 @@ void McaEditor::initActions() {
 
     gotoSelectedReadAction = new QAction(tr("Go to selected read"), this);
     gotoSelectedReadAction->setObjectName("centerReadStartAction");
-    gotoSelectedReadAction->setEnabled(false); // Action state is managed by updateActions().
+    gotoSelectedReadAction->setEnabled(false);    // Action state is managed by updateActions().
     connect(gotoSelectedReadAction, SIGNAL(triggered()), SLOT(sl_gotoSelectedRead()));
 
     GCounter::increment(QString("'Show overview' is %1 on MCA open").arg(overviewVisible ? "ON" : "OFF"));

--- a/src/corelibs/U2View/src/ov_msa/McaEditor.h
+++ b/src/corelibs/U2View/src/ov_msa/McaEditor.h
@@ -60,7 +60,7 @@ public:
 
     void buildStaticToolbar(QToolBar *tb) override;
 
-    void buildStaticMenu(QMenu *menu) override;
+    void buildMenu(QMenu *menu, const QString &type) override;
 
     int getRowContentIndent(int rowId) const override;
 
@@ -108,7 +108,7 @@ protected:
      * The start of the complement reads is they visual end position: such read sequences are read from the right to the left.
      * This way the action works the same as annotation selection in the sequence view.
      */
-    QAction *gotoSelectedReadAction;
+    QAction *gotoSelectedReadAction = nullptr;
 
     QMap<qint64, bool> chromVisibility;
 

--- a/src/corelibs/U2View/src/ov_msa/MsaEditorNameList.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MsaEditorNameList.cpp
@@ -31,15 +31,10 @@ namespace U2 {
 
 MsaEditorNameList::MsaEditorNameList(MaEditorWgt *ui, QScrollBar *nhBar)
     : MaEditorNameList(ui, nhBar) {
-    connect(editor, SIGNAL(si_buildPopupMenu(GObjectView *, QMenu *)), SLOT(sl_buildContextMenu(GObjectView *, QMenu *)));
-    connect(editor, SIGNAL(si_buildStaticMenu(GObjectView *, QMenu *)), SLOT(sl_buildStaticMenu(GObjectView *, QMenu *)));
+    connect(editor, SIGNAL(si_buildMenu(GObjectView *, QMenu *, const QString &)), SLOT(sl_buildMenu(GObjectView *, QMenu *, const QString &)));
 }
 
-void MsaEditorNameList::sl_buildStaticMenu(GObjectView *, QMenu *menu) {
-    buildMenu(menu);
-}
-
-void MsaEditorNameList::sl_buildContextMenu(GObjectView *, QMenu *menu) {
+void MsaEditorNameList::sl_buildMenu(GObjectView *, QMenu *menu, const QString &) {
     buildMenu(menu);
 }
 

--- a/src/corelibs/U2View/src/ov_msa/MsaEditorNameList.h
+++ b/src/corelibs/U2View/src/ov_msa/MsaEditorNameList.h
@@ -36,8 +36,7 @@ protected:
     void mouseDoubleClickEvent(QMouseEvent *e) override;
 
 private slots:
-    void sl_buildStaticMenu(GObjectView *view, QMenu *menu);
-    void sl_buildContextMenu(GObjectView *view, QMenu *menu);
+    void sl_buildMenu(GObjectView *view, QMenu *menu, const QString &type);
 
 private:
     void buildMenu(QMenu *menu);

--- a/src/corelibs/U2View/src/ov_phyltree/TreeViewer.cpp
+++ b/src/corelibs/U2View/src/ov_phyltree/TreeViewer.cpp
@@ -143,6 +143,10 @@ Task *TreeViewer::updateViewTask(const QString &stateName, const QVariantMap &st
     return new UpdateTreeViewerTask(this, stateName, stateData);
 }
 
+OptionsPanel *TreeViewer::getOptionsPanel() {
+    return optionsPanel;
+}
+
 void TreeViewer::createActions() {
     // Tree Settings
     treeSettingsAction = new QAction(QIcon(":core/images/phylip.png"), tr("Tree Settings..."), ui);
@@ -290,7 +294,11 @@ void TreeViewer::buildMSAEditorStaticToolbar(QToolBar *tb) {
     tb->removeAction(zoomToAllAction);
 }
 
-void TreeViewer::buildStaticMenu(QMenu *m) {
+void TreeViewer::buildMenu(QMenu *m, const QString &type) {
+    if (type != GObjectViewMenuType::STATIC) {
+        GObjectView::buildMenu(m, type);
+        return;
+    }
     // Tree Settings
     m->addAction(treeSettingsAction);
 
@@ -336,7 +344,7 @@ void TreeViewer::buildStaticMenu(QMenu *m) {
 
     m->addSeparator();
 
-    GObjectView::buildStaticMenu(m);
+    GObjectView::buildMenu(m, type);
     GUIUtils::disableEmptySubmenus(m);
 }
 
@@ -1593,7 +1601,7 @@ bool TreeViewerUI::isOnlyLeafSelected() const {
     return selectedItems == 2;
 }
 
-GraphicsBranchItem *TreeViewerUI::getRoot() const{
+GraphicsBranchItem *TreeViewerUI::getRoot() const {
     return root;
 }
 

--- a/src/corelibs/U2View/src/ov_phyltree/TreeViewer.h
+++ b/src/corelibs/U2View/src/ov_phyltree/TreeViewer.h
@@ -56,18 +56,18 @@ public:
     TreeViewer(const QString &viewName, GObject *obj, GraphicsRectangularBranchItem *root, qreal scale);
 
     //from GObjectView
-    virtual void buildStaticToolbar(QToolBar *tb);
-    virtual void buildStaticMenu(QMenu *m);
+    void buildStaticToolbar(QToolBar *tb) override;
+    void buildMenu(QMenu *m, const QString &type) override;
 
     void buildMSAEditorStaticToolbar(QToolBar *tb);
 
     void createActions();
 
-    virtual QVariantMap saveState();
-    virtual Task *updateViewTask(const QString &stateName, const QVariantMap &stateData);
-    virtual OptionsPanel *getOptionsPanel() {
-        return optionsPanel;
-    }
+    QVariantMap saveState() override;
+
+    Task *updateViewTask(const QString &stateName, const QVariantMap &stateData) override;
+
+    OptionsPanel *getOptionsPanel() override;
 
     QAction *getPrintAction() const {
         return printAction;

--- a/src/corelibs/U2View/src/ov_sequence/AnnotatedDNAView.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/AnnotatedDNAView.cpp
@@ -530,7 +530,11 @@ void AnnotatedDNAView::buildStaticToolbar(QToolBar *tb) {
     syncViewManager->updateToolbar2(tb);
 }
 
-void AnnotatedDNAView::buildStaticMenu(QMenu *m) {
+void AnnotatedDNAView::buildMenu(QMenu *m, const QString &type) {
+    if (type != GObjectViewMenuType::STATIC) {
+        GObjectView::buildMenu(m, type);
+        return;
+    }
     m->addAction(posSelectorAction);
     clipb->addCopyMenu(m);
     m->addSeparator();
@@ -544,7 +548,7 @@ void AnnotatedDNAView::buildStaticMenu(QMenu *m) {
 
     annotationsView->adjustStaticMenu(m);
 
-    GObjectView::buildStaticMenu(m);
+    GObjectView::buildMenu(m, type);
 }
 
 void AnnotatedDNAView::addAnalyseMenu(QMenu *m) {
@@ -818,7 +822,7 @@ void AnnotatedDNAView::sl_onContextMenuRequested() {
     if (activeSequenceWidget != NULL) {
         activeSequenceWidget->buildPopupMenu(m);
     }
-    emit si_buildPopupMenu(this, &m);
+    emit si_buildMenu(this, &m, GObjectViewMenuType::CONTEXT);
 
     m.exec(QCursor::pos());
 }

--- a/src/corelibs/U2View/src/ov_sequence/AnnotatedDNAView.h
+++ b/src/corelibs/U2View/src/ov_sequence/AnnotatedDNAView.h
@@ -70,7 +70,7 @@ public:
 
     void buildStaticToolbar(QToolBar *tb) override;
 
-    void buildStaticMenu(QMenu *n) override;
+    void buildMenu(QMenu *menu, const QString &type) override;
 
     Task *updateViewTask(const QString &stateName, const QVariantMap &stateData) override;
 

--- a/src/corelibs/U2View/src/ov_sequence/AnnotationsTreeView.h
+++ b/src/corelibs/U2View/src/ov_sequence/AnnotationsTreeView.h
@@ -122,7 +122,7 @@ private slots:
     void sl_onAddAnnotationObjectToView();
     void sl_removeObjectFromView();
     void sl_removeAnnsAndQs();
-    void sl_onBuildPopupMenu(GObjectView *thiz, QMenu *menu);
+    void sl_onBuildMenu(GObjectView *thiz, QMenu *menu, const QString &type);
     void sl_onCopyQualifierValue();
     void sl_onCopyQualifierURL();
     void sl_onToggleQualifierColumn();

--- a/src/plugins/annotator/src/AnnotatorPlugin.h
+++ b/src/plugins/annotator/src/AnnotatorPlugin.h
@@ -52,7 +52,7 @@ protected slots:
     void sl_showCustomAutoAnnotationDialog();
 
 protected:
-    virtual void initViewContext(GObjectView *view);
+    void initViewContext(GObjectView *view) override;
 };
 
 class AnnotatorTests {

--- a/src/plugins/biostruct3d_view/src/BioStruct3DViewPlugin.h
+++ b/src/plugins/biostruct3d_view/src/BioStruct3DViewPlugin.h
@@ -52,13 +52,13 @@ class BioStruct3DViewContext : public GObjectViewWindowContext {
 public:
     BioStruct3DViewContext(QObject *p);
 
-    virtual bool canHandle(GObjectView *v, GObject *o);
+    bool canHandle(GObjectView *v, GObject *o) override;
 
-    virtual void onObjectAdded(GObjectView *v, GObject *obj);
-    virtual void onObjectRemoved(GObjectView *v, GObject *obj);
+    void onObjectAdded(GObjectView *v, GObject *obj) override;
+    void onObjectRemoved(GObjectView *v, GObject *obj) override;
 
 protected:
-    virtual void initViewContext(GObjectView *view);
+    void initViewContext(GObjectView *view) override;
 
     void unregister3DView(GObjectView *view, BioStruct3DSplitter *view3d);
 

--- a/src/plugins/biostruct3d_view/src/deprecated/BioStruct3DViewPlugin.h
+++ b/src/plugins/biostruct3d_view/src/deprecated/BioStruct3DViewPlugin.h
@@ -52,13 +52,13 @@ class BioStruct3DViewContext : public GObjectViewWindowContext {
 public:
     BioStruct3DViewContext(QObject *p);
 
-    virtual bool canHandle(GObjectView *v, GObject *o);
+    bool canHandle(GObjectView *v, GObject *o) override;
 
-    virtual void onObjectAdded(GObjectView *v, GObject *obj);
-    virtual void onObjectRemoved(GObjectView *v, GObject *obj);
+    void onObjectAdded(GObjectView *v, GObject *obj) override;
+    void onObjectRemoved(GObjectView *v, GObject *obj) override;
 
 protected:
-    virtual void initViewContext(GObjectView *view);
+    void initViewContext(GObjectView *view) override;
 
     void unregister3DView(GObjectView *view, BioStruct3DSplitter *view3d);
 

--- a/src/plugins/chroma_view/src/ChromaViewPlugin.h
+++ b/src/plugins/chroma_view/src/ChromaViewPlugin.h
@@ -47,13 +47,13 @@ class ChromaViewContext : public GObjectViewWindowContext {
 public:
     ChromaViewContext(QObject *p);
 
-    bool canHandle(GObjectView *v, GObject *o);
+    bool canHandle(GObjectView *v, GObject *o) override;
 protected slots:
     void sl_showChromatogram();
     void sl_sequenceWidgetAdded(ADVSequenceWidget *);
 
 protected:
-    virtual void initViewContext(GObjectView *view);
+    void initViewContext(GObjectView *view) override;
 };
 
 class ChromaViewAction : public ADVSequenceWidgetAction {

--- a/src/plugins/circular_view/src/CircularViewPlugin.cpp
+++ b/src/plugins/circular_view/src/CircularViewPlugin.cpp
@@ -194,7 +194,7 @@ CircularViewSplitter *CircularViewContext::getView(GObjectView *view, bool creat
 }
 
 //////////////////////////////////////////////////////////////////////////
-void CircularViewContext::buildMenu(GObjectView *v, QMenu *m) {
+void CircularViewContext::buildStaticOrContextMenu(GObjectView *v, QMenu *m) {
     bool empty = true;
     QList<QObject *> resources = viewResources.value(v);
     foreach (QObject *r, resources) {

--- a/src/plugins/circular_view/src/CircularViewPlugin.h
+++ b/src/plugins/circular_view/src/CircularViewPlugin.h
@@ -104,8 +104,8 @@ protected slots:
     void sl_onDNAViewClosed(AnnotatedDNAView *v);
 
 protected:
-    virtual void initViewContext(GObjectView *view);
-    void buildMenu(GObjectView *v, QMenu *m);
+    void initViewContext(GObjectView *view) override;
+    void buildStaticOrContextMenu(GObjectView *view, QMenu *menu) override;
     CircularViewSplitter *getView(GObjectView *view, bool create);
     void removeCircularView(GObjectView *view);
     void toggleViews(AnnotatedDNAView *view);

--- a/src/plugins/dna_export/src/ExportAlignmentViewItems.cpp
+++ b/src/plugins/dna_export/src/ExportAlignmentViewItems.cpp
@@ -62,7 +62,7 @@ void ExportAlignmentViewItemsController::initViewContext(GObjectView *v) {
     addViewResource(msaed, mc);
 }
 
-void ExportAlignmentViewItemsController::buildMenu(GObjectView *v, QMenu *m) {
+void ExportAlignmentViewItemsController::buildMenu(GObjectView *v, QMenu *m, const QString &) {
     QList<QObject *> resources = viewResources.value(v);
     assert(resources.size() == 1);
     QObject *r = resources.first();

--- a/src/plugins/dna_export/src/ExportAlignmentViewItems.cpp
+++ b/src/plugins/dna_export/src/ExportAlignmentViewItems.cpp
@@ -62,7 +62,7 @@ void ExportAlignmentViewItemsController::initViewContext(GObjectView *v) {
     addViewResource(msaed, mc);
 }
 
-void ExportAlignmentViewItemsController::buildMenu(GObjectView *v, QMenu *m, const QString &) {
+void ExportAlignmentViewItemsController::buildStaticOrContextMenu(GObjectView *v, QMenu *m) {
     QList<QObject *> resources = viewResources.value(v);
     assert(resources.size() == 1);
     QObject *r = resources.first();

--- a/src/plugins/dna_export/src/ExportAlignmentViewItems.h
+++ b/src/plugins/dna_export/src/ExportAlignmentViewItems.h
@@ -43,7 +43,7 @@ public:
 protected:
     void initViewContext(GObjectView *view) override;
 
-    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
+    void buildStaticOrContextMenu(GObjectView *view, QMenu *menu) override;
 };
 
 class MSAExportContext : public QObject {

--- a/src/plugins/dna_export/src/ExportAlignmentViewItems.h
+++ b/src/plugins/dna_export/src/ExportAlignmentViewItems.h
@@ -41,8 +41,9 @@ public:
     ExportAlignmentViewItemsController(QObject *p);
 
 protected:
-    virtual void initViewContext(GObjectView *view);
-    virtual void buildMenu(GObjectView *v, QMenu *m);
+    void initViewContext(GObjectView *view) override;
+
+    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
 };
 
 class MSAExportContext : public QObject {

--- a/src/plugins/dna_export/src/ExportSequenceViewItems.cpp
+++ b/src/plugins/dna_export/src/ExportSequenceViewItems.cpp
@@ -80,7 +80,7 @@ void ExportSequenceViewItemsController::initViewContext(GObjectView *v) {
     addViewResource(av, vc);
 }
 
-void ExportSequenceViewItemsController::buildMenu(GObjectView *v, QMenu *m, const QString &) {
+void ExportSequenceViewItemsController::buildStaticOrContextMenu(GObjectView *v, QMenu *m) {
     QList<QObject *> resources = viewResources.value(v);
     assert(resources.size() == 1);
     QObject *r = resources.first();

--- a/src/plugins/dna_export/src/ExportSequenceViewItems.cpp
+++ b/src/plugins/dna_export/src/ExportSequenceViewItems.cpp
@@ -80,7 +80,7 @@ void ExportSequenceViewItemsController::initViewContext(GObjectView *v) {
     addViewResource(av, vc);
 }
 
-void ExportSequenceViewItemsController::buildMenu(GObjectView *v, QMenu *m) {
+void ExportSequenceViewItemsController::buildMenu(GObjectView *v, QMenu *m, const QString &) {
     QList<QObject *> resources = viewResources.value(v);
     assert(resources.size() == 1);
     QObject *r = resources.first();

--- a/src/plugins/dna_export/src/ExportSequenceViewItems.h
+++ b/src/plugins/dna_export/src/ExportSequenceViewItems.h
@@ -46,7 +46,7 @@ public:
 protected:
     void initViewContext(GObjectView *view) override;
 
-    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
+    void buildStaticOrContextMenu(GObjectView *view, QMenu *menu) override;
 
 private:
     AnnotatedDNAView *av;

--- a/src/plugins/dna_export/src/ExportSequenceViewItems.h
+++ b/src/plugins/dna_export/src/ExportSequenceViewItems.h
@@ -40,11 +40,13 @@ class ExportSequenceViewItemsController : public GObjectViewWindowContext {
     Q_OBJECT
 public:
     ExportSequenceViewItemsController(QObject *p);
-    void init();
+
+    void init() override;
 
 protected:
-    virtual void initViewContext(GObjectView *view);
-    virtual void buildMenu(GObjectView *v, QMenu *m);
+    void initViewContext(GObjectView *view) override;
+
+    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
 
 private:
     AnnotatedDNAView *av;

--- a/src/plugins/dna_export/src/McaEditorContext.cpp
+++ b/src/plugins/dna_export/src/McaEditorContext.cpp
@@ -56,7 +56,7 @@ void McaEditorContext::initViewContext(GObjectView *view) {
     addViewAction(action);
 }
 
-void McaEditorContext::buildMenu(GObjectView *view, QMenu *menu) {
+void McaEditorContext::buildStaticOrContextMenu(GObjectView *view, QMenu *menu) {
     McaEditor *mcaEditor = qobject_cast<McaEditor *>(view);
     SAFE_POINT(NULL != mcaEditor, "Mca Editor is NULL", );
     SAFE_POINT(NULL != menu, "Menu is NULL", );

--- a/src/plugins/dna_export/src/McaEditorContext.h
+++ b/src/plugins/dna_export/src/McaEditorContext.h
@@ -35,8 +35,8 @@ private slots:
     void sl_exportMca2Msa();
 
 private:
-    void initViewContext(GObjectView *view);
-    void buildMenu(GObjectView *view, QMenu *menu);
+    void initViewContext(GObjectView *view) override;
+    void buildStaticOrContextMenu(GObjectView *view, QMenu *menu) override;
 };
 
 }    // namespace U2

--- a/src/plugins/dna_flexibility/src/DNAFlexPlugin.h
+++ b/src/plugins/dna_flexibility/src/DNAFlexPlugin.h
@@ -53,7 +53,7 @@ private slots:
 private:
     GSequenceGraphFactory *graphFactory;
 
-    virtual void initViewContext(GObjectView *view);
+    void initViewContext(GObjectView *view) override;
 };
 
 }    // namespace U2

--- a/src/plugins/dna_graphpack/src/DNAGraphPackPlugin.h
+++ b/src/plugins/dna_graphpack/src/DNAGraphPackPlugin.h
@@ -61,7 +61,7 @@ public:
 private:
     QList<GSequenceGraphFactory *> graphFactories;
 
-    virtual void initViewContext(GObjectView *view);
+    void initViewContext(GObjectView *view) override;
 
 private slots:
     void sl_sequenceWidgetAdded(ADVSequenceWidget *);

--- a/src/plugins/dna_stat/src/DNAStatPlugin.cpp
+++ b/src/plugins/dna_stat/src/DNAStatPlugin.cpp
@@ -76,7 +76,7 @@ void DNAStatMSAEditorContext::initViewContext(GObjectView *v) {
     addViewAction(profileAction);
 }
 
-void DNAStatMSAEditorContext::buildMenu(GObjectView *v, QMenu *m) {
+void DNAStatMSAEditorContext::buildStaticOrContextMenu(GObjectView *v, QMenu *m) {
     MSAEditor *msaed = qobject_cast<MSAEditor *>(v);
     if (msaed != NULL && !msaed->getMaObject())
         return;
@@ -113,7 +113,7 @@ void DistanceMatrixMSAEditorContext::initViewContext(GObjectView *v) {
     addViewAction(profileAction);
 }
 
-void DistanceMatrixMSAEditorContext::buildMenu(GObjectView *v, QMenu *m) {
+void DistanceMatrixMSAEditorContext::buildStaticOrContextMenu(GObjectView *v, QMenu *m) {
     MSAEditor *msaed = qobject_cast<MSAEditor *>(v);
     if (msaed != NULL && !msaed->getMaObject())
         return;

--- a/src/plugins/dna_stat/src/DNAStatPlugin.h
+++ b/src/plugins/dna_stat/src/DNAStatPlugin.h
@@ -45,10 +45,10 @@ public:
 
 protected slots:
     void sl_showMSAProfileDialog();
-    void buildMenu(GObjectView *v, QMenu *m);
+    void buildStaticOrContextMenu(GObjectView *view, QMenu *menu) override;
 
 protected:
-    virtual void initViewContext(GObjectView *view);
+    void initViewContext(GObjectView *view) override;
 };
 
 class DistanceMatrixMSAEditorContext : public GObjectViewWindowContext {
@@ -58,10 +58,10 @@ public:
 
 protected slots:
     void sl_showDistanceMatrixDialog();
-    void buildMenu(GObjectView *v, QMenu *m);
+    void buildStaticOrContextMenu(GObjectView *view, QMenu *menu) override;
 
 protected:
-    virtual void initViewContext(GObjectView *view);
+    void initViewContext(GObjectView *view) override;
 };
 
 }    // namespace U2

--- a/src/plugins/dotplot/src/DotPlotPlugin.cpp
+++ b/src/plugins/dotplot/src/DotPlotPlugin.cpp
@@ -264,7 +264,7 @@ DotPlotSplitter *DotPlotViewContext::getView(GObjectView *view, bool create) {
 }
 
 // context menu opened
-void DotPlotViewContext::buildMenu(U2::GObjectView *v, QMenu *m) {
+void DotPlotViewContext::buildStaticOrContextMenu(GObjectView *v, QMenu *m) {
     QList<QObject *> resources = viewResources.value(v);
     foreach (QObject *r, resources) {
         DotPlotSplitter *dotPlotView = qobject_cast<DotPlotSplitter *>(r);

--- a/src/plugins/dotplot/src/DotPlotPlugin.h
+++ b/src/plugins/dotplot/src/DotPlotPlugin.h
@@ -50,10 +50,10 @@ public:
     DotPlotViewContext(QObject *p);
 
 protected:
-    virtual void initViewContext(GObjectView *view);
+    void initViewContext(GObjectView *view) override;
 
     void createSplitter();
-    void buildMenu(GObjectView *v, QMenu *m);
+    void buildStaticOrContextMenu(GObjectView *view, QMenu *menu) override;
     DotPlotSplitter *getView(GObjectView *view, bool create);
     void removeDotPlotView(GObjectView *view);
 

--- a/src/plugins/enzymes/src/EnzymesPlugin.cpp
+++ b/src/plugins/enzymes/src/EnzymesPlugin.cpp
@@ -209,7 +209,7 @@ void EnzymesADVContext::sl_search() {
 #define PRIMER_ANNOTATION_GROUP_NAME "pair"
 #define PRIMER_ANNOTATION_NAME "primer"
 
-void EnzymesADVContext::buildMenu(GObjectView *v, QMenu *m) {
+void EnzymesADVContext::buildMenu(GObjectView *v, QMenu *m, const QString &) {
     AnnotatedDNAView *av = qobject_cast<AnnotatedDNAView *>(v);
     SAFE_POINT(NULL != av, "Invalid sequence view", );
     CHECK(av->getActiveSequenceContext()->getAlphabet()->isNucleic(), );

--- a/src/plugins/enzymes/src/EnzymesPlugin.cpp
+++ b/src/plugins/enzymes/src/EnzymesPlugin.cpp
@@ -207,9 +207,8 @@ void EnzymesADVContext::sl_search() {
 
 // TODO: move definitions to core
 #define PRIMER_ANNOTATION_GROUP_NAME "pair"
-#define PRIMER_ANNOTATION_NAME "primer"
 
-void EnzymesADVContext::buildMenu(GObjectView *v, QMenu *m, const QString &) {
+void EnzymesADVContext::buildStaticOrContextMenu(GObjectView *v, QMenu *m) {
     AnnotatedDNAView *av = qobject_cast<AnnotatedDNAView *>(v);
     SAFE_POINT(NULL != av, "Invalid sequence view", );
     CHECK(av->getActiveSequenceContext()->getAlphabet()->isNucleic(), );

--- a/src/plugins/enzymes/src/EnzymesPlugin.h
+++ b/src/plugins/enzymes/src/EnzymesPlugin.h
@@ -59,8 +59,10 @@ protected slots:
     void sl_createPCRProduct();
 
 protected:
-    virtual void buildMenu(GObjectView *v, QMenu *m);
-    virtual void initViewContext(GObjectView *view);
+    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
+
+    void initViewContext(GObjectView *view) override;
+
     QList<QAction *> cloningActions;
 };
 

--- a/src/plugins/enzymes/src/EnzymesPlugin.h
+++ b/src/plugins/enzymes/src/EnzymesPlugin.h
@@ -59,7 +59,7 @@ protected slots:
     void sl_createPCRProduct();
 
 protected:
-    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
+    void buildStaticOrContextMenu(GObjectView *view, QMenu *menu) override;
 
     void initViewContext(GObjectView *view) override;
 

--- a/src/plugins/external_tool_support/src/blast_plus/BlastPlusSupport.cpp
+++ b/src/plugins/external_tool_support/src/blast_plus/BlastPlusSupport.cpp
@@ -287,7 +287,7 @@ static void setActionFontItalic(QAction *action, bool italic) {
     action->setFont(font);
 }
 
-void BlastPlusSupportContext::buildMenu(GObjectView *view, QMenu *m, const QString &) {
+void BlastPlusSupportContext::buildStaticOrContextMenu(GObjectView *view, QMenu *m) {
     QList<GObjectViewAction *> actions = getViewActions(view);
     QMenu *analyseMenu = GUIUtils::findSubMenu(m, ADV_MENU_ANALYSE);
     SAFE_POINT(analyseMenu != NULL, "analyseMenu", );

--- a/src/plugins/external_tool_support/src/blast_plus/BlastPlusSupport.cpp
+++ b/src/plugins/external_tool_support/src/blast_plus/BlastPlusSupport.cpp
@@ -287,7 +287,7 @@ static void setActionFontItalic(QAction *action, bool italic) {
     action->setFont(font);
 }
 
-void BlastPlusSupportContext::buildMenu(GObjectView *view, QMenu *m) {
+void BlastPlusSupportContext::buildMenu(GObjectView *view, QMenu *m, const QString &) {
     QList<GObjectViewAction *> actions = getViewActions(view);
     QMenu *analyseMenu = GUIUtils::findSubMenu(m, ADV_MENU_ANALYSE);
     SAFE_POINT(analyseMenu != NULL, "analyseMenu", );

--- a/src/plugins/external_tool_support/src/blast_plus/BlastPlusSupport.h
+++ b/src/plugins/external_tool_support/src/blast_plus/BlastPlusSupport.h
@@ -66,8 +66,8 @@ protected slots:
     void sl_fetchSequenceById();
 
 protected:
-    virtual void initViewContext(GObjectView *view);
-    virtual void buildMenu(GObjectView *view, QMenu *m);
+    void initViewContext(GObjectView *view) override;
+    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
 
 private:
     QStringList toolIdList;

--- a/src/plugins/external_tool_support/src/blast_plus/BlastPlusSupport.h
+++ b/src/plugins/external_tool_support/src/blast_plus/BlastPlusSupport.h
@@ -67,7 +67,7 @@ protected slots:
 
 protected:
     void initViewContext(GObjectView *view) override;
-    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
+    void buildStaticOrContextMenu(GObjectView *view, QMenu *menu) override;
 
 private:
     QStringList toolIdList;

--- a/src/plugins/external_tool_support/src/clustalo/ClustalOSupport.cpp
+++ b/src/plugins/external_tool_support/src/clustalo/ClustalOSupport.cpp
@@ -139,7 +139,7 @@ void ClustalOSupportContext::initViewContext(GObjectView *view) {
     connect(alignAction, SIGNAL(triggered()), SLOT(sl_align_with_ClustalO()));
 }
 
-void ClustalOSupportContext::buildMenu(GObjectView *view, QMenu *m, const QString &) {
+void ClustalOSupportContext::buildStaticOrContextMenu(GObjectView *view, QMenu *m) {
     QList<GObjectViewAction *> actions = getViewActions(view);
     QMenu *alignMenu = GUIUtils::findSubMenu(m, MSAE_MENU_ALIGN);
     SAFE_POINT(alignMenu != NULL, "alignMenu", );

--- a/src/plugins/external_tool_support/src/clustalo/ClustalOSupport.cpp
+++ b/src/plugins/external_tool_support/src/clustalo/ClustalOSupport.cpp
@@ -139,7 +139,7 @@ void ClustalOSupportContext::initViewContext(GObjectView *view) {
     connect(alignAction, SIGNAL(triggered()), SLOT(sl_align_with_ClustalO()));
 }
 
-void ClustalOSupportContext::buildMenu(GObjectView *view, QMenu *m) {
+void ClustalOSupportContext::buildMenu(GObjectView *view, QMenu *m, const QString &) {
     QList<GObjectViewAction *> actions = getViewActions(view);
     QMenu *alignMenu = GUIUtils::findSubMenu(m, MSAE_MENU_ALIGN);
     SAFE_POINT(alignMenu != NULL, "alignMenu", );

--- a/src/plugins/external_tool_support/src/clustalo/ClustalOSupport.h
+++ b/src/plugins/external_tool_support/src/clustalo/ClustalOSupport.h
@@ -59,7 +59,7 @@ protected slots:
 protected:
     void initViewContext(GObjectView *view) override;
     
-    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
+    void buildStaticOrContextMenu(GObjectView *view, QMenu *menu) override;
 };
 
 }    // namespace U2

--- a/src/plugins/external_tool_support/src/clustalo/ClustalOSupport.h
+++ b/src/plugins/external_tool_support/src/clustalo/ClustalOSupport.h
@@ -57,8 +57,9 @@ protected slots:
     void sl_align_with_ClustalO();
 
 protected:
-    virtual void initViewContext(GObjectView *view);
-    virtual void buildMenu(GObjectView *view, QMenu *m);
+    void initViewContext(GObjectView *view) override;
+    
+    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
 };
 
 }    // namespace U2

--- a/src/plugins/external_tool_support/src/clustalw/ClustalWSupport.cpp
+++ b/src/plugins/external_tool_support/src/clustalw/ClustalWSupport.cpp
@@ -139,7 +139,7 @@ void ClustalWSupportContext::initViewContext(GObjectView *view) {
     connect(alignAction, SIGNAL(triggered()), SLOT(sl_align_with_ClustalW()));
 }
 
-void ClustalWSupportContext::buildMenu(GObjectView *view, QMenu *m) {
+void ClustalWSupportContext::buildMenu(GObjectView *view, QMenu *m, const QString &) {
     QList<GObjectViewAction *> actions = getViewActions(view);
     QMenu *alignMenu = GUIUtils::findSubMenu(m, MSAE_MENU_ALIGN);
     SAFE_POINT(alignMenu != NULL, "alignMenu", );

--- a/src/plugins/external_tool_support/src/clustalw/ClustalWSupport.cpp
+++ b/src/plugins/external_tool_support/src/clustalw/ClustalWSupport.cpp
@@ -139,7 +139,7 @@ void ClustalWSupportContext::initViewContext(GObjectView *view) {
     connect(alignAction, SIGNAL(triggered()), SLOT(sl_align_with_ClustalW()));
 }
 
-void ClustalWSupportContext::buildMenu(GObjectView *view, QMenu *m, const QString &) {
+void ClustalWSupportContext::buildStaticOrContextMenu(GObjectView *view, QMenu *m) {
     QList<GObjectViewAction *> actions = getViewActions(view);
     QMenu *alignMenu = GUIUtils::findSubMenu(m, MSAE_MENU_ALIGN);
     SAFE_POINT(alignMenu != NULL, "alignMenu", );

--- a/src/plugins/external_tool_support/src/clustalw/ClustalWSupport.h
+++ b/src/plugins/external_tool_support/src/clustalw/ClustalWSupport.h
@@ -57,8 +57,9 @@ protected slots:
     void sl_align_with_ClustalW();
 
 protected:
-    virtual void initViewContext(GObjectView *view);
-    virtual void buildMenu(GObjectView *view, QMenu *m);
+    void initViewContext(GObjectView *view) override;
+
+    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
 };
 
 }    // namespace U2

--- a/src/plugins/external_tool_support/src/clustalw/ClustalWSupport.h
+++ b/src/plugins/external_tool_support/src/clustalw/ClustalWSupport.h
@@ -59,7 +59,7 @@ protected slots:
 protected:
     void initViewContext(GObjectView *view) override;
 
-    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
+    void buildStaticOrContextMenu(GObjectView *view, QMenu *menu) override;
 };
 
 }    // namespace U2

--- a/src/plugins/external_tool_support/src/hmmer/HmmerSupport.cpp
+++ b/src/plugins/external_tool_support/src/hmmer/HmmerSupport.cpp
@@ -287,7 +287,7 @@ void HmmerMsaEditorContext::initViewContext(GObjectView *view) {
     addViewAction(action);
 }
 
-void HmmerMsaEditorContext::buildMenu(GObjectView *view, QMenu *menu) {
+void HmmerMsaEditorContext::buildStaticOrContextMenu(GObjectView *view, QMenu *menu) {
     MSAEditor *msaEditor = qobject_cast<MSAEditor *>(view);
     SAFE_POINT(msaEditor != nullptr, "Msa Editor is NULL", );
     SAFE_POINT(menu != nullptr, "Menu is NULL", );

--- a/src/plugins/external_tool_support/src/hmmer/HmmerSupport.h
+++ b/src/plugins/external_tool_support/src/hmmer/HmmerSupport.h
@@ -64,8 +64,8 @@ private slots:
     void sl_build();
 
 private:
-    void initViewContext(GObjectView *view);
-    void buildMenu(GObjectView *view, QMenu *menu);
+    void initViewContext(GObjectView *view) override;
+    void buildStaticOrContextMenu(GObjectView *view, QMenu *menu) override;
 };
 
 class HmmerAdvContext : public GObjectViewWindowContext {
@@ -77,7 +77,7 @@ private slots:
     void sl_search();
 
 private:
-    void initViewContext(GObjectView *view);
+    void initViewContext(GObjectView *view) override;
 
     QWidget *getParentWidget(QObject *sender);
     U2SequenceObject *getSequenceInFocus(QObject *sender);

--- a/src/plugins/external_tool_support/src/mafft/MAFFTSupport.cpp
+++ b/src/plugins/external_tool_support/src/mafft/MAFFTSupport.cpp
@@ -137,7 +137,7 @@ void MAFFTSupportContext::initViewContext(GObjectView *view) {
     connect(alignAction, SIGNAL(triggered()), SLOT(sl_align_with_MAFFT()));
 }
 
-void MAFFTSupportContext::buildMenu(GObjectView *view, QMenu *m) {
+void MAFFTSupportContext::buildMenu(GObjectView *view, QMenu *m, const QString &) {
     QList<GObjectViewAction *> actions = getViewActions(view);
     QMenu *alignMenu = GUIUtils::findSubMenu(m, MSAE_MENU_ALIGN);
     SAFE_POINT(alignMenu != NULL, "alignMenu", );

--- a/src/plugins/external_tool_support/src/mafft/MAFFTSupport.cpp
+++ b/src/plugins/external_tool_support/src/mafft/MAFFTSupport.cpp
@@ -137,7 +137,7 @@ void MAFFTSupportContext::initViewContext(GObjectView *view) {
     connect(alignAction, SIGNAL(triggered()), SLOT(sl_align_with_MAFFT()));
 }
 
-void MAFFTSupportContext::buildMenu(GObjectView *view, QMenu *m, const QString &) {
+void MAFFTSupportContext::buildStaticOrContextMenu(GObjectView *view, QMenu *m) {
     QList<GObjectViewAction *> actions = getViewActions(view);
     QMenu *alignMenu = GUIUtils::findSubMenu(m, MSAE_MENU_ALIGN);
     SAFE_POINT(alignMenu != NULL, "alignMenu", );

--- a/src/plugins/external_tool_support/src/mafft/MAFFTSupport.h
+++ b/src/plugins/external_tool_support/src/mafft/MAFFTSupport.h
@@ -35,7 +35,7 @@ class MAFFTSupport : public ExternalTool {
 public:
     MAFFTSupport();
 
-    GObjectViewWindowContext *getViewContext() const{
+    GObjectViewWindowContext *getViewContext() const {
         return viewCtx;
     }
 
@@ -57,8 +57,9 @@ protected slots:
     void sl_align_with_MAFFT();
 
 protected:
-    virtual void initViewContext(GObjectView *view);
-    virtual void buildMenu(GObjectView *view, QMenu *m);
+    void initViewContext(GObjectView *view) override;
+
+    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
 };
 
 }    // namespace U2

--- a/src/plugins/external_tool_support/src/mafft/MAFFTSupport.h
+++ b/src/plugins/external_tool_support/src/mafft/MAFFTSupport.h
@@ -59,7 +59,7 @@ protected slots:
 protected:
     void initViewContext(GObjectView *view) override;
 
-    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
+    void buildStaticOrContextMenu(GObjectView *view, QMenu *menu) override;
 };
 
 }    // namespace U2

--- a/src/plugins/external_tool_support/src/spidey/SpideySupport.cpp
+++ b/src/plugins/external_tool_support/src/spidey/SpideySupport.cpp
@@ -116,7 +116,7 @@ void SpideySupportContext::initViewContext(GObjectView *view) {
     connect(alignAction, SIGNAL(triggered()), SLOT(sl_align_with_Spidey()));
 }
 
-void SpideySupportContext::buildMenu(GObjectView *view, QMenu *m) {
+void SpideySupportContext::buildMenu(GObjectView *view, QMenu *m, const QString &) {
     QList<GObjectViewAction *> actions = getViewActions(view);
     QMenu *alignMenu = GUIUtils::findSubMenu(m, ADV_MENU_ALIGN);
     SAFE_POINT(alignMenu != NULL, "alignMenu", );

--- a/src/plugins/external_tool_support/src/spidey/SpideySupport.cpp
+++ b/src/plugins/external_tool_support/src/spidey/SpideySupport.cpp
@@ -116,7 +116,7 @@ void SpideySupportContext::initViewContext(GObjectView *view) {
     connect(alignAction, SIGNAL(triggered()), SLOT(sl_align_with_Spidey()));
 }
 
-void SpideySupportContext::buildMenu(GObjectView *view, QMenu *m, const QString &) {
+void SpideySupportContext::buildStaticOrContextMenu(GObjectView *view, QMenu *m) {
     QList<GObjectViewAction *> actions = getViewActions(view);
     QMenu *alignMenu = GUIUtils::findSubMenu(m, ADV_MENU_ALIGN);
     SAFE_POINT(alignMenu != NULL, "alignMenu", );

--- a/src/plugins/external_tool_support/src/spidey/SpideySupport.h
+++ b/src/plugins/external_tool_support/src/spidey/SpideySupport.h
@@ -57,7 +57,7 @@ protected slots:
 protected:
     void initViewContext(GObjectView *view) override;
 
-    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
+    void buildStaticOrContextMenu(GObjectView *view, QMenu *menu) override;
 };
 
 }    // namespace U2

--- a/src/plugins/external_tool_support/src/spidey/SpideySupport.h
+++ b/src/plugins/external_tool_support/src/spidey/SpideySupport.h
@@ -55,8 +55,9 @@ protected slots:
     void sl_align_with_Spidey();
 
 protected:
-    virtual void initViewContext(GObjectView *view);
-    virtual void buildMenu(GObjectView *view, QMenu *m);
+    void initViewContext(GObjectView *view) override;
+
+    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
 };
 
 }    // namespace U2

--- a/src/plugins/external_tool_support/src/tcoffee/TCoffeeSupport.cpp
+++ b/src/plugins/external_tool_support/src/tcoffee/TCoffeeSupport.cpp
@@ -124,7 +124,7 @@ void TCoffeeSupportContext::initViewContext(GObjectView *view) {
     connect(alignAction, SIGNAL(triggered()), SLOT(sl_align_with_TCoffee()));
 }
 
-void TCoffeeSupportContext::buildMenu(GObjectView *view, QMenu *m, const QString &) {
+void TCoffeeSupportContext::buildStaticOrContextMenu(GObjectView *view, QMenu *m) {
     QList<GObjectViewAction *> actions = getViewActions(view);
     QMenu *alignMenu = GUIUtils::findSubMenu(m, MSAE_MENU_ALIGN);
     SAFE_POINT(alignMenu != nullptr, "alignMenu", );

--- a/src/plugins/external_tool_support/src/tcoffee/TCoffeeSupport.cpp
+++ b/src/plugins/external_tool_support/src/tcoffee/TCoffeeSupport.cpp
@@ -124,7 +124,7 @@ void TCoffeeSupportContext::initViewContext(GObjectView *view) {
     connect(alignAction, SIGNAL(triggered()), SLOT(sl_align_with_TCoffee()));
 }
 
-void TCoffeeSupportContext::buildMenu(GObjectView *view, QMenu *m) {
+void TCoffeeSupportContext::buildMenu(GObjectView *view, QMenu *m, const QString &) {
     QList<GObjectViewAction *> actions = getViewActions(view);
     QMenu *alignMenu = GUIUtils::findSubMenu(m, MSAE_MENU_ALIGN);
     SAFE_POINT(alignMenu != nullptr, "alignMenu", );

--- a/src/plugins/external_tool_support/src/tcoffee/TCoffeeSupport.h
+++ b/src/plugins/external_tool_support/src/tcoffee/TCoffeeSupport.h
@@ -59,7 +59,7 @@ protected slots:
 protected:
     void initViewContext(GObjectView *view) override;
 
-    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
+    void buildStaticOrContextMenu(GObjectView *view, QMenu *menu) override;
 };
 
 }    // namespace U2

--- a/src/plugins/external_tool_support/src/tcoffee/TCoffeeSupport.h
+++ b/src/plugins/external_tool_support/src/tcoffee/TCoffeeSupport.h
@@ -57,8 +57,9 @@ protected slots:
     void sl_align_with_TCoffee();
 
 protected:
-    virtual void initViewContext(GObjectView *view);
-    virtual void buildMenu(GObjectView *view, QMenu *m);
+    void initViewContext(GObjectView *view) override;
+
+    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
 };
 
 }    // namespace U2

--- a/src/plugins/orf_marker/src/ORFMarkerPlugin.h
+++ b/src/plugins/orf_marker/src/ORFMarkerPlugin.h
@@ -49,7 +49,7 @@ protected slots:
     void sl_showDialog();
 
 protected:
-    virtual void initViewContext(GObjectView *view);
+    void initViewContext(GObjectView *view) override;
 };
 
 class ORFMarkerTests {

--- a/src/plugins/query_designer/src/QueryDesignerPlugin.h
+++ b/src/plugins/query_designer/src/QueryDesignerPlugin.h
@@ -51,7 +51,8 @@ public:
     QueryDesignerViewContext(QObject *p);
 
 protected:
-    virtual void initViewContext(GObjectView *view);
+    void initViewContext(GObjectView *view) override;
+
 private slots:
     void sl_showDialog();
 };

--- a/src/plugins/remote_blast/src/RemoteBLASTPlugin.h
+++ b/src/plugins/remote_blast/src/RemoteBLASTPlugin.h
@@ -53,7 +53,8 @@ public:
     RemoteBLASTViewContext(QObject *p);
 
 protected:
-    virtual void initViewContext(GObjectView *view);
+    void initViewContext(GObjectView *view) override;
+
 private slots:
     void sl_showDialog();
 };

--- a/src/plugins/repeat_finder/src/RepeatFinderPlugin.h
+++ b/src/plugins/repeat_finder/src/RepeatFinderPlugin.h
@@ -47,7 +47,7 @@ protected slots:
     void sl_showTandemDialog();
 
 protected:
-    virtual void initViewContext(GObjectView *view);
+    void initViewContext(GObjectView *view) override;
 };
 
 }    // namespace U2

--- a/src/plugins/smith_waterman/src/SWAlgorithmPlugin.h
+++ b/src/plugins/smith_waterman/src/SWAlgorithmPlugin.h
@@ -64,7 +64,7 @@ protected slots:
     void sl_search();
 
 protected:
-    virtual void initViewContext(GObjectView *view);
+    void initViewContext(GObjectView *view) override;
 
 private:
     SWDialogConfig dialogConfig;

--- a/src/plugins/weight_matrix/src/WeightMatrixPlugin.h
+++ b/src/plugins/weight_matrix/src/WeightMatrixPlugin.h
@@ -54,7 +54,7 @@ protected slots:
     void sl_search();
 
 protected:
-    virtual void initViewContext(GObjectView *view);
+    void initViewContext(GObjectView *view) override;
 };
 
 class WeightMatrixAlgorithmTests {

--- a/src/plugins_3rdparty/hmm2/src/uHMMPlugin.cpp
+++ b/src/plugins_3rdparty/hmm2/src/uHMMPlugin.cpp
@@ -212,7 +212,7 @@ void HMMMSAEditorContext::initViewContext(GObjectView *view) {
     addViewAction(a);
 }
 
-void HMMMSAEditorContext::buildMenu(GObjectView *v, QMenu *m, const QString &) {
+void HMMMSAEditorContext::buildStaticOrContextMenu(GObjectView *v, QMenu *m) {
     MSAEditor *msaed = qobject_cast<MSAEditor *>(v);
     SAFE_POINT(NULL != msaed && NULL != m, "Invalid GObjectVeiw or QMenu", );
     CHECK(msaed->getMaObject() != NULL, );

--- a/src/plugins_3rdparty/hmm2/src/uHMMPlugin.cpp
+++ b/src/plugins_3rdparty/hmm2/src/uHMMPlugin.cpp
@@ -19,6 +19,8 @@
  * MA 02110-1301, USA.
  */
 
+#include "uHMMPlugin.h"
+
 #include <QAction>
 #include <QMenu>
 #include <QMessageBox>
@@ -32,6 +34,7 @@
 #include <U2Core/IOAdapter.h>
 #include <U2Core/L10n.h>
 #include <U2Core/MultipleSequenceAlignmentObject.h>
+#include <U2Core/QObjectScopedPointer.h>
 #include <U2Core/Task.h>
 #include <U2Core/U2OpStatusUtils.h>
 
@@ -40,7 +43,6 @@
 #include <U2Gui/ObjectViewModel.h>
 #include <U2Gui/ProjectView.h>
 #include <U2Gui/ToolsMenu.h>
-#include <U2Core/QObjectScopedPointer.h>
 
 #include <U2Test/GTestFrameworkComponents.h>
 
@@ -55,7 +57,6 @@
 #include "HMMIOWorker.h"
 #include "TaskLocalStorage.h"
 #include "hmmer2/funcs.h"
-#include "uHMMPlugin.h"
 #include "u_build/HMMBuildDialogController.h"
 #include "u_calibrate/HMMCalibrateDialogController.h"
 #include "u_search/HMMSearchDialogController.h"
@@ -66,24 +67,24 @@ Q_DECLARE_METATYPE(QMenu *);
 
 namespace U2 {
 
-extern "C" Q_DECL_EXPORT Plugin* U2_PLUGIN_INIT_FUNC() {
+extern "C" Q_DECL_EXPORT Plugin *U2_PLUGIN_INIT_FUNC() {
     return new uHMMPlugin();
 }
 
-uHMMPlugin::uHMMPlugin() : Plugin(tr("HMM2"), tr("Based on HMMER 2.3.2 package. Biological sequence analysis using profile hidden Markov models")), ctxMSA(NULL), ctxADV(NULL)
-{
+uHMMPlugin::uHMMPlugin()
+    : Plugin(tr("HMM2"), tr("Based on HMMER 2.3.2 package. Biological sequence analysis using profile hidden Markov models")), ctxMSA(NULL), ctxADV(NULL) {
     if (AppContext::getMainWindow()) {
-        QAction* buildAction = new QAction(tr("Build HMM2 profile..."), this);
+        QAction *buildAction = new QAction(tr("Build HMM2 profile..."), this);
         buildAction->setObjectName(ToolsMenu::HMMER_BUILD2);
         connect(buildAction, SIGNAL(triggered()), SLOT(sl_build()));
         ToolsMenu::addAction(ToolsMenu::HMMER_MENU, buildAction);
 
-        QAction* calibrateAction = new QAction(tr("Calibrate profile with HMMER2..."), this);
+        QAction *calibrateAction = new QAction(tr("Calibrate profile with HMMER2..."), this);
         calibrateAction->setObjectName(ToolsMenu::HMMER_CALIBRATE2);
         connect(calibrateAction, SIGNAL(triggered()), SLOT(sl_calibrate()));
         ToolsMenu::addAction(ToolsMenu::HMMER_MENU, calibrateAction);
 
-        QAction* searchAction = new QAction(tr("Search with HMMER2..."), this);
+        QAction *searchAction = new QAction(tr("Search with HMMER2..."), this);
         searchAction->setObjectName(ToolsMenu::HMMER_SEARCH2);
         connect(searchAction, SIGNAL(triggered()), SLOT(sl_search()));
         ToolsMenu::addAction(ToolsMenu::HMMER_MENU, searchAction);
@@ -96,18 +97,18 @@ uHMMPlugin::uHMMPlugin() : Plugin(tr("HMM2"), tr("Based on HMMER 2.3.2 package. 
     }
     LocalWorkflow::HMMLib::init();
 
-    QDActorPrototypeRegistry* qdpr = AppContext::getQDActorProtoRegistry();
+    QDActorPrototypeRegistry *qdpr = AppContext::getQDActorProtoRegistry();
     qdpr->registerProto(new HMM2QDActorPrototype());
 
     //uHMMER Tests
-    GTestFormatRegistry* tfr = AppContext::getTestFramework()->getTestFormatRegistry();
-    XMLTestFormat *xmlTestFormat = qobject_cast<XMLTestFormat*>(tfr->findFormat("XML"));
-    assert(xmlTestFormat!=NULL);
+    GTestFormatRegistry *tfr = AppContext::getTestFramework()->getTestFormatRegistry();
+    XMLTestFormat *xmlTestFormat = qobject_cast<XMLTestFormat *>(tfr->findFormat("XML"));
+    assert(xmlTestFormat != NULL);
 
-    GAutoDeleteList<XMLTestFactory>* l = new GAutoDeleteList<XMLTestFactory>(this);
+    GAutoDeleteList<XMLTestFactory> *l = new GAutoDeleteList<XMLTestFactory>(this);
     l->qlist = UHMMERTests::createTestFactories();
 
-    foreach(XMLTestFactory* f, l->qlist) {
+    foreach (XMLTestFactory *f, l->qlist) {
         bool res = xmlTestFormat->registerTestFactory(f);
         assert(res);
         Q_UNUSED(res);
@@ -118,9 +119,8 @@ uHMMPlugin::~uHMMPlugin() {
     LocalWorkflow::HMMLib::cleanup();
 }
 
-
 void uHMMPlugin::sl_calibrate() {
-    QWidget *p = (QWidget*)AppContext::getMainWindow()->getQMainWindow();
+    QWidget *p = (QWidget *)AppContext::getMainWindow()->getQMainWindow();
     QObjectScopedPointer<HMMCalibrateDialogController> d = new HMMCalibrateDialogController(p);
     d->exec();
 }
@@ -130,22 +130,22 @@ void uHMMPlugin::sl_build() {
 
     //try to find alignment check that MSA Editor is active
     QString profileName;
-    MWMDIWindow* w = AppContext::getMainWindow()->getMDIManager()->getActiveWindow();
-    if (w!=NULL) {
-        GObjectViewWindow* ow = qobject_cast<GObjectViewWindow*>(w);
-        if (ow!=NULL) {
-            GObjectView* ov = ow->getObjectView();
-            MSAEditor* av = qobject_cast<MSAEditor*>(ov);
-            if (av!=NULL) {
-                MultipleSequenceAlignmentObject* maObj = av->getMaObject();
-                if (maObj!=NULL) {
+    MWMDIWindow *w = AppContext::getMainWindow()->getMDIManager()->getActiveWindow();
+    if (w != NULL) {
+        GObjectViewWindow *ow = qobject_cast<GObjectViewWindow *>(w);
+        if (ow != NULL) {
+            GObjectView *ov = ow->getObjectView();
+            MSAEditor *av = qobject_cast<MSAEditor *>(ov);
+            if (av != NULL) {
+                MultipleSequenceAlignmentObject *maObj = av->getMaObject();
+                if (maObj != NULL) {
                     ma = maObj->getMsaCopy();
                     profileName = maObj->getGObjectName() == MA_OBJECT_NAME ? maObj->getDocument()->getName() : maObj->getGObjectName();
                 }
             }
         }
     }
-    QWidget *p = (QWidget*)AppContext::getMainWindow()->getQMainWindow();
+    QWidget *p = (QWidget *)AppContext::getMainWindow()->getQMainWindow();
     QObjectScopedPointer<HMMBuildDialogController> d = new HMMBuildDialogController(profileName, ma, p);
     d->exec();
 }
@@ -155,16 +155,16 @@ void uHMMPlugin::sl_search() {
     //1. check that annotated DNA view is active
     //2. if not -> check that DNASequence object is selected in project view
 
-    U2SequenceObject* obj = NULL;
-    ADVSequenceObjectContext* seqCtx = NULL;
+    U2SequenceObject *obj = NULL;
+    ADVSequenceObjectContext *seqCtx = NULL;
 
-    MWMDIWindow* w = AppContext::getMainWindow()->getMDIManager()->getActiveWindow();
-    if (w!=NULL) {
-        GObjectViewWindow* ow = qobject_cast<GObjectViewWindow*>(w);
-        if (ow!=NULL) {
-            GObjectView* ov = ow->getObjectView();
-            AnnotatedDNAView* av = qobject_cast<AnnotatedDNAView*>(ov);
-            if (av!=NULL) {
+    MWMDIWindow *w = AppContext::getMainWindow()->getMDIManager()->getActiveWindow();
+    if (w != NULL) {
+        GObjectViewWindow *ow = qobject_cast<GObjectViewWindow *>(w);
+        if (ow != NULL) {
+            GObjectView *ov = ow->getObjectView();
+            AnnotatedDNAView *av = qobject_cast<AnnotatedDNAView *>(ov);
+            if (av != NULL) {
                 seqCtx = av->getActiveSequenceContext();
                 obj = seqCtx->getSequenceObject();
             }
@@ -172,67 +172,65 @@ void uHMMPlugin::sl_search() {
     }
 
     if (obj == NULL) {
-        ProjectView* pv = AppContext::getProjectView();
-        if (pv!=NULL) {
-            const GObjectSelection* sel = pv->getGObjectSelection();
-            GObject* o = sel->getSelectedObjects().size() == 1 ? sel->getSelectedObjects().first() : NULL;
-            obj = qobject_cast<U2SequenceObject*>(o);
+        ProjectView *pv = AppContext::getProjectView();
+        if (pv != NULL) {
+            const GObjectSelection *sel = pv->getGObjectSelection();
+            GObject *o = sel->getSelectedObjects().size() == 1 ? sel->getSelectedObjects().first() : NULL;
+            obj = qobject_cast<U2SequenceObject *>(o);
         }
     }
-    QWidget *p = (QWidget*)AppContext::getMainWindow()->getQMainWindow();
+    QWidget *p = (QWidget *)AppContext::getMainWindow()->getQMainWindow();
     if (obj == NULL) {
         QMessageBox::critical(p, tr("Error"), tr("Error! Select sequence in Project view or open sequence view."));
         return;
     }
-    if(seqCtx != NULL){
+    if (seqCtx != NULL) {
         QObjectScopedPointer<HMMSearchDialogController> d = new HMMSearchDialogController(seqCtx, p);
         d->exec();
-    }else{
+    } else {
         QObjectScopedPointer<HMMSearchDialogController> d = new HMMSearchDialogController(obj, p);
         d->exec();
     }
 }
 
-
 //////////////////////////////////////////////////////////////////////////
 // contexts
 
-HMMMSAEditorContext::HMMMSAEditorContext(QObject* p) : GObjectViewWindowContext(p, MsaEditorFactory::ID) {
+HMMMSAEditorContext::HMMMSAEditorContext(QObject *p)
+    : GObjectViewWindowContext(p, MsaEditorFactory::ID) {
 }
 
-
-void HMMMSAEditorContext::initViewContext(GObjectView* view) {
-    MSAEditor* msaed = qobject_cast<MSAEditor*>(view);
+void HMMMSAEditorContext::initViewContext(GObjectView *view) {
+    MSAEditor *msaed = qobject_cast<MSAEditor *>(view);
     SAFE_POINT(msaed != NULL, "Invalid GObjectView", );
     CHECK(msaed->getMaObject() != NULL, );
 
-    GObjectViewAction* a = new GObjectViewAction(this, view, tr("Build HMMER2 profile"));
+    GObjectViewAction *a = new GObjectViewAction(this, view, tr("Build HMMER2 profile"));
     a->setObjectName("Build HMMER2 profile");
     a->setIcon(QIcon(":/hmm2/images/hmmer_16.png"));
     connect(a, SIGNAL(triggered()), SLOT(sl_build()));
     addViewAction(a);
 }
 
-void HMMMSAEditorContext::buildMenu(GObjectView* v, QMenu* m) {
-    MSAEditor* msaed = qobject_cast<MSAEditor*>(v);
-    SAFE_POINT( NULL != msaed && NULL != m, "Invalid GObjectVeiw or QMenu", );
+void HMMMSAEditorContext::buildMenu(GObjectView *v, QMenu *m, const QString &) {
+    MSAEditor *msaed = qobject_cast<MSAEditor *>(v);
+    SAFE_POINT(NULL != msaed && NULL != m, "Invalid GObjectVeiw or QMenu", );
     CHECK(msaed->getMaObject() != NULL, );
 
-    QList<GObjectViewAction*> list = getViewActions(v);
-    assert(list.size()==1);
-    GObjectViewAction* a = list.first();
-    QMenu* aMenu = GUIUtils::findSubMenu(m, MSAE_MENU_ADVANCED);
+    QList<GObjectViewAction *> list = getViewActions(v);
+    assert(list.size() == 1);
+    GObjectViewAction *a = list.first();
+    QMenu *aMenu = GUIUtils::findSubMenu(m, MSAE_MENU_ADVANCED);
     SAFE_POINT(aMenu != NULL, "aMenu", );
     aMenu->addAction(a);
 }
 
-
 void HMMMSAEditorContext::sl_build() {
-    GObjectViewAction* action = qobject_cast<GObjectViewAction*>(sender());
-    assert(action!=NULL);
-    MSAEditor* ed = qobject_cast<MSAEditor*>(action->getObjectView());
-    assert(ed!=NULL);
-    MultipleSequenceAlignmentObject* obj = ed->getMaObject();
+    GObjectViewAction *action = qobject_cast<GObjectViewAction *>(sender());
+    assert(action != NULL);
+    MSAEditor *ed = qobject_cast<MSAEditor *>(action->getObjectView());
+    assert(ed != NULL);
+    MultipleSequenceAlignmentObject *obj = ed->getMaObject();
     if (obj) {
         QString profileName = obj->getGObjectName() == MA_OBJECT_NAME ? obj->getDocument()->getName() : obj->getGObjectName();
         QObjectScopedPointer<HMMBuildDialogController> d = new HMMBuildDialogController(profileName, obj->getMultipleAlignment());
@@ -241,29 +239,29 @@ void HMMMSAEditorContext::sl_build() {
     }
 }
 
-HMMADVContext::HMMADVContext(QObject* p) : GObjectViewWindowContext(p, ANNOTATED_DNA_VIEW_FACTORY_ID) {
-
+HMMADVContext::HMMADVContext(QObject *p)
+    : GObjectViewWindowContext(p, ANNOTATED_DNA_VIEW_FACTORY_ID) {
 }
 
-void HMMADVContext::initViewContext(GObjectView* view) {
-    AnnotatedDNAView* av = qobject_cast<AnnotatedDNAView*>(view);
-    ADVGlobalAction* a = new ADVGlobalAction(av, QIcon(":/hmm2/images/hmmer_16.png"), tr("Find HMM signals with HMMER2..."), 70);
+void HMMADVContext::initViewContext(GObjectView *view) {
+    AnnotatedDNAView *av = qobject_cast<AnnotatedDNAView *>(view);
+    ADVGlobalAction *a = new ADVGlobalAction(av, QIcon(":/hmm2/images/hmmer_16.png"), tr("Find HMM signals with HMMER2..."), 70);
     connect(a, SIGNAL(triggered()), SLOT(sl_search()));
 }
 
 void HMMADVContext::sl_search() {
-    GObjectViewAction* action = qobject_cast<GObjectViewAction*>(sender());
-    assert(action!=NULL);
-    AnnotatedDNAView* av = qobject_cast<AnnotatedDNAView*>(action->getObjectView());
-    assert(av!=NULL);
+    GObjectViewAction *action = qobject_cast<GObjectViewAction *>(sender());
+    assert(action != NULL);
+    AnnotatedDNAView *av = qobject_cast<AnnotatedDNAView *>(action->getObjectView());
+    assert(av != NULL);
     QWidget *p;
-    if (av->getWidget()){
+    if (av->getWidget()) {
         p = av->getWidget();
-    }else{
-        p = (QWidget*)AppContext::getMainWindow()->getQMainWindow();
+    } else {
+        p = (QWidget *)AppContext::getMainWindow()->getQMainWindow();
     }
-    ADVSequenceObjectContext* seqCtx = av->getActiveSequenceContext();
-    if(seqCtx == NULL) {
+    ADVSequenceObjectContext *seqCtx = av->getActiveSequenceContext();
+    if (seqCtx == NULL) {
         QMessageBox::critical(p, tr("Error"), tr("No sequences found"));
         return;
     }
@@ -271,4 +269,4 @@ void HMMADVContext::sl_search() {
     d->exec();
 }
 
-}   // namespace U2
+}    // namespace U2

--- a/src/plugins_3rdparty/hmm2/src/uHMMPlugin.h
+++ b/src/plugins_3rdparty/hmm2/src/uHMMPlugin.h
@@ -22,11 +22,12 @@
 #ifndef _U2_UHMMER_PLUGIN_H_
 #define _U2_UHMMER_PLUGIN_H_
 
-#include <U2Core/PluginModel.h>
-#include <U2Core/AppContext.h>
-#include <U2Gui/ObjectViewModel.h>
-
 #include <QMenu>
+
+#include <U2Core/AppContext.h>
+#include <U2Core/PluginModel.h>
+
+#include <U2Gui/ObjectViewModel.h>
 
 namespace U2 {
 
@@ -46,35 +47,35 @@ private slots:
     void sl_search();
 
 private:
-    HMMMSAEditorContext*    ctxMSA;
-    HMMADVContext*          ctxADV;
+    HMMMSAEditorContext *ctxMSA;
+    HMMADVContext *ctxADV;
 };
 
-class HMMMSAEditorContext: public GObjectViewWindowContext {
+class HMMMSAEditorContext : public GObjectViewWindowContext {
     Q_OBJECT
 public:
-    HMMMSAEditorContext(QObject* p);
+    HMMMSAEditorContext(QObject *p);
 
 protected slots:
     void sl_build();
 
 protected:
-    virtual void initViewContext(GObjectView* view);
-    virtual void buildMenu(GObjectView* v, QMenu* m);
+    void initViewContext(GObjectView *view) override;
+    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
 };
 
-class HMMADVContext: public GObjectViewWindowContext {
+class HMMADVContext : public GObjectViewWindowContext {
     Q_OBJECT
 public:
-    HMMADVContext(QObject* p);
+    HMMADVContext(QObject *p);
 
 protected slots:
     void sl_search();
 
 protected:
-    virtual void initViewContext(GObjectView* view);
+    void initViewContext(GObjectView *view) override;
 };
 
-} //namespace
+}    // namespace U2
 
 #endif

--- a/src/plugins_3rdparty/hmm2/src/uHMMPlugin.h
+++ b/src/plugins_3rdparty/hmm2/src/uHMMPlugin.h
@@ -61,7 +61,7 @@ protected slots:
 
 protected:
     void initViewContext(GObjectView *view) override;
-    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
+    void buildStaticOrContextMenu(GObjectView *view, QMenu *menu) override;
 };
 
 class HMMADVContext : public GObjectViewWindowContext {

--- a/src/plugins_3rdparty/kalign/src/KalignPlugin.cpp
+++ b/src/plugins_3rdparty/kalign/src/KalignPlugin.cpp
@@ -19,6 +19,8 @@
  * MA 02110-1301, USA.
  */
 
+#include "KalignPlugin.h"
+
 #include <QDialog>
 #include <QMainWindow>
 
@@ -52,7 +54,6 @@
 
 #include "KalignConstants.h"
 #include "KalignDialogController.h"
-#include "KalignPlugin.h"
 #include "KalignTask.h"
 #include "KalignWorker.h"
 #include "PairwiseAlignmentHirschbergGUIExtensionFactory.h"
@@ -62,42 +63,40 @@
 
 namespace U2 {
 
-extern "C" Q_DECL_EXPORT Plugin* U2_PLUGIN_INIT_FUNC() {
-    KalignPlugin * plug = new KalignPlugin();
+extern "C" Q_DECL_EXPORT Plugin *U2_PLUGIN_INIT_FUNC() {
+    KalignPlugin *plug = new KalignPlugin();
     return plug;
 }
 
 KalignPlugin::KalignPlugin()
     : Plugin(tr("Kalign"),
-    tr("A port of Kalign package for multiple sequence alignment. Check http://msa.sbc.su.se for the original version")),
-    ctx(NULL)
-{
-
-    bool guiMode = AppContext::getMainWindow()!=NULL;
+             tr("A port of Kalign package for multiple sequence alignment. Check http://msa.sbc.su.se for the original version")),
+      ctx(NULL) {
+    bool guiMode = AppContext::getMainWindow() != NULL;
 
     if (guiMode) {
         ctx = new KalignMSAEditorContext(this);
         ctx->init();
 
-        QAction* kalignAction = new QAction(tr("Align with Kalign..."), this);
+        QAction *kalignAction = new QAction(tr("Align with Kalign..."), this);
         kalignAction->setObjectName(ToolsMenu::MALIGN_KALIGN);
         kalignAction->setIcon(QIcon(":kalign/images/kalign_16.png"));
         ToolsMenu::addAction(ToolsMenu::MALIGN_MENU, kalignAction);
-        connect(kalignAction,SIGNAL(triggered()),SLOT(sl_runWithExtFileSpecify()));
+        connect(kalignAction, SIGNAL(triggered()), SLOT(sl_runWithExtFileSpecify()));
     }
 
-    LocalWorkflow::KalignWorkerFactory::init(); //TODO
+    LocalWorkflow::KalignWorkerFactory::init();    //TODO
     //TODO:
     //Kalign Test
 
-    GTestFormatRegistry* tfr = AppContext::getTestFramework()->getTestFormatRegistry();
-    XMLTestFormat *xmlTestFormat = qobject_cast<XMLTestFormat*>(tfr->findFormat("XML"));
-    assert(xmlTestFormat!=NULL);
+    GTestFormatRegistry *tfr = AppContext::getTestFramework()->getTestFormatRegistry();
+    XMLTestFormat *xmlTestFormat = qobject_cast<XMLTestFormat *>(tfr->findFormat("XML"));
+    assert(xmlTestFormat != NULL);
 
-    GAutoDeleteList<XMLTestFactory>* l = new GAutoDeleteList<XMLTestFactory>(this);
+    GAutoDeleteList<XMLTestFactory> *l = new GAutoDeleteList<XMLTestFactory>(this);
     l->qlist = KalignTests ::createTestFactories();
 
-    foreach(XMLTestFactory* f, l->qlist) {
+    foreach (XMLTestFactory *f, l->qlist) {
         bool res = xmlTestFormat->registerTestFactory(f);
         Q_UNUSED(res);
         assert(res);
@@ -114,10 +113,10 @@ void KalignPlugin::sl_runWithExtFileSpecify() {
     kalignRunDialog->exec();
     CHECK(!kalignRunDialog.isNull(), );
 
-    if(kalignRunDialog->result() != QDialog::Accepted){
+    if (kalignRunDialog->result() != QDialog::Accepted) {
         return;
     }
-    KalignWithExtFileSpecifySupportTask* kalignTask=new KalignWithExtFileSpecifySupportTask(settings);
+    KalignWithExtFileSpecifySupportTask *kalignTask = new KalignWithExtFileSpecifySupportTask(settings);
     AppContext::getTaskScheduler()->registerTopLevelTask(kalignTask);
 }
 
@@ -125,32 +124,33 @@ KalignPlugin::~KalignPlugin() {
     //nothing to do
 }
 
-MSAEditor* KalignAction::getMSAEditor() const {
-    MSAEditor* e = qobject_cast<MSAEditor*>(getObjectView());
+MSAEditor *KalignAction::getMSAEditor() const {
+    MSAEditor *e = qobject_cast<MSAEditor *>(getObjectView());
     SAFE_POINT(e != NULL, "Can't get an appropriate MSA Editor", NULL);
     return e;
 }
 
 void KalignAction::sl_updateState() {
-    StateLockableItem* item = qobject_cast<StateLockableItem*>(sender());
+    StateLockableItem *item = qobject_cast<StateLockableItem *>(sender());
     SAFE_POINT(item != NULL, "Unexpected sender: expect StateLockableItem", );
-    MSAEditor* msaEditor = getMSAEditor();
+    MSAEditor *msaEditor = getMSAEditor();
     CHECK(msaEditor != NULL, );
     setEnabled(!item->isStateLocked() && !msaEditor->isAlignmentEmpty());
 }
 
-KalignMSAEditorContext::KalignMSAEditorContext(QObject* p) : GObjectViewWindowContext(p, MsaEditorFactory::ID) {
+KalignMSAEditorContext::KalignMSAEditorContext(QObject *p)
+    : GObjectViewWindowContext(p, MsaEditorFactory::ID) {
 }
 
-void KalignMSAEditorContext::initViewContext(GObjectView* view) {
-    MSAEditor* msaed = qobject_cast<MSAEditor*>(view);
+void KalignMSAEditorContext::initViewContext(GObjectView *view) {
+    MSAEditor *msaed = qobject_cast<MSAEditor *>(view);
     SAFE_POINT(msaed != NULL, "Invalid GObjectView", );
     CHECK(msaed->getMaObject() != NULL, );
 
     bool objLocked = msaed->getMaObject()->isStateLocked();
     bool isMsaEmpty = msaed->isAlignmentEmpty();
 
-    KalignAction* alignAction = new KalignAction(this, view, tr("Align with Kalign..."), 2000);
+    KalignAction *alignAction = new KalignAction(this, view, tr("Align with Kalign..."), 2000);
     alignAction->setObjectName("align_with_kalign");
     alignAction->setIcon(QIcon(":kalign/images/kalign_16.png"));
     alignAction->setEnabled(!objLocked && !isMsaEmpty);
@@ -161,20 +161,20 @@ void KalignMSAEditorContext::initViewContext(GObjectView* view) {
     addViewAction(alignAction);
 }
 
-void KalignMSAEditorContext::buildMenu(GObjectView* v, QMenu* m) {
+void KalignMSAEditorContext::buildMenu(GObjectView *v, QMenu *m, const QString &) {
     QList<GObjectViewAction *> actions = getViewActions(v);
-    QMenu* alignMenu = GUIUtils::findSubMenu(m, MSAE_MENU_ALIGN);
-    assert(alignMenu!=NULL);
-    foreach(GObjectViewAction* a, actions) {
+    QMenu *alignMenu = GUIUtils::findSubMenu(m, MSAE_MENU_ALIGN);
+    assert(alignMenu != NULL);
+    foreach (GObjectViewAction *a, actions) {
         a->addToMenuWithOrder(alignMenu);
     }
 }
 
 void KalignMSAEditorContext::sl_align() {
-    KalignAction* action = qobject_cast<KalignAction*>(sender());
-    assert(action!=NULL);
-    MSAEditor* ed = action->getMSAEditor();
-    MultipleSequenceAlignmentObject* obj = ed->getMaObject();
+    KalignAction *action = qobject_cast<KalignAction *>(sender());
+    assert(action != NULL);
+    MSAEditor *ed = action->getMSAEditor();
+    MultipleSequenceAlignmentObject *obj = ed->getMaObject();
 
     KalignTaskSettings s;
     QObjectScopedPointer<KalignDialogController> dlg = new KalignDialogController(ed->getWidget(), obj->getMultipleAlignment(), s);
@@ -185,7 +185,7 @@ void KalignMSAEditorContext::sl_align() {
         return;
     }
 
-    AlignGObjectTask * kalignTask = new KalignGObjectRunFromSchemaTask(obj, s);
+    AlignGObjectTask *kalignTask = new KalignGObjectRunFromSchemaTask(obj, s);
     Task *alignTask = NULL;
 
     if (dlg->translateToAmino()) {
@@ -202,15 +202,11 @@ void KalignMSAEditorContext::sl_align() {
 }
 
 KalignPairwiseAligmnentAlgorithm::KalignPairwiseAligmnentAlgorithm()
-    : AlignmentAlgorithm(PairwiseAlignment, "Hirschberg (KAlign)",
-                                 new PairwiseAlignmentHirschbergTaskFactory(),
-                                 new PairwiseAlignmentHirschbergGUIExtensionFactory(),
-                                 "KAlign")
-{
+    : AlignmentAlgorithm(PairwiseAlignment, "Hirschberg (KAlign)", new PairwiseAlignmentHirschbergTaskFactory(), new PairwiseAlignmentHirschbergGUIExtensionFactory(), "KAlign") {
 }
 
 bool KalignPairwiseAligmnentAlgorithm::checkAlphabet(const DNAAlphabet *al) const {
     return !(al->isRaw() || (al->isAmino() && al->isExtended()));
 }
 
-}//namespace
+}    // namespace U2

--- a/src/plugins_3rdparty/kalign/src/KalignPlugin.cpp
+++ b/src/plugins_3rdparty/kalign/src/KalignPlugin.cpp
@@ -161,7 +161,7 @@ void KalignMSAEditorContext::initViewContext(GObjectView *view) {
     addViewAction(alignAction);
 }
 
-void KalignMSAEditorContext::buildMenu(GObjectView *v, QMenu *m, const QString &) {
+void KalignMSAEditorContext::buildStaticOrContextMenu(GObjectView *v, QMenu *m) {
     QList<GObjectViewAction *> actions = getViewActions(v);
     QMenu *alignMenu = GUIUtils::findSubMenu(m, MSAE_MENU_ALIGN);
     assert(alignMenu != NULL);

--- a/src/plugins_3rdparty/kalign/src/KalignPlugin.h
+++ b/src/plugins_3rdparty/kalign/src/KalignPlugin.h
@@ -22,12 +22,14 @@
 #ifndef _U2_KALIGN_PLUGIN_H_
 #define _U2_KALIGN_PLUGIN_H_
 
-#include <U2Core/PluginModel.h>
-#include <U2Core/AppContext.h>
-#include <U2Gui/ObjectViewModel.h>
+#include <QMenu>
+
 #include <U2Algorithm/AlignmentAlgorithmsRegistry.h>
 
-#include <QMenu>
+#include <U2Core/AppContext.h>
+#include <U2Core/PluginModel.h>
+
+#include <U2Gui/ObjectViewModel.h>
 
 //#include <kalign_local_task/KalignLocalTask.h> //TODO
 
@@ -46,29 +48,29 @@ public slots:
     void sl_runWithExtFileSpecify();
 
 private:
-    KalignMSAEditorContext* ctx;
+    KalignMSAEditorContext *ctx;
 };
 
-
-class KalignMSAEditorContext: public GObjectViewWindowContext {
+class KalignMSAEditorContext : public GObjectViewWindowContext {
     Q_OBJECT
 public:
-    KalignMSAEditorContext(QObject* p);
+    KalignMSAEditorContext(QObject *p);
 
 protected slots:
     void sl_align();
 
 protected:
-    virtual void initViewContext(GObjectView* view);
-    virtual void buildMenu(GObjectView* v, QMenu* m);
+    void initViewContext(GObjectView *view) override;
+    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
 };
 
 class KalignAction : public GObjectViewAction {
     Q_OBJECT
 public:
-    KalignAction(QObject* p, GObjectView* v, const QString& text, int order)
-        : GObjectViewAction(p,v,text,order) {}
-    MSAEditor*  getMSAEditor() const;
+    KalignAction(QObject *p, GObjectView *v, const QString &text, int order)
+        : GObjectViewAction(p, v, text, order) {
+    }
+    MSAEditor *getMSAEditor() const;
 
 private slots:
     void sl_updateState();
@@ -80,6 +82,6 @@ public:
     bool checkAlphabet(const DNAAlphabet *alphabet) const;
 };
 
-} //namespace
+}    // namespace U2
 
 #endif

--- a/src/plugins_3rdparty/kalign/src/KalignPlugin.h
+++ b/src/plugins_3rdparty/kalign/src/KalignPlugin.h
@@ -61,7 +61,7 @@ protected slots:
 
 protected:
     void initViewContext(GObjectView *view) override;
-    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
+    void buildStaticOrContextMenu(GObjectView *view, QMenu *menu) override;
 };
 
 class KalignAction : public GObjectViewAction {

--- a/src/plugins_3rdparty/primer3/src/Primer3Plugin.h
+++ b/src/plugins_3rdparty/primer3/src/Primer3Plugin.h
@@ -50,7 +50,7 @@ public:
 protected slots:
         void sl_showDialog();
 protected:
-    virtual void initViewContext(GObjectView* v);
+    void initViewContext(GObjectView* v) override;
     //virtual void makeBaseMenu(GObjectView* v, QMenu* m);
 };
 

--- a/src/plugins_3rdparty/sitecon/src/SiteconPlugin.h
+++ b/src/plugins_3rdparty/sitecon/src/SiteconPlugin.h
@@ -61,7 +61,7 @@ protected slots:
     void sl_search();
 
 protected:
-    virtual void initViewContext(GObjectView* view);
+    void initViewContext(GObjectView* view) override;
 };
 
 class SiteconAlgorithmTests {

--- a/src/plugins_3rdparty/umuscle/src/MusclePlugin.cpp
+++ b/src/plugins_3rdparty/umuscle/src/MusclePlugin.cpp
@@ -161,7 +161,7 @@ void MuscleMSAEditorContext::initViewContext(GObjectView *view) {
     addViewAction(alignProfilesAction);
 }
 
-void MuscleMSAEditorContext::buildMenu(GObjectView *v, QMenu *m, const QString &) {
+void MuscleMSAEditorContext::buildStaticOrContextMenu(GObjectView *v, QMenu *m) {
     QList<GObjectViewAction *> actions = getViewActions(v);
     QMenu *alignMenu = GUIUtils::findSubMenu(m, MSAE_MENU_ALIGN);
     SAFE_POINT(alignMenu != NULL, "alignMenu", );

--- a/src/plugins_3rdparty/umuscle/src/MusclePlugin.cpp
+++ b/src/plugins_3rdparty/umuscle/src/MusclePlugin.cpp
@@ -19,6 +19,8 @@
  * MA 02110-1301, USA.
  */
 
+#include "MusclePlugin.h"
+
 #include <QDialog>
 #include <QMainWindow>
 
@@ -40,7 +42,6 @@
 #include <U2View/MaEditorFactory.h>
 
 #include "MuscleAlignDialogController.h"
-#include "MusclePlugin.h"
 #include "MuscleTask.h"
 #include "MuscleWorker.h"
 #include "ProfileToProfileWorker.h"
@@ -48,59 +49,57 @@
 
 namespace U2 {
 
-extern "C" Q_DECL_EXPORT Plugin* U2_PLUGIN_INIT_FUNC() {
-    MusclePlugin * plug = new MusclePlugin();
+extern "C" Q_DECL_EXPORT Plugin *U2_PLUGIN_INIT_FUNC() {
+    MusclePlugin *plug = new MusclePlugin();
     return plug;
 }
 
-
 MusclePlugin::MusclePlugin()
-: Plugin(tr("MUSCLE"),
-         tr("A port of MUSCLE package for multiple sequence alignment. Check http://www.drive5.com/muscle/ for the original version")),
-         ctx(NULL)
-{
+    : Plugin(tr("MUSCLE"),
+             tr("A port of MUSCLE package for multiple sequence alignment. Check http://www.drive5.com/muscle/ for the original version")),
+      ctx(NULL) {
     if (AppContext::getMainWindow()) {
         ctx = new MuscleMSAEditorContext(this);
         ctx->init();
 
         //Add to tools menu for fast run
-        QAction* muscleAction = new QAction(tr("Align with MUSCLE..."), this);
+        QAction *muscleAction = new QAction(tr("Align with MUSCLE..."), this);
         muscleAction->setIcon(QIcon(":umuscle/images/muscle_16.png"));
         muscleAction->setObjectName(ToolsMenu::MALIGN_MUSCLE);
-        connect(muscleAction,SIGNAL(triggered()),SLOT(sl_runWithExtFileSpecify()));
+        connect(muscleAction, SIGNAL(triggered()), SLOT(sl_runWithExtFileSpecify()));
 
         ToolsMenu::addAction(ToolsMenu::MALIGN_MENU, muscleAction);
     }
     LocalWorkflow::MuscleWorkerFactory::init();
     LocalWorkflow::ProfileToProfileWorkerFactory::init();
     //uMUSCLE Test
-    GTestFormatRegistry* tfr = AppContext::getTestFramework()->getTestFormatRegistry();
-    XMLTestFormat *xmlTestFormat = qobject_cast<XMLTestFormat*>(tfr->findFormat("XML"));
-    assert(xmlTestFormat!=NULL);
+    GTestFormatRegistry *tfr = AppContext::getTestFramework()->getTestFormatRegistry();
+    XMLTestFormat *xmlTestFormat = qobject_cast<XMLTestFormat *>(tfr->findFormat("XML"));
+    assert(xmlTestFormat != NULL);
 
-    GAutoDeleteList<XMLTestFactory>* l = new GAutoDeleteList<XMLTestFactory>(this);
+    GAutoDeleteList<XMLTestFactory> *l = new GAutoDeleteList<XMLTestFactory>(this);
     l->qlist = UMUSCLETests ::createTestFactories();
 
-    foreach(XMLTestFactory* f, l->qlist) {
+    foreach (XMLTestFactory *f, l->qlist) {
         bool res = xmlTestFormat->registerTestFactory(f);
         Q_UNUSED(res);
         assert(res);
     }
 }
 
-void MusclePlugin::sl_runWithExtFileSpecify(){
+void MusclePlugin::sl_runWithExtFileSpecify() {
     //Call select input file and setup settings dialog
     MuscleTaskSettings settings;
     QObjectScopedPointer<MuscleAlignWithExtFileSpecifyDialogController> muscleRunDialog = new MuscleAlignWithExtFileSpecifyDialogController(AppContext::getMainWindow()->getQMainWindow(), settings);
     muscleRunDialog->exec();
     CHECK(!muscleRunDialog.isNull(), );
 
-    if (muscleRunDialog->result() != QDialog::Accepted){
+    if (muscleRunDialog->result() != QDialog::Accepted) {
         return;
     }
     assert(!settings.inputFilePath.isEmpty());
 
-    MuscleWithExtFileSpecifySupportTask* muscleTask=new MuscleWithExtFileSpecifySupportTask(settings);
+    MuscleWithExtFileSpecifySupportTask *muscleTask = new MuscleWithExtFileSpecifySupportTask(settings);
     AppContext::getTaskScheduler()->registerTopLevelTask(muscleTask);
 }
 
@@ -108,33 +107,33 @@ MusclePlugin::~MusclePlugin() {
     //nothing to do
 }
 
-MSAEditor* MuscleAction::getMSAEditor() const {
-    MSAEditor* e = qobject_cast<MSAEditor*>(getObjectView());
+MSAEditor *MuscleAction::getMSAEditor() const {
+    MSAEditor *e = qobject_cast<MSAEditor *>(getObjectView());
     SAFE_POINT(e != NULL, "Can't get an appropriate MSA Editor", NULL);
     return e;
 }
 
 void MuscleAction::sl_updateState() {
-    StateLockableItem* item = qobject_cast<StateLockableItem*>(sender());
+    StateLockableItem *item = qobject_cast<StateLockableItem *>(sender());
     SAFE_POINT(item != NULL, "Unexpected sender: expect StateLockableItem", );
-    MSAEditor* msaEditor = getMSAEditor();
+    MSAEditor *msaEditor = getMSAEditor();
     CHECK(msaEditor != NULL, );
     setEnabled(!item->isStateLocked() && !msaEditor->isAlignmentEmpty());
 }
 
-MuscleMSAEditorContext::MuscleMSAEditorContext(QObject* p) : GObjectViewWindowContext(p, MsaEditorFactory::ID) {
+MuscleMSAEditorContext::MuscleMSAEditorContext(QObject *p)
+    : GObjectViewWindowContext(p, MsaEditorFactory::ID) {
 }
 
-
-void MuscleMSAEditorContext::initViewContext(GObjectView* view) {
-    MSAEditor* msaed = qobject_cast<MSAEditor*>(view);
+void MuscleMSAEditorContext::initViewContext(GObjectView *view) {
+    MSAEditor *msaed = qobject_cast<MSAEditor *>(view);
     SAFE_POINT(msaed != NULL, "Invalid GObjectView", );
     CHECK(msaed->getMaObject() != NULL, );
 
     bool objLocked = msaed->getMaObject()->isStateLocked();
     bool isMsaEmpty = msaed->isAlignmentEmpty();
 
-    MuscleAction* alignAction = new MuscleAction(this, view, tr("Align with MUSCLE..."), 1000);
+    MuscleAction *alignAction = new MuscleAction(this, view, tr("Align with MUSCLE..."), 1000);
     alignAction->setIcon(QIcon(":umuscle/images/muscle_16.png"));
     alignAction->setEnabled(!objLocked && !isMsaEmpty);
     alignAction->setObjectName("Align with muscle");
@@ -143,7 +142,7 @@ void MuscleMSAEditorContext::initViewContext(GObjectView* view) {
     connect(msaed->getMaObject(), SIGNAL(si_alignmentBecomesEmpty(bool)), alignAction, SLOT(sl_updateState()));
     addViewAction(alignAction);
 
-    MuscleAction* addSequencesAction = new MuscleAction(this, view, tr("Align sequences to profile with MUSCLE..."), 1001);
+    MuscleAction *addSequencesAction = new MuscleAction(this, view, tr("Align sequences to profile with MUSCLE..."), 1001);
     addSequencesAction->setIcon(QIcon(":umuscle/images/muscle_16.png"));
     addSequencesAction->setEnabled(!objLocked && !isMsaEmpty);
     addSequencesAction->setObjectName("Align sequences to profile with MUSCLE");
@@ -152,7 +151,7 @@ void MuscleMSAEditorContext::initViewContext(GObjectView* view) {
     connect(msaed->getMaObject(), SIGNAL(si_alignmentBecomesEmpty(bool)), addSequencesAction, SLOT(sl_updateState()));
     addViewAction(addSequencesAction);
 
-    MuscleAction* alignProfilesAction = new MuscleAction(this, view, tr("Align profile to profile with MUSCLE..."), 1002);
+    MuscleAction *alignProfilesAction = new MuscleAction(this, view, tr("Align profile to profile with MUSCLE..."), 1002);
     alignProfilesAction->setIcon(QIcon(":umuscle/images/muscle_16.png"));
     alignProfilesAction->setEnabled(!objLocked && !isMsaEmpty);
     alignProfilesAction->setObjectName("Align profile to profile with MUSCLE");
@@ -162,27 +161,27 @@ void MuscleMSAEditorContext::initViewContext(GObjectView* view) {
     addViewAction(alignProfilesAction);
 }
 
-void MuscleMSAEditorContext::buildMenu(GObjectView* v, QMenu* m) {
+void MuscleMSAEditorContext::buildMenu(GObjectView *v, QMenu *m, const QString &) {
     QList<GObjectViewAction *> actions = getViewActions(v);
-    QMenu* alignMenu = GUIUtils::findSubMenu(m, MSAE_MENU_ALIGN);
+    QMenu *alignMenu = GUIUtils::findSubMenu(m, MSAE_MENU_ALIGN);
     SAFE_POINT(alignMenu != NULL, "alignMenu", );
-    foreach(GObjectViewAction* a, actions) {
+    foreach (GObjectViewAction *a, actions) {
         a->addToMenuWithOrder(alignMenu);
     }
 }
 
 void MuscleMSAEditorContext::sl_align() {
-    MuscleAction* action = qobject_cast<MuscleAction*>(sender());
-    assert(action!=NULL);
-    MSAEditor* ed = action->getMSAEditor();
-    MultipleSequenceAlignmentObject* obj = ed->getMaObject();
+    MuscleAction *action = qobject_cast<MuscleAction *>(sender());
+    assert(action != NULL);
+    MSAEditor *ed = action->getMSAEditor();
+    MultipleSequenceAlignmentObject *obj = ed->getMaObject();
 
     const QRect selection = action->getMSAEditor()->getSelectionRect();
     MuscleTaskSettings s;
-    if (!selection.isNull() ) {
+    if (!selection.isNull()) {
         int width = selection.width();
         // it doesn't make sense to align one column!
-        if ( (width > 1) && ( width < obj->getLength() ) ) {
+        if ((width > 1) && (width < obj->getLength())) {
             s.regionToAlign = U2Region(selection.x() + 1, selection.width() - 1);
             s.alignRegion = true;
         }
@@ -196,8 +195,7 @@ void MuscleMSAEditorContext::sl_align() {
         return;
     }
 
-
-    AlignGObjectTask* muscleTask = new MuscleGObjectRunFromSchemaTask(obj, s);
+    AlignGObjectTask *muscleTask = new MuscleGObjectRunFromSchemaTask(obj, s);
     Task *alignTask = NULL;
 
     if (dlg->translateToAmino()) {
@@ -215,10 +213,10 @@ void MuscleMSAEditorContext::sl_align() {
 }
 
 void MuscleMSAEditorContext::sl_alignSequencesToProfile() {
-    MuscleAction* action = qobject_cast<MuscleAction*>(sender());
-    assert(action!=NULL);
-    MSAEditor* ed = action->getMSAEditor();
-    MultipleSequenceAlignmentObject* obj = ed->getMaObject();
+    MuscleAction *action = qobject_cast<MuscleAction *>(sender());
+    assert(action != NULL);
+    MSAEditor *ed = action->getMSAEditor();
+    MultipleSequenceAlignmentObject *obj = ed->getMaObject();
     if (obj == NULL)
         return;
     assert(!obj->isStateLocked());
@@ -231,10 +229,10 @@ void MuscleMSAEditorContext::sl_alignSequencesToProfile() {
     LastUsedDirHelper lod;
 #ifdef Q_OS_DARWIN
     if (qgetenv(ENV_GUI_TEST).toInt() == 1 && qgetenv(ENV_USE_NATIVE_DIALOGS).toInt() == 0) {
-        lod.url = U2FileDialog::getOpenFileName(NULL, tr("Select file with sequences"), lod, filter, 0, QFileDialog::DontUseNativeDialog );
+        lod.url = U2FileDialog::getOpenFileName(NULL, tr("Select file with sequences"), lod, filter, 0, QFileDialog::DontUseNativeDialog);
     } else
 #endif
-    lod.url = U2FileDialog::getOpenFileName(NULL, tr("Select file with sequences"), lod, filter);
+        lod.url = U2FileDialog::getOpenFileName(NULL, tr("Select file with sequences"), lod, filter);
     if (lod.url.isEmpty()) {
         return;
     }
@@ -248,10 +246,10 @@ void MuscleMSAEditorContext::sl_alignSequencesToProfile() {
 }
 
 void MuscleMSAEditorContext::sl_alignProfileToProfile() {
-    MuscleAction* action = qobject_cast<MuscleAction*>(sender());
-    assert(action!=NULL);
-    MSAEditor* ed = action->getMSAEditor();
-    MultipleSequenceAlignmentObject* obj = ed->getMaObject();
+    MuscleAction *action = qobject_cast<MuscleAction *>(sender());
+    assert(action != NULL);
+    MSAEditor *ed = action->getMSAEditor();
+    MultipleSequenceAlignmentObject *obj = ed->getMaObject();
     if (obj == NULL)
         return;
     assert(!obj->isStateLocked());
@@ -259,12 +257,10 @@ void MuscleMSAEditorContext::sl_alignProfileToProfile() {
     LastUsedDirHelper lod;
 #ifdef Q_OS_DARWIN
     if (qgetenv(ENV_GUI_TEST).toInt() == 1 && qgetenv(ENV_USE_NATIVE_DIALOGS).toInt() == 0) {
-        lod.url = U2FileDialog::getOpenFileName(NULL, tr("Select file with alignment"), lod,
-            DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, true), 0, QFileDialog::DontUseNativeDialog );
+        lod.url = U2FileDialog::getOpenFileName(NULL, tr("Select file with alignment"), lod, DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, true), 0, QFileDialog::DontUseNativeDialog);
     } else
 #endif
-    lod.url = U2FileDialog::getOpenFileName(NULL, tr("Select file with alignment"), lod,
-        DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, true));
+        lod.url = U2FileDialog::getOpenFileName(NULL, tr("Select file with alignment"), lod, DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, true));
 
     if (lod.url.isEmpty()) {
         return;
@@ -278,5 +274,4 @@ void MuscleMSAEditorContext::sl_alignProfileToProfile() {
     ed->resetCollapsibleModel();
 }
 
-}//namespace
-
+}    // namespace U2

--- a/src/plugins_3rdparty/umuscle/src/MusclePlugin.h
+++ b/src/plugins_3rdparty/umuscle/src/MusclePlugin.h
@@ -60,7 +60,7 @@ protected slots:
 
 protected:
     void initViewContext(GObjectView *view) override;
-    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
+    void buildStaticOrContextMenu(GObjectView *view, QMenu *menu) override;
 };
 
 class MuscleAction : public GObjectViewAction {

--- a/src/plugins_3rdparty/umuscle/src/MusclePlugin.h
+++ b/src/plugins_3rdparty/umuscle/src/MusclePlugin.h
@@ -22,11 +22,12 @@
 #ifndef _U2_UMUSCLE_PLUGIN_H_
 #define _U2_UMUSCLE_PLUGIN_H_
 
-#include <U2Core/PluginModel.h>
-#include <U2Core/AppContext.h>
-#include <U2Gui/ObjectViewModel.h>
-
 #include <QMenu>
+
+#include <U2Core/AppContext.h>
+#include <U2Core/PluginModel.h>
+
+#include <U2Gui/ObjectViewModel.h>
 
 namespace U2 {
 
@@ -44,15 +45,13 @@ public slots:
     void sl_runWithExtFileSpecify();
 
 private:
-    MuscleMSAEditorContext* ctx;
-    
+    MuscleMSAEditorContext *ctx;
 };
 
-
-class MuscleMSAEditorContext: public GObjectViewWindowContext {
+class MuscleMSAEditorContext : public GObjectViewWindowContext {
     Q_OBJECT
 public:
-    MuscleMSAEditorContext(QObject* p);
+    MuscleMSAEditorContext(QObject *p);
 
 protected slots:
     void sl_align();
@@ -60,22 +59,23 @@ protected slots:
     void sl_alignProfileToProfile();
 
 protected:
-    virtual void initViewContext(GObjectView* view);
-    virtual void buildMenu(GObjectView* v, QMenu* m);
+    void initViewContext(GObjectView *view) override;
+    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType) override;
 };
 
 class MuscleAction : public GObjectViewAction {
     Q_OBJECT
 public:
-    MuscleAction(QObject* p, GObjectView* v, const QString& text, int order) 
-		: GObjectViewAction(p, v, text, order) {}
+    MuscleAction(QObject *p, GObjectView *v, const QString &text, int order)
+        : GObjectViewAction(p, v, text, order) {
+    }
 
-    MSAEditor*  getMSAEditor() const;
+    MSAEditor *getMSAEditor() const;
 
 private slots:
     void sl_updateState();
 };
 
-} //namespace
+}    // namespace U2
 
 #endif


### PR DESCRIPTION
This is a second PR in the series to fix UGENE-7238.

This change adds an option to create 'any' (not only 'static' or 'context') kind of popup menus for object views.

This functionality is needed to implement the following scenario: plugins can populate menus like 'Align' or 'Align sequence to alignment'.

Today in order to build a context menu for the 'Align' button on the MSA Editor toolbar we have to use the following workaround:
https://github.com/ugeneunipro/ugene/blob/ea3a560789fe69252cb55d9fe70d3ff0de0bff05/src/corelibs/U2View/src/ov_msa/MSAEditor.cpp#L589

This code is not correct: it builds the whole menu, 'Align context menu' contains unrelated items to 'Align button'.

After my change there will be an option to call buildMenu() method with a 'align-button' type. Next I will add 'add-sequence-to-alignment' popup menu.

There should be no change in UGENE behavior after this PR: only internal API cleanup.