### PR TITLE
UGENE-7135. Crash on database error.

### DIFF
--- a/src/corelibs/U2Formats/src/EMBLGenbankAbstractDocument.cpp
+++ b/src/corelibs/U2Formats/src/EMBLGenbankAbstractDocument.cpp
@@ -203,6 +203,7 @@ void EMBLGenbankAbstractDocument::load(const U2DbiRef &dbiRef, IOAdapter *io, QL
                 }
                 CHECK_OP(os, );
             }
+            CHECK_OP(os, )
             foreach (const QString &groupName, groupName2Annotations.keys()) {
                 annotationsObject->addAnnotations(groupName2Annotations[groupName], groupName);
             }


### PR DESCRIPTION
Can't reproduced. The user just opened the file GFX0437388_variants.filtered.EEF.snp.gb and then there was a database error and a crash. I don't know if my fixes will work, how to check them. Any ideas?
Added `return` before the crash.