### PR TITLE
Fix GT_CHECK_RESULT() result in GTUtilsMdi::isTabbedLayout() method

### DIFF
--- a/src/plugins/GUITestBase/src/GTUtilsMdi.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsMdi.cpp
@@ -215,9 +215,9 @@ void GTUtilsMdi::closeAllWindows(HI::GUITestOpStatus &os) {
 #define GT_METHOD_NAME "isTabbedLayout"
 bool GTUtilsMdi::isTabbedLayout(HI::GUITestOpStatus &os) {
     MainWindow *mainWindow = AppContext::getMainWindow();
-    GT_CHECK_RESULT(mainWindow != NULL, "MainWindow == NULL", NULL);
+    GT_CHECK_RESULT(mainWindow != NULL, "MainWindow == NULL", false);
     QMdiArea *mdiArea = GTWidget::findExactWidget<QMdiArea *>(os, "MDI_Area", mainWindow->getQMainWindow());
-    GT_CHECK_RESULT(mdiArea != NULL, "mdiArea == NULL", NULL);
+    GT_CHECK_RESULT(mdiArea != NULL, "mdiArea == NULL", false);
     return mdiArea->viewMode() == QMdiArea::TabbedView;
 }
 #undef GT_METHOD_NAME


### PR DESCRIPTION
`GTUtilsMdi::isTabbedLayout(HI::GUITestOpStatus &os)` returns `bool` while `GT_CHECK_RESULT()` assertion macro is currently being called with `NULL` result which is defined to `nullptr` in modern C++ which is of type `nullptr_t` and cannot initialize return object of type `bool`.
```
src/GTUtilsMdi.cpp:218:63: error: cannot initialize return object of type 'bool'
  with an rvalue of type 'nullptr_t'
    GT_CHECK_RESULT(mainWindow != NULL, "MainWindow == NULL", NULL);
                                                              ^~~~
/usr/include/sys/_null.h:37:14: note: expanded from macro 'NULL'
#define NULL    nullptr
```