### PR TITLE
Fix 'version news' language selection

### DIFF
--- a/src/corelibs/U2Core/src/globals/L10n.h
+++ b/src/corelibs/U2Core/src/globals/L10n.h
@@ -142,6 +142,16 @@ public:
     static QString required() {
         return tr("Required");
     }
+
+    /**
+     * Returns active language code: 'en', 'ru', 'tr'.
+     * The string 'ugene-active-translation-language-code' must be correctly translated in the .ts file.
+     * If the string is not translated, 'en' is returned as the default.
+     */
+    static QString getActiveLanguageCode() {
+        QString code = tr("ugene-active-translation-language-code");
+        return code.isEmpty() || code == "ugene-active-translation-language-code" ? "en" : code;
+    }
 };
 
 }    // namespace U2

--- a/src/corelibs/U2Core/transl/russian.ts
+++ b/src/corelibs/U2Core/transl/russian.ts
@@ -2063,6 +2063,11 @@ The session database file is removed after closing of UGENE.</source>
         <translation>Требуемый</translation>
     </message>
     <message>
+        <location filename="../src/globals/L10n.h" line="152"/>
+        <source>ugene-active-translation-language-code</source>
+        <translation>ru</translation>
+    </message>
+    <message>
         <location filename="../src/globals/L10n.h" line="43"/>
         <source>Internal error, bad argument: %1</source>
         <translation>Внутренняя ошибка! Неверный аргумент: %1</translation>

--- a/src/ugeneui/src/shtirlitz/Shtirlitz.cpp
+++ b/src/ugeneui/src/shtirlitz/Shtirlitz.cpp
@@ -35,6 +35,7 @@
 #include <U2Core/AppContext.h>
 #include <U2Core/AppSettings.h>
 #include <U2Core/Counter.h>
+#include <U2Core/L10n.h>
 #include <U2Core/Log.h>
 #include <U2Core/NetworkConfiguration.h>
 #include <U2Core/QObjectScopedPointer.h>
@@ -82,9 +83,9 @@ QUuid Shtirlitz::getUniqueUgeneId() {
 }
 
 static QString getWhatsNewHtml() {
-    QString activeLanguage = AppContext::getSettings()->getValue("UGENE_CURR_TRANSL", "en").toString().toLower();
-    if (activeLanguage != "en" && activeLanguage != "ru") {
-        activeLanguage = "en";    // We do not have other variants of "Whats New?" file today.
+    QString activeLanguage = L10N::getActiveLanguageCode();
+    if (activeLanguage != "ru") {    // We have only Russian & English versions of "version_news_" files.
+        activeLanguage = "en";
     }
     QFile htmlFile(":/ugene/html/version_news_" + activeLanguage + ".html");
     if (!htmlFile.open(QFile::ReadOnly | QFile::Text)) {

--- a/src/ugeneui/src/shtirlitz/Shtirlitz.h
+++ b/src/ugeneui/src/shtirlitz/Shtirlitz.h
@@ -78,7 +78,7 @@ class ShtirlitzTask : public Task {
     Q_OBJECT
 public:
     ShtirlitzTask(const QString &_report);
-    void run();
+    void run() override;
 
 private:
     QString report;
@@ -88,7 +88,7 @@ class ShtirlitzStartupTask : public Task {
     Q_OBJECT
 public:
     ShtirlitzStartupTask();
-    void prepare();
+    void prepare() override;
 };
 
 }    // namespace U2


### PR DESCRIPTION
A file with translation can come from different sources (via env variable, etc) so we can't rely on the file name.
Instead of it the translation file itself may contain the required code.