### PR TITLE
Update create package script for installing always to /Applications dir

### DIFF
--- a/installer/macosx/bundle_release.sh
+++ b/installer/macosx/bundle_release.sh
@@ -249,6 +249,10 @@ if [ ! "$1" ]; then
     echo Signing dmg-file...
     echo ./codesign.mac.sh ugene-${UGENE_VERSION}-mac-${ARCHITECTURE}-r${BUILD_VCS_NUMBER_new_trunk}.dmg
     bash ./codesign.mac.sh ugene-${UGENE_VERSION}-mac-${ARCHITECTURE}-r${BUILD_VCS_NUMBER_new_trunk}.dmg
+    
+    echo Notarize dmg-file
+    echo ./notarize.sh -n ugene-${UGENE_VERSION}-mac-${ARCHITECTURE}-r${BUILD_VCS_NUMBER_new_trunk}.dmg
+    bash ./notarize.sh -n ugene-${UGENE_VERSION}-mac-${ARCHITECTURE}-r${BUILD_VCS_NUMBER_new_trunk}.dmg
 
     set +x
 fi

--- a/installer/macosx/productbuild.sh
+++ b/installer/macosx/productbuild.sh
@@ -16,9 +16,27 @@ if [[ -z "$3" ]]; then
     exit -2
 fi
 
-productbuild \
-    --component "$1" \
-    /Applications/ \
+#productbuild \
+#    --component "$1" \
+#    /Applications/ \
+#    "$2"
+
+pkgbuild \
+    --analyze \
+    --root "$1" \
+    "Unipro UGENE-component.plist"
+
+plutil \
+    -replace BundleIsRelocatable \
+    -bool NO \
+    "Unipro UGENE-component.plist"
+
+pkgbuild \
+    --root "$1" \
+    --identifier net.ugene.ugene \
+    --version 39.0 \
+    --install-location /Applications/UGENE.app \
+    --component-plist "Unipro UGENE-component.plist" \
     "$2"
 
 productsign \


### PR DESCRIPTION
Update script which creates install package  on macos
Disable relocation of the installed app
The UGENE now always is installed to /Applications dir