### PR TITLE
Restore 'hmm3-search' command line parameter and fix XML tests

### DIFF
--- a/data/cmdline/hmm3-search.uwl
+++ b/data/cmdline/hmm3-search.uwl
@@ -1,0 +1,100 @@
+#@UGENE_WORKFLOW
+# Runs a HMM search over sample sequence and saves results as annotations using Genbank file format. To run this workflow, you need to specify appropriate locations for input/output files. This is achieved by selecting a task and editing interesting parameters in Property Inspector panel.Optionally, fine tune the search parameters as you see fit. Then schedule the workflow for execution by pressing CTRL+R shortcut. You can watch its" progress in a Task View of UGENE.
+
+
+
+workflow "New workflow"{
+
+    read-sequence {
+        type:read-sequence;
+        name:"Read Sequence";
+        url-in {
+            dataset:"Dataset 1";
+        }
+    }
+    hmm3-search {
+        type:hmm3-search;
+        name:"HMM3 Search";
+    }
+    write-annotations {
+        type:write-annotations;
+        name:"Write Annotations";
+        url-out:"";
+        write-mode:0;
+    }
+    get-file-list {
+        type:get-file-list;
+        name:"Read File URL(s)";
+        url-in {
+            dataset:"Dataset 1";
+        }
+    }
+
+    .actor-bindings {
+        hmm3-search.out-annotations->write-annotations.in-annotations
+        get-file-list.out-url->hmm3-search.in-hmm3
+        read-sequence.out-sequence->hmm3-search.in-sequence
+    }
+
+    get-file-list.url->hmm3-search.in-hmm3.url
+    read-sequence.sequence->hmm3-search.in-sequence.sequence
+    hmm3-search.annotations->write-annotations.in-annotations.annotations
+
+    .meta {
+        parameter-aliases {
+            read-sequence.url-in {
+                alias:in-seq;
+            }
+            write-annotations.document-format {
+                alias:format;
+                description:"Annotations document format. Default: 'genbank'.";
+            }
+            write-annotations.url-out {
+                alias:out;
+                description:"Output file with annotations";
+            }
+            get-file-list.url-in {
+                alias:in-hmm;
+                description:"Input profile HMM";
+            }
+        }
+        visual {
+            get-file-list {
+                pos:"-870 -555";
+                style:ext;
+                bg-color-ext:"0 128 128 64";
+                out-url.angle:360;
+            }
+            hmm3-search {
+                pos:"-570 -405";
+                style:ext;
+                bg-color-ext:"0 128 128 64";
+                in-hmm3.angle:150;
+                in-sequence.angle:210;
+                out-annotations.angle:360;
+            }
+            read-sequence {
+                pos:"-870 -390";
+                style:ext;
+                bg-color-ext:"0 128 128 64";
+                out-sequence.angle:360;
+            }
+            write-annotations {
+                pos:"-240 -405";
+                style:ext;
+                bg-color-ext:"0 128 128 64";
+                in-annotations.angle:180;
+            }
+            get-file-list.out-url->hmm3-search.in-hmm3 {
+                text-pos:"-45 -48";
+            }
+            hmm3-search.out-annotations->write-annotations.in-annotations {
+                text-pos:"-45 -37";
+            }
+            read-sequence.out-sequence->hmm3-search.in-sequence {
+                text-pos:"-27.5 -24";
+            }
+        }
+    }
+}
+

--- a/tests/cmdline/common/hmm3/test_0005.xml
+++ b/tests/cmdline/common/hmm3/test_0005.xml
@@ -1,10 +1,9 @@
 <multi-test>
     <run-cmdline
             task="hmm3-search"
-            in="!common_data_dir!hmmer3/search/14-3-3_epsilon2_transl.fa"
-            hmm="!common_data_dir!hmmer3/build/14-3-3.hmm"
+            in-seq="!common_data_dir!hmmer3/search/14-3-3_epsilon2.fa"
+            in-hmm="!common_data_dir!hmmer3/build/14-3-3.hmm"
             out="!tmp_data_dir!hmm3-search_0005.gb"
-            max="True"
     />
 
     <load-document index="doc1" url="hmm3-search_0005.gb" io="local_file" format="genbank" dir="temp"/>

--- a/tests/cmdline/common/hmm3/test_0006.xml
+++ b/tests/cmdline/common/hmm3/test_0006.xml
@@ -1,16 +1,13 @@
 <multi-test>
     <run-cmdline
             task="hmm3-search"
-            in="!common_data_dir!hmmer3/search/14-3-3_epsilon2_transl.fa"
-            hmm="!common_data_dir!hmmer3/build/14-3-3.hmm"
+            in-seq="!common_data_dir!hmmer3/search/COI.fa"
+            in-hmm="!common_data_dir!hmmer3/search/COI.hmm"
             out="!tmp_data_dir!hmm3-search_0006.gb"
-            F1="999"
-            F2="999"
-            F3="999"
     />
 
     <load-document index="doc1" url="hmm3-search_0006.gb" io="local_file" format="genbank" dir="temp"/>
-    <load-document index="doc2" url="cmdline/hmm3/out5.gb" io="local_file" format="genbank"/>
+    <load-document index="doc2" url="cmdline/hmm3/out6.gb" io="local_file" format="genbank"/>
 
     <compare-annotations-num-in-two-objects doc="doc1" value="doc2"/>
     <compare-annotations-locations-in-two-objects doc="doc1" value="doc2"/>


### PR DESCRIPTION
Note: we actually do not need a joined 'build-and-search' cmd line task at all, and only need 'build' and 'search' as separate cmd-line tasks. The reason is quite simple: a model (HMM3 profile) is build once. It is very cpu/memory intensive process.  Next it may be used many times to search for hits and this very fast process. Joining both into a single task has no sense.

In this fix I restore 'search' task. 

I will create a separate bug to restore the original 'biuld' task and cleanup params (yes we pass custom params to HMMER3 binaries user is not aware about at all)