### PR TITLE
UGENE-7364. Move row to another MA object

### DIFF
--- a/src/corelibs/U2Core/src/datatype/msa/MultipleAlignmentRow.cpp
+++ b/src/corelibs/U2Core/src/datatype/msa/MultipleAlignmentRow.cpp
@@ -107,4 +107,33 @@ bool MultipleAlignmentRowData::isEqualsIgnoreGaps(const MultipleAlignmentRowData
     return row1->getUngappedSequence().seq == row2->getUngappedSequence().seq;
 }
 
+QByteArray MultipleAlignmentRowData::getSequenceWithGaps(bool keepLeadingGaps, bool keepTrailingGaps) const {
+    QByteArray bytes = sequence.constSequence();
+    int beginningOffset = 0;
+
+    if (gaps.isEmpty()) {
+        return bytes;
+    }
+
+    for (int i = 0; i < gaps.size(); ++i) {
+        QByteArray gapsBytes;
+        if (!keepLeadingGaps && (0 == gaps[i].offset)) {
+            beginningOffset = gaps[i].gap;
+            continue;
+        }
+
+        gapsBytes.fill(U2Msa::GAP_CHAR, gaps[i].gap);
+        bytes.insert(gaps[i].offset - beginningOffset, gapsBytes);
+    }
+    MultipleAlignmentData* alignment = getMultipleAlignmentData();
+    SAFE_POINT(alignment != nullptr, "Parent MAlignment is NULL", QByteArray());
+    if (keepTrailingGaps && bytes.size() < alignment->getLength()) {
+        QByteArray gapsBytes;
+        gapsBytes.fill(U2Msa::GAP_CHAR, alignment->getLength() - bytes.size());
+        bytes.append(gapsBytes);
+    }
+
+    return bytes;
+}
+
 }    // namespace U2

--- a/src/corelibs/U2Core/src/datatype/msa/MultipleAlignmentRow.h
+++ b/src/corelibs/U2Core/src/datatype/msa/MultipleAlignmentRow.h
@@ -139,6 +139,12 @@ public:
     /* Compares sequences of 2 rows ignoring gaps. */
     static bool isEqualsIgnoreGaps(const MultipleAlignmentRowData *row1, const MultipleAlignmentRowData *row2);
 
+    /** Joins sequence chars and gaps into one byte array. */
+    QByteArray getSequenceWithGaps(bool keepLeadingGaps, bool keepTrailingGaps) const;
+
+    /** Returns whole alignment data. */
+    virtual MultipleAlignmentData *getMultipleAlignmentData() const = 0;
+
 protected:
     /** The sequence of the row without gaps (cached) */
     DNASequence sequence;

--- a/src/corelibs/U2Core/src/datatype/msa/MultipleChromatogramAlignmentRow.h
+++ b/src/corelibs/U2Core/src/datatype/msa/MultipleChromatogramAlignmentRow.h
@@ -237,6 +237,8 @@ public:
 
     MultipleChromatogramAlignmentRow getExplicitCopy() const;
 
+    MultipleAlignmentData *getMultipleAlignmentData() const override;
+
     void setAdditionalInfo(const QVariantMap &additionalInfo);
     QVariantMap getAdditionalInfo() const;
 
@@ -258,12 +260,6 @@ private:
      * Warning: it is not verified that the row sequence is not empty.
      */
     static void addOffsetToGapModel(QList<U2MsaGap> &gapModel, int offset);
-
-    /**
-     * Joins sequence chars and gaps into one byte array.
-     * "keepOffset" specifies to take into account gaps at the beginning of the row.
-     */
-    QByteArray joinCharsAndGaps(bool keepOffset, bool keepTrailingGaps) const;
 
     /** Gets the length of all gaps */
     inline int getGapsLength() const;

--- a/src/corelibs/U2Core/src/datatype/msa/MultipleSequenceAlignmentRow.cpp
+++ b/src/corelibs/U2Core/src/datatype/msa/MultipleSequenceAlignmentRow.cpp
@@ -176,7 +176,7 @@ QByteArray MultipleSequenceAlignmentRowData::toByteArray(U2OpStatus &os, qint64 
         return sequence.constSequence();
     }
 
-    QByteArray bytes = joinCharsAndGaps(true, true);
+    QByteArray bytes = getSequenceWithGaps(true, true);
 
     // Append additional gaps, if necessary
     if (length > bytes.count()) {
@@ -198,11 +198,11 @@ int MultipleSequenceAlignmentRowData::getRowLength() const {
 }
 
 QByteArray MultipleSequenceAlignmentRowData::getCore() const {
-    return joinCharsAndGaps(false, false);
+    return getSequenceWithGaps(false, false);
 }
 
 QByteArray MultipleSequenceAlignmentRowData::getData() const {
-    return joinCharsAndGaps(true, true);
+    return getSequenceWithGaps(true, true);
 }
 
 qint64 MultipleSequenceAlignmentRowData::getCoreLength() const {
@@ -508,34 +508,6 @@ void MultipleSequenceAlignmentRowData::addOffsetToGapModel(QList<U2MsaGap> &gapM
     }
 }
 
-QByteArray MultipleSequenceAlignmentRowData::joinCharsAndGaps(bool keepOffset, bool keepTrailingGaps) const {
-    QByteArray bytes = sequence.constSequence();
-    int beginningOffset = 0;
-
-    if (gaps.isEmpty()) {
-        return bytes;
-    }
-
-    for (int i = 0; i < gaps.size(); ++i) {
-        QByteArray gapsBytes;
-        if (!keepOffset && (0 == gaps[i].offset)) {
-            beginningOffset = gaps[i].gap;
-            continue;
-        }
-
-        gapsBytes.fill(U2Msa::GAP_CHAR, gaps[i].gap);
-        bytes.insert(gaps[i].offset - beginningOffset, gapsBytes);
-    }
-    SAFE_POINT(alignment != nullptr, "Parent MAlignment is NULL", QByteArray());
-    if (keepTrailingGaps && bytes.size() < alignment->getLength()) {
-        QByteArray gapsBytes;
-        gapsBytes.fill(U2Msa::GAP_CHAR, alignment->getLength() - bytes.size());
-        bytes.append(gapsBytes);
-    }
-
-    return bytes;
-}
-
 void MultipleSequenceAlignmentRowData::mergeConsecutiveGaps() {
     MsaRowUtils::mergeConsecutiveGaps(gaps);
 }
@@ -611,6 +583,10 @@ void MultipleSequenceAlignmentRowData::setParentAlignment(MultipleSequenceAlignm
 
 int MultipleSequenceAlignmentRowData::getCoreStart() const {
     return MsaRowUtils::getCoreStart(gaps);
+}
+
+MultipleAlignmentData *MultipleSequenceAlignmentRowData::getMultipleAlignmentData() const {
+    return alignment;
 }
 
 }    // namespace U2

--- a/src/corelibs/U2Core/src/datatype/msa/MultipleSequenceAlignmentRow.h
+++ b/src/corelibs/U2Core/src/datatype/msa/MultipleSequenceAlignmentRow.h
@@ -221,6 +221,8 @@ public:
 
     MultipleSequenceAlignmentRow getExplicitCopy() const;
 
+    MultipleAlignmentData *getMultipleAlignmentData() const override;
+
 private:
     /** Splits input to sequence bytes and gaps model */
     static void splitBytesToCharsAndGaps(const QByteArray &input, QByteArray &seqBytes, QList<U2MsaGap> &gapModel);
@@ -230,12 +232,6 @@ private:
      * Warning: it is not verified that the row sequence is not empty.
      */
     static void addOffsetToGapModel(QList<U2MsaGap> &gapModel, int offset);
-
-    /**
-     * Joins sequence chars and gaps into one byte array.
-     * "keepOffset" specifies to take into account gaps at the beginning of the row.
-     */
-    QByteArray joinCharsAndGaps(bool keepOffset, bool keepTrailingGaps) const;
 
     /** Gets the length of all gaps */
     inline int getGapsLength() const;

--- a/src/corelibs/U2Core/src/globals/L10n.h
+++ b/src/corelibs/U2Core/src/globals/L10n.h
@@ -124,6 +124,15 @@ public:
     static QString errorDocumentNotFound(const GUrl &url) {
         return tr("Document not found: %1").arg(url.getURLString());
     }
+
+    static QString errorObjectNotFound(const QString &objectName) {
+        return tr("Object not found: %1").arg(objectName);
+    }
+
+    static QString errorObjectIsReadOnly(const QString &objectName) {
+        return tr("Object is read only: %1").arg(objectName);
+    }
+
     static QString suffixBp() {
         return tr(" bp");
     }

--- a/src/corelibs/U2Core/src/gobjects/GObjectUtils.h
+++ b/src/corelibs/U2Core/src/gobjects/GObjectUtils.h
@@ -39,7 +39,11 @@ public:
 
     static GObject *selectOne(const QList<GObject *> &objects, GObjectType type, UnloadedObjectFilter f);
 
-    static QList<GObject *> findAllObjects(UnloadedObjectFilter f, GObjectType t = GObjectType());
+    /**
+     * Returns list of all objects from the active project that match the parameters.
+     * 'objectType' may be empty. In this case any object type is matched.
+     */
+    static QList<GObject *> findAllObjects(const UnloadedObjectFilter &unloadedObjectFilter, const GObjectType &objectType = GObjectType(), bool writableOnly = false);
 
     /*
      * Select objects from @fromObjects that are referenced by relations stored in @obj with @relationRole and @type.

--- a/src/corelibs/U2View/U2View.pro
+++ b/src/corelibs/U2View/U2View.pro
@@ -56,6 +56,7 @@ HEADERS += src/LicenseDialog.h \
            src/ov_msa/MaConsensusMismatchController.h \
            src/ov_msa/MaEditor.h \
            src/ov_msa/MaEditorConsensusAreaSettings.h \
+           src/ov_msa/MaEditorContext.h \
            src/ov_msa/MaEditorFactory.h \
            src/ov_msa/MaEditorNameList.h \
            src/ov_msa/MaEditorState.h \
@@ -109,6 +110,7 @@ HEADERS += src/LicenseDialog.h \
            src/ov_msa/highlighting/MsaSchemesMenuBuilder.h \
            src/ov_msa/mca_reads/McaAlternativeMutationsWidget.h \
            src/ov_msa/mca_reads/McaReadsTabFactory.h \
+           src/ov_msa/move_to_object/MoveToObjectMaController.h \
            src/ov_msa/overview/MaEditorOverviewArea.h \
            src/ov_msa/overview/MaGraphCalculationTask.h \
            src/ov_msa/overview/MaGraphOverview.h \
@@ -337,6 +339,7 @@ SOURCES += src/LicenseDialog.cpp \
            src/ov_msa/MaConsensusMismatchController.cpp \
            src/ov_msa/MaEditor.cpp \
            src/ov_msa/MaEditorConsensusAreaSettings.cpp \
+           src/ov_msa/MaEditorContext.cpp \
            src/ov_msa/MaEditorFactory.cpp \
            src/ov_msa/MaEditorNameList.cpp \
            src/ov_msa/MaEditorState.cpp \
@@ -388,6 +391,7 @@ SOURCES += src/LicenseDialog.cpp \
            src/ov_msa/highlighting/MsaSchemesMenuBuilder.cpp \
            src/ov_msa/mca_reads/McaAlternativeMutationsWidget.cpp \
            src/ov_msa/mca_reads/McaReadsTabFactory.cpp \
+           src/ov_msa/move_to_object/MoveToObjectMaController.cpp \
            src/ov_msa/overview/MaEditorOverviewArea.cpp \
            src/ov_msa/overview/MaGraphCalculationTask.cpp \
            src/ov_msa/overview/MaGraphOverview.cpp \

--- a/src/corelibs/U2View/src/ov_msa/MSAEditor.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditor.cpp
@@ -51,6 +51,7 @@
 #include "MaEditorNameList.h"
 #include "MaEditorTasks.h"
 #include "highlighting/MsaSchemesMenuBuilder.h"
+#include "move_to_object/MoveToObjectMaController.h"
 #include "overview/MaEditorOverviewArea.h"
 #include "realign_to_alignment/RealignSequencesInAlignmentTask.h"
 #include "view_rendering/MaEditorConsensusArea.h"
@@ -277,7 +278,7 @@ void MSAEditor::addCopyPasteMenu(QMenu *m) {
     const MaEditorSelection &selection = getSelection();
     ui->copySelectionAction->setDisabled(selection.isEmpty());
 
-    //TODO:? move the signal emit point to a correct location.
+    // TODO:? move the signal emit point to a correct location.
     auto sequenceArea = qobject_cast<MSAEditorSequenceArea *>(ui->getSequenceArea());
     SAFE_POINT(sequenceArea != nullptr, "sequenceArea is null", );
     emit sequenceArea->si_copyFormattedChanging(!selection.isEmpty());
@@ -405,7 +406,7 @@ void MSAEditor::addNavigationMenu(QMenu *m) {
 
 void MSAEditor::addTreeMenu(QMenu *m) {
     QMenu *em = m->addMenu(tr("Tree"));
-    //em->setIcon(QIcon(":core/images/tree.png"));
+    // em->setIcon(QIcon(":core/images/tree.png"));
     em->menuAction()->setObjectName(MSAE_MENU_TREES);
     em->addAction(buildTreeAction);
 }
@@ -503,6 +504,8 @@ QWidget *MSAEditor::createWidget() {
     sl_hideTreeOP();
 
     treeManager.loadRelatedTrees();
+
+    new MoveToObjectMaController(this);
 
     initDragAndDropSupport();
     updateActions();

--- a/src/corelibs/U2View/src/ov_msa/MSAEditor.h
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditor.h
@@ -132,7 +132,7 @@ public:
     void removeFreeModeMasterMarker(QObject *marker);
 
 protected slots:
-    void sl_onContextMenuRequested(const QPoint &pos);
+    void sl_onContextMenuRequested(const QPoint &pos) override;
 
     void sl_buildTree();
     void sl_align();

--- a/src/corelibs/U2View/src/ov_msa/MaEditorContext.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorContext.cpp
@@ -34,7 +34,7 @@ MaEditorContext::MaEditorContext(MaEditor *maEditor)
       maObject(maEditor->getMaObject()),
       ui(maEditor->getUI()),
       selectionController(maEditor->getSelectionController()),
-      collapseModel(editor->getUI()->getCollapseModel()) {
+      collapseModel(editor->getCollapseModel()) {
     SAFE_POINT(maObject != nullptr, "maObject is null", );
     SAFE_POINT(ui != nullptr, "ui is null", );
     SAFE_POINT(selectionController != nullptr, "selectionController is null", );

--- a/src/corelibs/U2View/src/ov_msa/MaEditorContext.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorContext.cpp
@@ -1,0 +1,48 @@
+/**
+ * UGENE - Integrated Bioinformatics Tools.
+ * Copyright (C) 2008-2021 UniPro <ugene@unipro.ru>
+ * http://ugene.net
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#include "MaEditorContext.h"
+
+#include <U2Core/U2SafePoints.h>
+
+#include "MaEditor.h"
+#include "view_rendering/MaEditorSelection.h"
+#include "view_rendering/MaEditorWgt.h"
+
+namespace U2 {
+
+MaEditorContext::MaEditorContext(MaEditor *maEditor)
+    : editor(maEditor),
+      maObject(maEditor->getMaObject()),
+      ui(maEditor->getUI()),
+      selectionController(maEditor->getSelectionController()),
+      collapseModel(editor->getUI()->getCollapseModel()) {
+    SAFE_POINT(maObject != nullptr, "maObject is null", );
+    SAFE_POINT(ui != nullptr, "ui is null", );
+    SAFE_POINT(selectionController != nullptr, "selectionController is null", );
+    SAFE_POINT(collapseModel != nullptr, "collapseModel is null", );
+}
+
+const MaEditorSelection &MaEditorContext::getSelection() const {
+    return selectionController->getSelection();
+}
+
+}    // namespace U2

--- a/src/corelibs/U2View/src/ov_msa/MaEditorContext.h
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorContext.h
@@ -1,0 +1,57 @@
+/**
+ * UGENE - Integrated Bioinformatics Tools.
+ * Copyright (C) 2008-2021 UniPro <ugene@unipro.ru>
+ * http://ugene.net
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#ifndef _U2_MAEDITOR_CONTEXT_H_
+#define _U2_MAEDITOR_CONTEXT_H_
+
+#include <U2Core/global.h>
+
+namespace U2 {
+
+class MaEditor;
+class MultipleAlignmentObject;
+class MaEditorWgt;
+class MaEditorSelectionController;
+class MaEditorSelection;
+class MaCollapseModel;
+
+/**
+ * Holds immutable pointers to the core models and controllers in MAEditor: the editor itself, ma-object, UI, controllers, etc.
+ * Helps to avoid a boilerplate code with a lot of getters and nullptr checks.
+ *
+ * This class when instantiated guarantees that all fields are valid and non-null.
+ */
+class U2VIEW_EXPORT MaEditorContext {
+public:
+    MaEditorContext(MaEditor *editor);
+
+    MaEditor *const editor;
+    MultipleAlignmentObject *const maObject;
+    MaEditorWgt *const ui;
+    MaEditorSelectionController *const selectionController;
+    MaCollapseModel *const collapseModel;
+
+    const MaEditorSelection &getSelection() const;
+};
+
+}    // namespace U2
+
+#endif    // _U2_MAEDITOR_CONTEXT_H_

--- a/src/corelibs/U2View/src/ov_msa/move_to_object/MoveToObjectMaController.cpp
+++ b/src/corelibs/U2View/src/ov_msa/move_to_object/MoveToObjectMaController.cpp
@@ -79,7 +79,7 @@ QMenu *MoveToObjectMaController::buildMoveSelectionToAnotherObjectMenu() const {
             U2OpStatusImpl os;
             for (const QRect &rect : qAsConst(selectedRects)) {
                 for (int viewRowIndex = rect.top(); viewRowIndex <= rect.bottom(); viewRowIndex++) {
-                    int maRowIndex = ui->getCollapseModel()->getMaRowIndexByViewRowIndex(viewRowIndex);
+                    int maRowIndex = collapseModel->getMaRowIndexByViewRowIndex(viewRowIndex);
                     SAFE_POINT(maRowIndex >= 0, "MA row not found. View row: " + QString::number(viewRowIndex), );
                     maRowIndexesToRemove << maRowIndex;
                     MultipleAlignmentRow row = maObject->getRow(maRowIndex);

--- a/src/corelibs/U2View/src/ov_msa/move_to_object/MoveToObjectMaController.cpp
+++ b/src/corelibs/U2View/src/ov_msa/move_to_object/MoveToObjectMaController.cpp
@@ -1,0 +1,130 @@
+/**
+ * UGENE - Integrated Bioinformatics Tools.
+ * Copyright (C) 2008-2021 UniPro <ugene@unipro.ru>
+ * http://ugene.net
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#include "MoveToObjectMaController.h"
+
+#include <QMessageBox>
+
+#include <U2Core/AddSequencesToAlignmentTask.h>
+#include <U2Core/AppContext.h>
+#include <U2Core/DocumentModel.h>
+#include <U2Core/GObject.h>
+#include <U2Core/GObjectTypes.h>
+#include <U2Core/GObjectUtils.h>
+#include <U2Core/L10n.h>
+#include <U2Core/MultipleSequenceAlignmentObject.h>
+#include <U2Core/U2Mod.h>
+#include <U2Core/U2OpStatusUtils.h>
+
+#include <U2Gui/GUIUtils.h>
+
+#include <U2View/MSAEditor.h>
+#include <U2View/MaCollapseModel.h>
+#include <U2View/MaEditor.h>
+#include <U2View/MaEditorSelection.h>
+#include <U2View/MaEditorWgt.h>
+
+namespace U2 {
+
+MoveToObjectMaController::MoveToObjectMaController(MaEditor *maEditor)
+    : QObject(maEditor), MaEditorContext(maEditor) {
+    moveSelectionToAnotherObjectAction = new QAction(tr("Move selected rows to another alignment"));
+    moveSelectionToAnotherObjectAction->setObjectName("move_selection_to_another_object");
+    connect(moveSelectionToAnotherObjectAction, &QAction::triggered, this, &MoveToObjectMaController::showMoveSelectedRowsToAnotherObjectMenu);
+
+    connect(editor, &MaEditor::si_updateActions, this, &MoveToObjectMaController::updateActions);
+    connect(editor, &MaEditor::si_buildMenu, this, &MoveToObjectMaController::buildMenu);
+}
+
+QMenu *MoveToObjectMaController::buildMoveSelectionToAnotherObjectMenu() const {
+    QMenu *menu = new QMenu(moveSelectionToAnotherObjectAction->text());
+    QList<GObject *> writableMsaObjects = GObjectUtils::findAllObjects(UOF_LoadedOnly, GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, true);
+    writableMsaObjects.removeOne(maObject);
+    std::stable_sort(writableMsaObjects.begin(), writableMsaObjects.end(), [&](const GObject *o1, const GObject *o2) {
+        return o1->getGObjectName().compare(o2->getGObjectName(), Qt::CaseInsensitive);
+    });
+    for (const GObject *object : qAsConst(writableMsaObjects)) {
+        GObjectReference reference(object);
+        QString fileName = object->getDocument()->getURL().fileName();
+        QString menuItemText = object->getGObjectName() + " [" + fileName + "] ";
+        QAction *action = menu->addAction(menuItemText, [this, reference]() {
+            GObject *object = GObjectUtils::selectObjectByReference(reference, UOF_LoadedOnly);
+            CHECK_EXT(object != nullptr, QMessageBox::critical(ui, L10N::errorTitle(), L10N::errorObjectNotFound(reference.objName)), );
+            CHECK_EXT(!object->isStateLocked(), QMessageBox::critical(ui, L10N::errorTitle(), L10N::errorObjectIsReadOnly(reference.objName)), );
+
+            auto targetMsaObject = qobject_cast<MultipleSequenceAlignmentObject *>(object);
+            CHECK_EXT(targetMsaObject != nullptr, QMessageBox::critical(ui, L10N::errorTitle(), L10N::nullPointerError(reference.objName)), );
+
+            const QList<QRect> &selectedRects = getSelection().getRectList();
+            QList<DNASequence> sequencesWithGapsToMove;
+            QList<int> maRowIndexesToRemove;
+            U2OpStatusImpl os;
+            for (const QRect &rect : qAsConst(selectedRects)) {
+                for (int viewRowIndex = rect.top(); viewRowIndex <= rect.bottom(); viewRowIndex++) {
+                    int maRowIndex = ui->getCollapseModel()->getMaRowIndexByViewRowIndex(viewRowIndex);
+                    SAFE_POINT(maRowIndex >= 0, "MA row not found. View row: " + QString::number(viewRowIndex), );
+                    maRowIndexesToRemove << maRowIndex;
+                    MultipleAlignmentRow row = maObject->getRow(maRowIndex);
+                    QByteArray sequenceWithGaps = row->getSequenceWithGaps(true, false);
+                    CHECK_OP_EXT(os, QMessageBox::critical(ui, L10N::errorTitle(), os.getError()), );
+                    sequencesWithGapsToMove << DNASequence(row->getName(), sequenceWithGaps, maObject->getAlphabet());
+                }
+            }
+            CHECK_EXT(maRowIndexesToRemove.size() < maObject->getNumRows(), os.setError(tr("Can't remove all rows from the alignment")), );
+            U2UseCommonUserModStep userModStep(maObject->getEntityRef(), os);
+            CHECK_OP(os, );
+            maObject->removeRows(maRowIndexesToRemove);
+            // If not cleared explicitly another row is auto-selected and the result may be misinterpret like not all rows were moved.
+            selectionController->clearSelection();
+
+            auto addRowsTask = new AddSequenceObjectsToAlignmentTask(targetMsaObject, sequencesWithGapsToMove, -1, true);
+            AppContext::getTaskScheduler()->registerTopLevelTask(addRowsTask);
+        });
+        action->setObjectName(fileName);    // For UI testing.
+    }
+    if (menu->isEmpty()) {
+        QAction *noObjectsAction = menu->addAction(tr("No other alignment objects in the project"), []() {});
+        noObjectsAction->setObjectName("no_other_objects_item");
+        noObjectsAction->setEnabled(false);
+    }
+    menu->setEnabled(moveSelectionToAnotherObjectAction->isEnabled());
+    return menu;
+}
+
+void MoveToObjectMaController::showMoveSelectedRowsToAnotherObjectMenu() {
+    QScopedPointer<QMenu> menu(buildMoveSelectionToAnotherObjectMenu());
+    menu->exec(QCursor::pos());
+}
+
+void MoveToObjectMaController::updateActions() {
+    int countOfSelectedRows = getSelection().getCountOfSelectedRows();
+    moveSelectionToAnotherObjectAction->setEnabled(!maObject->isStateLocked() && countOfSelectedRows > 0 && countOfSelectedRows < maObject->getNumRows());
+}
+
+void MoveToObjectMaController::buildMenu(GObjectView *, QMenu *menu, const QString &menuType) {
+    CHECK(menuType == MsaEditorMenuType::CONTEXT, );
+    QMenu *exportMenu = GUIUtils::findSubMenu(menu, MSAE_MENU_EXPORT);
+    SAFE_POINT(exportMenu != nullptr, "exportMenu is null", );
+    QAction *menuAction = exportMenu->addMenu(buildMoveSelectionToAnotherObjectMenu());
+    menuAction->setObjectName(moveSelectionToAnotherObjectAction->objectName());
+}
+
+}    // namespace U2

--- a/src/corelibs/U2View/src/ov_msa/move_to_object/MoveToObjectMaController.h
+++ b/src/corelibs/U2View/src/ov_msa/move_to_object/MoveToObjectMaController.h
@@ -1,0 +1,61 @@
+/**
+ * UGENE - Integrated Bioinformatics Tools.
+ * Copyright (C) 2008-2021 UniPro <ugene@unipro.ru>
+ * http://ugene.net
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#ifndef _U2_MOVETOOBJECTMAMENUCONTROLLER_H_
+#define _U2_MOVETOOBJECTMAMENUCONTROLLER_H_
+
+#include <QAction>
+#include <QMenu>
+
+#include <U2View/MaEditorContext.h>
+
+namespace U2 {
+
+class MaEditorContext;
+class GObjectView;
+
+/** Implements set of actions to move data between different MA objects in project. */
+class MoveToObjectMaController : public QObject, public MaEditorContext {
+    Q_OBJECT
+public:
+    MoveToObjectMaController(MaEditor *maEditor);
+
+private slots:
+    /** Shows moveSelectionToAnotherObject at cursor position. */
+    void showMoveSelectedRowsToAnotherObjectMenu();
+
+    /** Adds 'moveSelectionToAnotherObjectAction' to the export menu. */
+    void buildMenu(GObjectView *view, QMenu *menu, const QString &menuType);
+
+    /** Updates all  si_updateActions from MaEditor. */
+    void updateActions();
+
+private:
+    /** Builds a new 'Move selection to another object' sub-menu. */
+    QMenu *buildMoveSelectionToAnotherObjectMenu() const;
+
+    /** Moves selected rows into another MSA object. */
+    QAction *moveSelectionToAnotherObjectAction = nullptr;
+};
+
+}    // namespace U2
+
+#endif    // _U2_MOVETOOBJECTMAMENUCONTROLLER_H_

--- a/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorSelection.cpp
+++ b/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorSelection.cpp
@@ -170,6 +170,14 @@ void MaEditorSelectionController::setSelection(const MaEditorSelection &newSelec
     emit si_selectionChanged(selection, oldSelection);
 }
 
+int MaEditorSelection::getCountOfSelectedRows() const {
+    int count = 0;
+    for (const QRect &rect : qAsConst(rectList)) {
+        count += rect.height();
+    }
+    return count;
+}
+
 /************************************************************************/
 /* McaEditorSelectionController */
 /************************************************************************/

--- a/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorSelection.h
+++ b/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorSelection.h
@@ -55,6 +55,9 @@ public:
     /** Returns true if selection contains 1 rect with 1x1 dimension. */
     bool isSingleBaseSelection() const;
 
+    /** Returns sum of height of all selected rects. */
+    int getCountOfSelectedRows() const;
+
     /**
      * Returns selection state as a rect.
      * The returned rect is a bounding rect for all rects in the 'rectList'.

--- a/src/include/U2View/MaCollapseModel.h
+++ b/src/include/U2View/MaCollapseModel.h
@@ -1,0 +1,1 @@
+#include "../../corelibs/U2View/src/ov_msa/MaCollapseModel.h"

--- a/src/include/U2View/MaEditor.h
+++ b/src/include/U2View/MaEditor.h
@@ -1,0 +1,1 @@
+#include "../../corelibs/U2View/src/ov_msa/MaEditor.h"

--- a/src/include/U2View/MaEditorContext.h
+++ b/src/include/U2View/MaEditorContext.h
@@ -1,0 +1,1 @@
+#include "../../corelibs/U2View/src/ov_msa/MaEditorContext.h"

--- a/src/include/U2View/MaEditorWgt.h
+++ b/src/include/U2View/MaEditorWgt.h
@@ -1,0 +1,1 @@
+#include "../../corelibs/U2View/src/ov_msa/view_rendering/MaEditorWgt.h"

--- a/src/libs_3rdparty/QSpec/src/drivers/GTKeyboardDriver.h
+++ b/src/libs_3rdparty/QSpec/src/drivers/GTKeyboardDriver.h
@@ -72,7 +72,7 @@ public:
 
     static keys key;
 
-private:
+    /** Maps Shift, Alt, Control and Meta modifiers to the corresponding key codes. */
     static QList<Qt::Key> modifiersToKeys(Qt::KeyboardModifiers m);
 };
 

--- a/src/libs_3rdparty/QSpec/src/primitives/PopupChooser.cpp
+++ b/src/libs_3rdparty/QSpec/src/primitives/PopupChooser.cpp
@@ -144,7 +144,7 @@ void PopupChecker::commonScenario() {
         GT_CHECK(!act->isChecked(), "action '" + act->objectName() + "' is checked");
         qDebug("GT_DEBUG_MESSAGE options.testFlag(IsUnchecked)");
     }
-    for (int i = 0; i < namePath.size() + 1; i++) {
+    for (int i = 0; i < namePath.size(); i++) {
         PopupChooser::clickEsc(os);
         GTGlobals::sleep(250);
     }

--- a/src/plugins/GUITestBase/src/GTUtilsMsaEditor.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsMsaEditor.cpp
@@ -261,9 +261,17 @@ void GTUtilsMsaEditor::clickSequence(GUITestOpStatus &os, int rowNumber, Qt::Mou
 #undef GT_METHOD_NAME
 
 #define GT_METHOD_NAME "clickSequenceName"
-void GTUtilsMsaEditor::clickSequenceName(GUITestOpStatus &os, const QString &sequenceName, Qt::MouseButton mouseButton) {
+void GTUtilsMsaEditor::clickSequenceName(GUITestOpStatus &os, const QString &sequenceName, const Qt::MouseButton &mouseButton, const Qt::KeyboardModifiers &modifiers) {
     moveToSequenceName(os, sequenceName);
+
+    QList<Qt::Key> modifierKeys = GTKeyboardDriver::modifiersToKeys(modifiers);
+    for (auto key : qAsConst(modifierKeys)) {
+        GTKeyboardDriver::keyPress(key);
+    }
     GTMouseDriver::click(mouseButton);
+    for (auto key : qAsConst(modifierKeys)) {
+        GTKeyboardDriver::keyRelease(key);
+    }
 }
 #undef GT_METHOD_NAME
 
@@ -299,6 +307,14 @@ void GTUtilsMsaEditor::selectRows(GUITestOpStatus &os, int firstRowNumber, int l
             GT_CHECK(false, "Not implemented");
         default:
             GT_CHECK(false, "An unknown method");
+    }
+}
+#undef GT_METHOD_NAME
+
+#define GT_METHOD_NAME "selectRowsByName"
+void GTUtilsMsaEditor::selectRowsByName(HI::GUITestOpStatus &os, const QStringList &rowNames) {
+    for (const QString &rowName : qAsConst(rowNames)) {
+        clickSequenceName(os, rowName, Qt::LeftButton, Qt::ControlModifier);
     }
 }
 #undef GT_METHOD_NAME

--- a/src/plugins/GUITestBase/src/GTUtilsMsaEditor.h
+++ b/src/plugins/GUITestBase/src/GTUtilsMsaEditor.h
@@ -75,15 +75,25 @@ public:
     static void moveToSequence(HI::GUITestOpStatus &os, int rowNumber);
     static void moveToSequenceName(HI::GUITestOpStatus &os, const QString &sequenceName);
     static void clickSequence(HI::GUITestOpStatus &os, int rowNumber, Qt::MouseButton mouseButton = Qt::LeftButton);
-    static void clickSequenceName(HI::GUITestOpStatus &os, const QString &sequenceName, Qt::MouseButton mouseButton = Qt::LeftButton);
+
+    /** Clicks sequence with a mouse button and a keyboard key pressed. */
+    static void clickSequenceName(HI::GUITestOpStatus &os,
+                                  const QString &sequenceName,
+                                  const Qt::MouseButton& mouseButton = Qt::LeftButton,
+                                  const Qt::KeyboardModifiers &modifiers = Qt::NoModifier);
+
     static void moveToColumn(HI::GUITestOpStatus &os, int column);
     static void clickColumn(HI::GUITestOpStatus &os, int column, Qt::MouseButton mouseButton = Qt::LeftButton);
 
     static void selectRows(HI::GUITestOpStatus &os, int firstRowNumber, int lastRowNumber, HI::GTGlobals::UseMethod method = HI::GTGlobals::UseKey);
+
+    /** Select rows in the name list by name using Ctrl + Mouse click. Fails if any of the rows is not found. */
+    static void selectRowsByName(HI::GUITestOpStatus &os, const QStringList &rowNames);
+
     static void selectColumns(HI::GUITestOpStatus &os, int firstColumnNumber, int lastColumnNumber, HI::GTGlobals::UseMethod method = HI::GTGlobals::UseKey);
 
     /** Checks that MSA editor selection is equal to the given rect. Fails if not. */
-    static void checkSelection(HI::GUITestOpStatus &os, const QList<QRect>& expectedRects);
+    static void checkSelection(HI::GUITestOpStatus &os, const QList<QRect> &expectedRects);
 
     static void clearSelection(HI::GUITestOpStatus &os);
 

--- a/src/plugins/GUITestBase/src/GUITestBasePlugin.cpp
+++ b/src/plugins/GUITestBase/src/GUITestBasePlugin.cpp
@@ -2377,6 +2377,7 @@ void GUITestBasePlugin::registerTests(UGUITestBase *guiTestBase) {
     REGISTER_TEST(GUITest_common_scenarios_msa_editor::test_0093_1);
     REGISTER_TEST(GUITest_common_scenarios_msa_editor::test_0093_2);
     REGISTER_TEST(GUITest_common_scenarios_msa_editor::test_0094);
+    REGISTER_TEST(GUITest_common_scenarios_msa_editor::test_0095);
 
     /////////////////////////////////////////////////////////////////////////
     // Common align sequences to an alignment

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/GTTestsMsaEditor.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/GTTestsMsaEditor.cpp
@@ -44,6 +44,7 @@
 
 #include <QApplication>
 
+#include <U2Core/DocumentModel.h>
 #include <U2Core/TextUtils.h>
 
 #include <U2View/ADVConstants.h>
@@ -227,7 +228,7 @@ GUI_TEST_CLASS_DEFINITION(test_0002_2) {
     GTUtilsTaskTreeView::waitTaskFinished(os);
     GTGlobals::sleep(1000);
 
-    //GTUtilsMdi::click(os, GTGlobals::Maximize);
+    // GTUtilsMdi::click(os, GTGlobals::Maximize);
     GTGlobals::sleep();
 
     GTMenu::clickMainMenuItem(os, QStringList() << "Actions"
@@ -306,7 +307,7 @@ GUI_TEST_CLASS_DEFINITION(test_0002_4) {
     GTMouseDriver::doubleClick();
     GTGlobals::sleep();
 
-    //GTUtilsMdi::click(os, GTGlobals::Maximize);
+    // GTUtilsMdi::click(os, GTGlobals::Maximize);
     GTGlobals::sleep();
 
     GTUtilsDialog::waitForDialog(os, new PopupChooser(os, QStringList() << MSAE_MENU_APPEARANCE << "show_offsets"));
@@ -570,7 +571,7 @@ GUI_TEST_CLASS_DEFINITION(test_0005_2) {
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0007) {
-    //1. Open document _common_data\scenarios\msa\ma2_gapped.aln
+    // 1. Open document _common_data\scenarios\msa\ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
     GTGlobals::sleep(1000);
@@ -578,30 +579,30 @@ GUI_TEST_CLASS_DEFINITION(test_0007) {
     QWidget *mdiWindow = GTUtilsMdi::activeWindow(os);
     CHECK_SET_ERR(mdiWindow != nullptr, "MDI window == NULL");
 
-    //Expected state: Aligniment length 14, left offset 1, right offset 14
+    // Expected state: Aligniment length 14, left offset 1, right offset 14
 
-    //2. Do double click on Tettigonia_viridissima sequence name.
-    //Expected state: Rename dialog appears
-    //3. Put "Sequence_a" into text field. Click OK.
+    // 2. Do double click on Tettigonia_viridissima sequence name.
+    // Expected state: Rename dialog appears
+    // 3. Put "Sequence_a" into text field. Click OK.
 
     GTUtilsDialog::waitForDialog(os, new RenameSequenceFiller(os, "Sequence_a", "Tettigonia_viridissima"));
     GTUtilsMSAEditorSequenceArea::moveTo(os, QPoint(-10, 3));
     GTMouseDriver::doubleClick();
     GTGlobals::sleep();
 
-    //Expected state: Tettigonia_viridissima renamed to Sequence_a
+    // Expected state: Tettigonia_viridissima renamed to Sequence_a
     GTUtilsDialog::waitForDialog(os, new RenameSequenceFiller(os, "Sequence_a", "Sequence_a"));
     GTUtilsMSAEditorSequenceArea::moveTo(os, QPoint(-10, 3));
     GTMouseDriver::doubleClick();
     GTGlobals::sleep();
 
-    //4. Rlick Undo button.
+    // 4. Rlick Undo button.
     QAbstractButton *undo = GTAction::button(os, "msa_action_undo");
     GTWidget::click(os, undo);
-    //GTKeyboardDriver::keyClick( 'z', Qt::ControlModifier);
+    // GTKeyboardDriver::keyClick( 'z', Qt::ControlModifier);
     GTGlobals::sleep();
 
-    //Expected state: Tettigonia_viridissima renamed back
+    // Expected state: Tettigonia_viridissima renamed back
     GTUtilsDialog::waitForDialog(os, new RenameSequenceFiller(os, "Tettigonia_viridissima", "Tettigonia_viridissima"));
     GTUtilsMSAEditorSequenceArea::moveTo(os, QPoint(-10, 3));
     GTMouseDriver::doubleClick();
@@ -609,7 +610,7 @@ GUI_TEST_CLASS_DEFINITION(test_0007) {
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0007_1) {
-    //1. Open document _common_data\scenarios\msa\ma2_gapped.aln
+    // 1. Open document _common_data\scenarios\msa\ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
     GTGlobals::sleep(1000);
@@ -617,29 +618,29 @@ GUI_TEST_CLASS_DEFINITION(test_0007_1) {
     QWidget *mdiWindow = GTUtilsMdi::activeWindow(os);
     CHECK_SET_ERR(mdiWindow != nullptr, "MDI window == NULL");
 
-    //Expected state: Aligniment length 14, left offset 1, right offset 14
+    // Expected state: Aligniment length 14, left offset 1, right offset 14
 
-    //2. Do double click on Tettigonia_viridissima sequence name.
-    //Expected state: Rename dialog appears
-    //3. Put "Sequence_a" into text field. Click OK.
+    // 2. Do double click on Tettigonia_viridissima sequence name.
+    // Expected state: Rename dialog appears
+    // 3. Put "Sequence_a" into text field. Click OK.
 
     GTUtilsDialog::waitForDialog(os, new RenameSequenceFiller(os, "Sequence_a", "Tettigonia_viridissima"));
     GTUtilsMSAEditorSequenceArea::moveTo(os, QPoint(-10, 3));
     GTMouseDriver::doubleClick();
     GTGlobals::sleep();
 
-    //Expected state: Tettigonia_viridissima renamed to Sequence_a
+    // Expected state: Tettigonia_viridissima renamed to Sequence_a
 
     GTUtilsDialog::waitForDialog(os, new RenameSequenceFiller(os, "Sequence_a", "Sequence_a"));
     GTUtilsMSAEditorSequenceArea::moveTo(os, QPoint(-10, 3));
     GTMouseDriver::doubleClick();
     GTGlobals::sleep();
 
-    //4. Rlick Undo button. CHANGES: clicking undo by mouse
+    // 4. Rlick Undo button. CHANGES: clicking undo by mouse
     GTWidget::click(os, GTToolbar::getWidgetForActionObjectName(os, GTToolbar::getToolbar(os, "mwtoolbar_activemdi"), "msa_action_undo"));
     GTGlobals::sleep();
 
-    //Expected state: Tettigonia_viridissima renamed back
+    // Expected state: Tettigonia_viridissima renamed back
     GTUtilsDialog::waitForDialog(os, new RenameSequenceFiller(os, "Tettigonia_viridissima", "Tettigonia_viridissima"));
     GTUtilsMSAEditorSequenceArea::moveTo(os, QPoint(-10, 3));
     GTMouseDriver::doubleClick();
@@ -647,7 +648,7 @@ GUI_TEST_CLASS_DEFINITION(test_0007_1) {
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0007_2) {
-    //1. Open document _common_data\scenarios\msa\ma2_gapped.aln
+    // 1. Open document _common_data\scenarios\msa\ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
     GTGlobals::sleep(1000);
@@ -655,28 +656,28 @@ GUI_TEST_CLASS_DEFINITION(test_0007_2) {
     QWidget *mdiWindow = GTUtilsMdi::activeWindow(os);
     CHECK_SET_ERR(mdiWindow != nullptr, "MDI window == NULL");
 
-    //Expected state: Aligniment length 14, left offset 1, right offset 14
+    // Expected state: Aligniment length 14, left offset 1, right offset 14
 
-    //2. Do double click on Tettigonia_viridissima sequence name. CHANGES: another sequence renamed
-    //Expected state: Rename dialog appears
-    //3. Put "Sequence_a" into text field. Click OK.
+    // 2. Do double click on Tettigonia_viridissima sequence name. CHANGES: another sequence renamed
+    // Expected state: Rename dialog appears
+    // 3. Put "Sequence_a" into text field. Click OK.
 
     GTUtilsDialog::waitForDialog(os, new RenameSequenceFiller(os, "Sequence_a", "Bicolorana_bicolor_EF540830"));
     GTUtilsMSAEditorSequenceArea::moveTo(os, QPoint(-10, 2));
     GTMouseDriver::doubleClick();
     GTGlobals::sleep();
 
-    //Expected state: Tettigonia_viridissima renamed to Sequence_a
+    // Expected state: Tettigonia_viridissima renamed to Sequence_a
     GTUtilsDialog::waitForDialog(os, new RenameSequenceFiller(os, "Sequence_a", "Sequence_a"));
     GTUtilsMSAEditorSequenceArea::moveTo(os, QPoint(-10, 2));
     GTMouseDriver::doubleClick();
     GTGlobals::sleep();
 
-    //4. Rlick Undo button.
+    // 4. Rlick Undo button.
     GTKeyboardDriver::keyClick('z', Qt::ControlModifier);
     GTGlobals::sleep();
 
-    //Expected state: Tettigonia_viridissima renamed back
+    // Expected state: Tettigonia_viridissima renamed back
     GTUtilsDialog::waitForDialog(os, new RenameSequenceFiller(os, "Bicolorana_bicolor_EF540830", "Bicolorana_bicolor_EF540830"));
     GTUtilsMSAEditorSequenceArea::moveTo(os, QPoint(-10, 2));
     GTMouseDriver::doubleClick();
@@ -684,7 +685,7 @@ GUI_TEST_CLASS_DEFINITION(test_0007_2) {
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0007_3) {
-    //1. Open document _common_data\scenarios\msa\ma2_gapped.aln
+    // 1. Open document _common_data\scenarios\msa\ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
     GTGlobals::sleep(1000);
@@ -692,28 +693,28 @@ GUI_TEST_CLASS_DEFINITION(test_0007_3) {
     QWidget *mdiWindow = GTUtilsMdi::activeWindow(os);
     CHECK_SET_ERR(mdiWindow != nullptr, "MDI window == NULL");
 
-    //Expected state: Aligniment length 14, left offset 1, right offset 14
+    // Expected state: Aligniment length 14, left offset 1, right offset 14
 
-    //2. Do double click on Tettigonia_viridissima sequence name. CHANGES: another sequence renamed
-    //Expected state: Rename dialog appears
-    //3. Put "Sequence_a" into text field. Click OK.
+    // 2. Do double click on Tettigonia_viridissima sequence name. CHANGES: another sequence renamed
+    // Expected state: Rename dialog appears
+    // 3. Put "Sequence_a" into text field. Click OK.
 
     GTUtilsDialog::waitForDialog(os, new RenameSequenceFiller(os, "Sequence_a", "Phaneroptera_falcata"));
     GTUtilsMSAEditorSequenceArea::moveTo(os, QPoint(-10, 0));
     GTMouseDriver::doubleClick();
     GTGlobals::sleep();
 
-    //Expected state: Tettigonia_viridissima renamed to Sequence_a
+    // Expected state: Tettigonia_viridissima renamed to Sequence_a
     GTUtilsDialog::waitForDialog(os, new RenameSequenceFiller(os, "Sequence_a", "Sequence_a"));
     GTUtilsMSAEditorSequenceArea::moveTo(os, QPoint(-10, 0));
     GTMouseDriver::doubleClick();
     GTGlobals::sleep();
 
-    //4. Rlick Undo button.
+    // 4. Rlick Undo button.
     GTKeyboardDriver::keyClick('z', Qt::ControlModifier);
     GTGlobals::sleep();
 
-    //Expected state: Tettigonia_viridissima renamed back
+    // Expected state: Tettigonia_viridissima renamed back
     GTUtilsDialog::waitForDialog(os, new RenameSequenceFiller(os, "Phaneroptera_falcata", "Phaneroptera_falcata"));
     GTUtilsMSAEditorSequenceArea::moveTo(os, QPoint(-10, 0));
     GTMouseDriver::doubleClick();
@@ -721,7 +722,7 @@ GUI_TEST_CLASS_DEFINITION(test_0007_3) {
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0007_4) {
-    //1. Open document _common_data\scenarios\msa\ma2_gapped.aln
+    // 1. Open document _common_data\scenarios\msa\ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
     GTGlobals::sleep(1000);
@@ -729,28 +730,28 @@ GUI_TEST_CLASS_DEFINITION(test_0007_4) {
     QWidget *mdiWindow = GTUtilsMdi::activeWindow(os);
     CHECK_SET_ERR(mdiWindow != nullptr, "MDI window == NULL");
 
-    //Expected state: Aligniment length 14, left offset 1, right offset 14
+    // Expected state: Aligniment length 14, left offset 1, right offset 14
 
-    //2. Do double click on Tettigonia_viridissima sequence name. CHANGES: another sequence renamed
-    //Expected state: Rename dialog appears
-    //3. Put "Sequence_a" into text field. Click OK.
+    // 2. Do double click on Tettigonia_viridissima sequence name. CHANGES: another sequence renamed
+    // Expected state: Rename dialog appears
+    // 3. Put "Sequence_a" into text field. Click OK.
 
     GTUtilsDialog::waitForDialog(os, new RenameSequenceFiller(os, "Sequence_a", "Conocephalus_sp."));
     GTUtilsMSAEditorSequenceArea::moveTo(os, QPoint(-10, 5));
     GTMouseDriver::doubleClick();
     GTGlobals::sleep();
 
-    //Expected state: Tettigonia_viridissima renamed to Sequence_a
+    // Expected state: Tettigonia_viridissima renamed to Sequence_a
     GTUtilsDialog::waitForDialog(os, new RenameSequenceFiller(os, "Sequence_a", "Sequence_a"));
     GTUtilsMSAEditorSequenceArea::moveTo(os, QPoint(-10, 5));
     GTMouseDriver::doubleClick();
     GTGlobals::sleep();
 
-    //4. Rlick Undo button.
+    // 4. Rlick Undo button.
     GTKeyboardDriver::keyClick('z', Qt::ControlModifier);
     GTGlobals::sleep();
 
-    //Expected state: Tettigonia_viridissima renamed back
+    // Expected state: Tettigonia_viridissima renamed back
     GTUtilsDialog::waitForDialog(os, new RenameSequenceFiller(os, "Conocephalus_sp.", "Conocephalus_sp."));
     GTUtilsMSAEditorSequenceArea::moveTo(os, QPoint(-10, 5));
     GTMouseDriver::doubleClick();
@@ -812,7 +813,7 @@ GUI_TEST_CLASS_DEFINITION(test_0008) {
 
     RO = GTUtilsMSAEditorSequenceArea::getLastVisibleBase(os);
     LO = GTUtilsMSAEditorSequenceArea::getFirstVisibleBase(os);
-    //CHECK_SET_ERR(endRO == RO && endLO == LO, "end bookmark offsets aren't equal to the expected");
+    // CHECK_SET_ERR(endRO == RO && endLO == LO, "end bookmark offsets aren't equal to the expected");
     CHECK_SET_ERR(endLO == LO, QString("end bookmark offsets aren't equal to the expected: endLO=%3 LO=%4").arg(endLO).arg(LO));
     //     7. Delete Start bookmark
     GTUtilsBookmarksTreeView::deleteBookmark(os, "start bookmark");
@@ -822,7 +823,7 @@ GUI_TEST_CLASS_DEFINITION(test_0008) {
     CHECK_SET_ERR(startBookmark == nullptr, "Start bookmark is not deleted");
 }
 
-GUI_TEST_CLASS_DEFINITION(test_0008_1) {    //CHANGES: default names used
+GUI_TEST_CLASS_DEFINITION(test_0008_1) {    // CHANGES: default names used
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW/COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
@@ -961,23 +962,23 @@ GUI_TEST_CLASS_DEFINITION(test_0008_3) {
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0009) {
-    //1. Open ma2_gapped.aln
+    // 1. Open ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
     GTGlobals::sleep();
 
-    //2. Select a trailing region length=3 (all gaps) for Isophia_altiacaEF540820
+    // 2. Select a trailing region length=3 (all gaps) for Isophia_altiacaEF540820
     GTUtilsMSAEditorSequenceArea::selectArea(os, QPoint(11, 1), QPoint(13, 1));
     GTGlobals::sleep();
 
-    //3. Do context menu {Align-> Align with MUSCLE}  use "column range"
+    // 3. Do context menu {Align-> Align with MUSCLE}  use "column range"
     GTUtilsDialog::waitForDialog(os, new MuscleDialogFiller(os));
 
     GTUtilsDialog::waitForDialog(os, new PopupChooser(os, QStringList() << MSAE_MENU_ALIGN << "Align with muscle", GTGlobals::UseKey));
     GTWidget::click(os, GTUtilsMdi::activeWindow(os), Qt::RightButton);
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    //Expected state: Column range = 12-14
+    // Expected state: Column range = 12-14
     GTUtilsMSAEditorSequenceArea::selectArea(os, QPoint(11, 0), QPoint(13, 9));
     GTKeyboardDriver::keyClick('c', Qt::ControlModifier);
     GTGlobals::sleep();
@@ -989,29 +990,29 @@ GUI_TEST_CLASS_DEFINITION(test_0009) {
 
     GTGlobals::sleep();
 
-    //4. Press Align
-    //Expected state: After aligning with 'stable' option the order must not change
+    // 4. Press Align
+    // Expected state: After aligning with 'stable' option the order must not change
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0009_1) {
-    //1. Open ma2_gapped.aln
+    // 1. Open ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
     GTGlobals::sleep();
 
-    //2. Select a trailing region length=3 (all gaps) for Isophia_altiacaEF540820
-    //CHANGES: selection from right to left
+    // 2. Select a trailing region length=3 (all gaps) for Isophia_altiacaEF540820
+    // CHANGES: selection from right to left
     GTUtilsMSAEditorSequenceArea::selectArea(os, QPoint(13, 1), QPoint(11, 1));
     GTGlobals::sleep();
 
-    //3. Do context menu {Align-> Align with MUSCLE}  use "column range"
+    // 3. Do context menu {Align-> Align with MUSCLE}  use "column range"
     GTUtilsDialog::waitForDialog(os, new MuscleDialogFiller(os));
 
     GTUtilsDialog::waitForDialog(os, new PopupChooser(os, QStringList() << MSAE_MENU_ALIGN << "Align with muscle", GTGlobals::UseKey));
     GTWidget::click(os, GTUtilsMdi::activeWindow(os), Qt::RightButton);
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    //Expected state: Column range = 12-14
+    // Expected state: Column range = 12-14
     GTUtilsMSAEditorSequenceArea::selectArea(os, QPoint(11, 0), QPoint(13, 9));
     GTKeyboardDriver::keyClick('c', Qt::ControlModifier);
 
@@ -1022,29 +1023,29 @@ GUI_TEST_CLASS_DEFINITION(test_0009_1) {
 
     GTGlobals::sleep();
 
-    //4. Press Align
-    //Expected state: After aligning with 'stable' option the order must not change
+    // 4. Press Align
+    // Expected state: After aligning with 'stable' option the order must not change
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0009_2) {
-    //1. Open ma2_gapped.aln
+    // 1. Open ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
     GTGlobals::sleep();
 
-    //2. Select a trailing region length=3 (all gaps) for Isophia_altiacaEF540820
-    //CHANGES: another region selected
+    // 2. Select a trailing region length=3 (all gaps) for Isophia_altiacaEF540820
+    // CHANGES: another region selected
     GTUtilsMSAEditorSequenceArea::selectArea(os, QPoint(11, 4), QPoint(13, 4));
     GTGlobals::sleep();
 
-    //3. Do context menu {Align-> Align with MUSCLE}  use "column range"
+    // 3. Do context menu {Align-> Align with MUSCLE}  use "column range"
     GTUtilsDialog::waitForDialog(os, new MuscleDialogFiller(os));
 
     GTUtilsDialog::waitForDialog(os, new PopupChooser(os, QStringList() << MSAE_MENU_ALIGN << "Align with muscle", GTGlobals::UseKey));
     GTWidget::click(os, GTUtilsMdi::activeWindow(os), Qt::RightButton);
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    //Expected state: Column range = 12-14
+    // Expected state: Column range = 12-14
     GTUtilsMSAEditorSequenceArea::selectArea(os, QPoint(11, 0), QPoint(13, 9));
     GTKeyboardDriver::keyClick('c', Qt::ControlModifier);
     GTGlobals::sleep();
@@ -1056,8 +1057,8 @@ GUI_TEST_CLASS_DEFINITION(test_0009_2) {
 
     GTGlobals::sleep();
 
-    //4. Press Align
-    //Expected state: After aligning with 'stable' option the order must not change
+    // 4. Press Align
+    // Expected state: After aligning with 'stable' option the order must not change
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0010) {
@@ -1240,8 +1241,8 @@ GUI_TEST_CLASS_DEFINITION(test_0011_2) {
                                                 << "Edit"
                                                 << "Replace selected rows with reverse-complement");
     GTGlobals::sleep();
-    //GTUtilsMSAEditorSequenceArea::selectArea(os, QPoint(0, 0), QPoint(-1, 0));
-    // Expected state: sequence changed from TTG -> CAA
+    // GTUtilsMSAEditorSequenceArea::selectArea(os, QPoint(0, 0), QPoint(-1, 0));
+    //  Expected state: sequence changed from TTG -> CAA
     GTGlobals::sleep();
     GTUtilsMSAEditorSequenceArea::moveTo(os, QPoint(0, 0));
     GTUtilsMSAEditorSequenceArea::copySelectionByContextMenu(os);
@@ -1261,7 +1262,7 @@ GUI_TEST_CLASS_DEFINITION(test_0011_2) {
                                                 << "Replace selected rows with reverse-complement");
 
     // Expected state: sequence changed from CAA -> TTG
-    //GTUtilsMSAEditorSequenceArea::selectArea(os, QPoint(0, 0), QPoint(-1, 0));
+    // GTUtilsMSAEditorSequenceArea::selectArea(os, QPoint(0, 0), QPoint(-1, 0));
     GTKeyboardDriver::keyClick('c', Qt::ControlModifier);
 
     clipboardText = GTClipboard::text(os);
@@ -1631,7 +1632,7 @@ GUI_TEST_CLASS_DEFINITION(test_0016_2) {
 
     // 2. Open same file in text editor. Change first 3 bases of 'Phaneroptera_falcata'
     //    from 'AAG' to 'CTT' and save file.
-    //CHANGES: backup old file, copy changed file
+    // CHANGES: backup old file, copy changed file
     GTUtilsDialog::waitForDialog(os, new MessageBoxDialogFiller(os, QMessageBox::Yes));
     GTGlobals::sleep(1000);    // ugene doesn't detect changes whithin one second interval
     GTFile::copy(os, testDir + "_common_data/scenarios/msa/ma2_gapped_edited.aln", sandBoxDir + "ma2_gapped.aln");
@@ -1932,71 +1933,71 @@ GUI_TEST_CLASS_DEFINITION(test_0021_2) {
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0022) {
-    //1. Open document _common_data\scenarios\msa\ma2_gapped.aln
+    // 1. Open document _common_data\scenarios\msa\ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //2. Select character â„–3 in "Phaneroptera_falcata"(G)
+    // 2. Select character â„–3 in "Phaneroptera_falcata"(G)
     GTUtilsMSAEditorSequenceArea::click(os, QPoint(2, 0));
     QLabel *posLabel = qobject_cast<QLabel *>(GTWidget::findWidget(os, "Position"));
     CHECK_SET_ERR(posLabel, "Position label not found");
     CHECK_SET_ERR(posLabel->text() == "Pos 3 / 14", "Expected text: Pos 3/14. Found: " + posLabel->text());
-    //Expected state: Statistics "Pos" in right bottom is "Pos 3/14"
+    // Expected state: Statistics "Pos" in right bottom is "Pos 3/14"
 
-    //3. Insert 3 gaps to first three positoons in "Phaneroptera_falcata"
+    // 3. Insert 3 gaps to first three positoons in "Phaneroptera_falcata"
     GTUtilsMSAEditorSequenceArea::click(os, QPoint(0, 0));
     for (int i = 0; i < 3; i++) {
         GTKeyboardDriver::keyClick(Qt::Key_Space);
         GTGlobals::sleep(200);
     }
-    //4. Select char at 4 position in "Phaneroptera_falcata"(A)
+    // 4. Select char at 4 position in "Phaneroptera_falcata"(A)
     GTUtilsMSAEditorSequenceArea::click(os, QPoint(3, 0));
     CHECK_SET_ERR(posLabel->text() == "Pos 1 / 14", "Expected text: Pos 1/14. Found: " + posLabel->text());
-    //Expected state: Gaps are inserted, statistics "Pos" in right bottom is "Pos 1/14"
+    // Expected state: Gaps are inserted, statistics "Pos" in right bottom is "Pos 1/14"
 }
 
-GUI_TEST_CLASS_DEFINITION(test_0022_1) {    //DIFFERENCE: Column label is tested
-    //1. Open document _common_data\scenarios\msa\ma2_gapped.aln
+GUI_TEST_CLASS_DEFINITION(test_0022_1) {    // DIFFERENCE: Column label is tested
+    // 1. Open document _common_data\scenarios\msa\ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //2. Select character â„–3 in "Phaneroptera_falcata"(G)
+    // 2. Select character â„–3 in "Phaneroptera_falcata"(G)
     GTUtilsMSAEditorSequenceArea::click(os, QPoint(2, 0));
     QLabel *colLabel = qobject_cast<QLabel *>(GTWidget::findWidget(os, "Column"));
     CHECK_SET_ERR(colLabel, "Column label not found");
     CHECK_SET_ERR(colLabel->text() == "Col 3 / 14", "Expected text: Col 3/14. Found: " + colLabel->text());
-    //Expected state: Statistics "Pos" in right bottom is "Pos 3/14"
+    // Expected state: Statistics "Pos" in right bottom is "Pos 3/14"
 
-    //3. Insert 3 gaps to first three positoons in "Phaneroptera_falcata"
+    // 3. Insert 3 gaps to first three positoons in "Phaneroptera_falcata"
     GTUtilsMSAEditorSequenceArea::click(os, QPoint(0, 0));
     for (int i = 0; i < 3; i++) {
         GTKeyboardDriver::keyClick(Qt::Key_Space);
         GTGlobals::sleep(200);
     }
-    //4. Select char at 4 position in "Phaneroptera_falcata"(A)
+    // 4. Select char at 4 position in "Phaneroptera_falcata"(A)
     GTUtilsMSAEditorSequenceArea::click(os, QPoint(3, 0));
     CHECK_SET_ERR(colLabel->text() == "Col 4 / 17", "Expected text: Col 4 / 17. Found: " + colLabel->text());
-    //Expected state: Gaps are inserted, statistics "Pos" in right bottom is "Pos 1/14"
+    // Expected state: Gaps are inserted, statistics "Pos" in right bottom is "Pos 1/14"
 }
 
-GUI_TEST_CLASS_DEFINITION(test_0022_2) {    //DIFFERENCE: Line label is tested
-    //1. Open document _common_data\scenarios\msa\ma2_gapped.aln
+GUI_TEST_CLASS_DEFINITION(test_0022_2) {    // DIFFERENCE: Line label is tested
+    // 1. Open document _common_data\scenarios\msa\ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    //2. Select the thirs character in "Phaneroptera_falcata"(G)
+    // 2. Select the thirs character in "Phaneroptera_falcata"(G)
     GTUtilsMSAEditorSequenceArea::click(os, QPoint(2, 0));
 
-    //Expected state: Statistics "Seq" in right bottom is "Seq 1 / 10"
+    // Expected state: Statistics "Seq" in right bottom is "Seq 1 / 10"
     QLabel *lineLabel = GTWidget::findExactWidget<QLabel *>(os, "Line");
     CHECK_SET_ERR(lineLabel, "Line label not found");
     CHECK_SET_ERR(lineLabel->text() == "Seq 1 / 10", "Expected text: Seq 1 / 10. Found: " + lineLabel->text());
 
-    //3. Select and delete 5 lines
+    // 3. Select and delete 5 lines
     GTUtilsMsaEditor::selectRows(os, 3, 7);
     GTKeyboardDriver::keyClick(Qt::Key_Delete);
 
-    //4. Select char at 4 position in "Phaneroptera_falcata"(A)
+    // 4. Select char at 4 position in "Phaneroptera_falcata"(A)
     GTUtilsMSAEditorSequenceArea::click(os, QPoint(3, 0));
-    //Expected state: Gaps are inserted, statistics "Seq" in right bottom is "Seq 1 / 5"
+    // Expected state: Gaps are inserted, statistics "Seq" in right bottom is "Seq 1 / 5"
     CHECK_SET_ERR(lineLabel->text() == "Seq 1 / 5", "Expected text: Seq 1 / 5. Found: " + lineLabel->text());
 }
 
@@ -2019,29 +2020,29 @@ GUI_TEST_CLASS_DEFINITION(test_0023) {
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0024) {
-    //1. open document samples/CLUSTALW/COI.aln
+    // 1. open document samples/CLUSTALW/COI.aln
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW/", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //2. select first symbol of first sequence
+    // 2. select first symbol of first sequence
     GTUtilsMSAEditorSequenceArea::moveTo(os, QPoint(0, 0));
     GTMouseDriver::click();
-    //3. press toolbar button "zoom to selection"
+    // 3. press toolbar button "zoom to selection"
     int initOffset = GTUtilsMSAEditorSequenceArea::getLastVisibleBase(os);
-    //offsets are used to check zooming
+    // offsets are used to check zooming
     QAbstractButton *zoom_to_sel = GTAction::button(os, "Zoom To Selection");
     GTWidget::click(os, zoom_to_sel);
 
     int finOffset = GTUtilsMSAEditorSequenceArea::getLastVisibleBase(os);
     CHECK_SET_ERR(initOffset >= (finOffset * 2 - 8), "inital offset: " + QString().setNum(initOffset) + " final offset: " + QString().setNum(finOffset));
-    //Expected state: MSA is zoomed
+    // Expected state: MSA is zoomed
 
-    //4. press toolbar button "Reset zoom"
+    // 4. press toolbar button "Reset zoom"
     GTGlobals::sleep();
     QAbstractButton *reset_zoom = GTAction::button(os, "Reset Zoom");
     GTWidget::click(os, reset_zoom);
     GTGlobals::sleep(500);
     CHECK_SET_ERR(GTUtilsMSAEditorSequenceArea::getLastVisibleBase(os) == initOffset, "MSA is not zoomed back");
-    //Expected state: MSA is zoomed back
+    // Expected state: MSA is zoomed back
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0025) {
@@ -2109,7 +2110,7 @@ GUI_TEST_CLASS_DEFINITION(test_0026) {
     //    Expected state: image is exported
 }
 
-GUI_TEST_CLASS_DEFINITION(test_0026_1) {    //DIFFERENCE: context menu is used
+GUI_TEST_CLASS_DEFINITION(test_0026_1) {    // DIFFERENCE: context menu is used
     //    1. open document samples/CLUSTALW/COI.aln
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW/", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
@@ -2286,7 +2287,7 @@ GUI_TEST_CLASS_DEFINITION(test_0029) {
     //    Expectes state: sequence added to project
 }
 
-GUI_TEST_CLASS_DEFINITION(test_0029_1) {    //DIFFERENCE:gaps are trimmed, FASTQ format is used
+GUI_TEST_CLASS_DEFINITION(test_0029_1) {    // DIFFERENCE:gaps are trimmed, FASTQ format is used
     //    1. open document samples/CLUSTALW/COI.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
@@ -2348,7 +2349,7 @@ GUI_TEST_CLASS_DEFINITION(test_0029_2) {
     //    Expectes state: sequence added to project
 }
 
-GUI_TEST_CLASS_DEFINITION(test_0031) {    //TODO: check statistic result
+GUI_TEST_CLASS_DEFINITION(test_0031) {    // TODO: check statistic result
     //    1. Open document test/_common_data/scenarios/msa/ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
@@ -2365,7 +2366,7 @@ GUI_TEST_CLASS_DEFINITION(test_0031) {    //TODO: check statistic result
     //    Expected state: Alignment profile generated
 }
 
-GUI_TEST_CLASS_DEFINITION(test_0031_1) {    //DIFFERENCE: Percentage is used
+GUI_TEST_CLASS_DEFINITION(test_0031_1) {    // DIFFERENCE: Percentage is used
     //    1. Open document test/_common_data/scenarios/msa/ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
@@ -2382,7 +2383,7 @@ GUI_TEST_CLASS_DEFINITION(test_0031_1) {    //DIFFERENCE: Percentage is used
     //    Expected state: Alignment profile generated
 }
 
-GUI_TEST_CLASS_DEFINITION(test_0031_2) {    //TODO: check statistic result
+GUI_TEST_CLASS_DEFINITION(test_0031_2) {    // TODO: check statistic result
     //    1. Open document test/_common_data/scenarios/msa/ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
@@ -2399,7 +2400,7 @@ GUI_TEST_CLASS_DEFINITION(test_0031_2) {    //TODO: check statistic result
     //    Expected state: Alignment profile generated
 }
 
-GUI_TEST_CLASS_DEFINITION(test_0031_3) {    //TODO: check statistic result
+GUI_TEST_CLASS_DEFINITION(test_0031_3) {    // TODO: check statistic result
     //    1. Open document test/_common_data/scenarios/msa/ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
@@ -2416,7 +2417,7 @@ GUI_TEST_CLASS_DEFINITION(test_0031_3) {    //TODO: check statistic result
     //    Expected state: Alignment profile generated
 }
 
-GUI_TEST_CLASS_DEFINITION(test_0031_4) {    //TODO: check statistic result
+GUI_TEST_CLASS_DEFINITION(test_0031_4) {    // TODO: check statistic result
     //    1. Open document test/_common_data/scenarios/msa/ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
@@ -2454,7 +2455,7 @@ GUI_TEST_CLASS_DEFINITION(test_0032) {
     //    Expected state: Alignment profile file created
 }
 
-GUI_TEST_CLASS_DEFINITION(test_0032_1) {    //DIFFERENCE: csv format is used
+GUI_TEST_CLASS_DEFINITION(test_0032_1) {    // DIFFERENCE: csv format is used
     //    1. Open document test/_common_data/scenarios/msa/ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
@@ -2476,424 +2477,424 @@ GUI_TEST_CLASS_DEFINITION(test_0032_1) {    //DIFFERENCE: csv format is used
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0033) {
-    //1. Open document test/_common_data/scenarios/msa/ma2_gapped.aln
+    // 1. Open document test/_common_data/scenarios/msa/ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //2. Do MSA area context menu->Statistics->generate distance matrix
+    // 2. Do MSA area context menu->Statistics->generate distance matrix
     GTUtilsDialog::waitForDialog(os, new DistanceMatrixDialogFiller(os, true, true, true));
     Runnable *pop = new PopupChooser(os, QStringList() << MSAE_MENU_STATISTICS << "Generate distance matrix", GTGlobals::UseKey);
     GTUtilsDialog::waitForDialog(os, pop);
     GTMenu::showContextMenu(os, GTUtilsMdi::activeWindow(os));
     GTGlobals::sleep(500);
-    //Exptcted state: generata distance matrix dialog appeared
+    // Exptcted state: generata distance matrix dialog appeared
 
-    //3. Fill dialog: Distance Algorithm: Hamming dissimilarity(Simple similiraty)
-    //        Profile mode: Counts
-    //        Exclude gakls: checked
-    //        Click "Generate"
+    // 3. Fill dialog: Distance Algorithm: Hamming dissimilarity(Simple similiraty)
+    //         Profile mode: Counts
+    //         Exclude gakls: checked
+    //         Click "Generate"
     QWidget *profile = GTWidget::findWidget(os, "Distance matrix for ma2_gapped");
     CHECK_SET_ERR(profile, "Alignment profile widget not found");
-    //Expected state: Alignment profile file created
+    // Expected state: Alignment profile file created
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0033_1) {
-    //1. Open document test/_common_data/scenarios/msa/ma2_gapped.aln
+    // 1. Open document test/_common_data/scenarios/msa/ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //2. Do MSA area context menu->Statistics->generate distance matrix
+    // 2. Do MSA area context menu->Statistics->generate distance matrix
     GTUtilsDialog::waitForDialog(os, new DistanceMatrixDialogFiller(os, false, true, true));
     Runnable *pop = new PopupChooser(os, QStringList() << MSAE_MENU_STATISTICS << "Generate distance matrix", GTGlobals::UseKey);
     GTUtilsDialog::waitForDialog(os, pop);
     GTMenu::showContextMenu(os, GTUtilsMdi::activeWindow(os));
     GTGlobals::sleep(500);
-    //Exptcted state: generata distance matrix dialog appeared
+    // Exptcted state: generata distance matrix dialog appeared
 
-    //3. Fill dialog: Distance Algorithm: Hamming dissimilarity(Simple similiraty)
-    //        Profile mode: Counts
-    //        Exclude gakls: checked
-    //        Click "Generate"
+    // 3. Fill dialog: Distance Algorithm: Hamming dissimilarity(Simple similiraty)
+    //         Profile mode: Counts
+    //         Exclude gakls: checked
+    //         Click "Generate"
     QWidget *profile = GTWidget::findWidget(os, "Distance matrix for ma2_gapped");
     CHECK_SET_ERR(profile, "Alignment profile widget not found");
-    //Expected state: Alignment profile file created
+    // Expected state: Alignment profile file created
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0034) {
-    //1. Open document test/_common_data/scenarios/msa/ma2_gapped.aln
+    // 1. Open document test/_common_data/scenarios/msa/ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //2. Do MSA area context menu->Statistics->generate distance matrix
+    // 2. Do MSA area context menu->Statistics->generate distance matrix
     GTUtilsDialog::waitForDialog(os, new DistanceMatrixDialogFiller(os, true, false, true));
     Runnable *pop = new PopupChooser(os, QStringList() << MSAE_MENU_STATISTICS << "Generate distance matrix", GTGlobals::UseKey);
     GTUtilsDialog::waitForDialog(os, pop);
     GTMenu::showContextMenu(os, GTUtilsMdi::activeWindow(os));
     GTGlobals::sleep(500);
-    //Exptcted state: generata distance matrix dialog appeared
+    // Exptcted state: generata distance matrix dialog appeared
 
-    //3. Fill dialog: Distance Algorithm: Hamming dissimilarity
-    //        Profile mode: Counts(Percents)
-    //        Exclude gakls: checked(unchecked)
-    //        Click "Generate"
+    // 3. Fill dialog: Distance Algorithm: Hamming dissimilarity
+    //         Profile mode: Counts(Percents)
+    //         Exclude gakls: checked(unchecked)
+    //         Click "Generate"
     QWidget *profile = GTWidget::findWidget(os, "Distance matrix for ma2_gapped");
     CHECK_SET_ERR(profile, "Alignment profile widget not found");
-    //Expected state: Alignment profile file created
+    // Expected state: Alignment profile file created
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0034_1) {
-    //1. Open document test/_common_data/scenarios/msa/ma2_gapped.aln
+    // 1. Open document test/_common_data/scenarios/msa/ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //2. Do MSA area context menu->Statistics->generate distance matrix
+    // 2. Do MSA area context menu->Statistics->generate distance matrix
     GTUtilsDialog::waitForDialog(os, new DistanceMatrixDialogFiller(os, true, true, false));
     Runnable *pop = new PopupChooser(os, QStringList() << MSAE_MENU_STATISTICS << "Generate distance matrix", GTGlobals::UseKey);
     GTUtilsDialog::waitForDialog(os, pop);
     GTMenu::showContextMenu(os, GTUtilsMdi::activeWindow(os));
     GTGlobals::sleep(500);
-    //Exptcted state: generata distance matrix dialog appeared
+    // Exptcted state: generata distance matrix dialog appeared
 
-    //3. Fill dialog: Distance Algorithm: Hamming dissimilarity
-    //        Profile mode: Counts(Percents)
-    //        Exclude gakls: checked(unchecked)
-    //        Click "Generate"
+    // 3. Fill dialog: Distance Algorithm: Hamming dissimilarity
+    //         Profile mode: Counts(Percents)
+    //         Exclude gakls: checked(unchecked)
+    //         Click "Generate"
     QWidget *profile = GTWidget::findWidget(os, "Distance matrix for ma2_gapped");
     CHECK_SET_ERR(profile, "Alignment profile widget not found");
-    //Expected state: Alignment profile file created
+    // Expected state: Alignment profile file created
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0035) {
-    //1. Open document test/_common_data/scenarios/msa/ma2_gapped.aln
+    // 1. Open document test/_common_data/scenarios/msa/ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //2. Do MSA area context menu->Statistics->generate distance matrix
+    // 2. Do MSA area context menu->Statistics->generate distance matrix
     Runnable *dis = new DistanceMatrixDialogFiller(os, DistanceMatrixDialogFiller::HTML, testDir + "_common_data/scenarios/sandbox/matrix.html");
     GTUtilsDialog::waitForDialog(os, dis);
     Runnable *pop = new PopupChooser(os, QStringList() << MSAE_MENU_STATISTICS << "Generate distance matrix", GTGlobals::UseKey);
     GTUtilsDialog::waitForDialog(os, pop);
     GTMenu::showContextMenu(os, GTUtilsMdi::activeWindow(os));
     GTGlobals::sleep(500);
-    //Exptcted state: generata distance matrix dialog appeared
+    // Exptcted state: generata distance matrix dialog appeared
 
-    //3. Fill dialog: Distance Algorithm: Hamming dissimilarity
-    //        Profile mode: Counts
-    //        Exclude gakls: checked
-    //        Save profile to file: checked
-    //        File path: test/_common_data/scenarios/sandbox/matrix.html(matrix.csv)
-    //        Click "Generate"
+    // 3. Fill dialog: Distance Algorithm: Hamming dissimilarity
+    //         Profile mode: Counts
+    //         Exclude gakls: checked
+    //         Save profile to file: checked
+    //         File path: test/_common_data/scenarios/sandbox/matrix.html(matrix.csv)
+    //         Click "Generate"
     qint64 size = GTFile::getSize(os, testDir + "_common_data/scenarios/sandbox/matrix.html");
     CHECK_SET_ERR(size != 0, "file not created");
-    //Expected state: Alignment profile file created
+    // Expected state: Alignment profile file created
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0035_1) {
-    //1. Open document test/_common_data/scenarios/msa/ma2_gapped.aln
+    // 1. Open document test/_common_data/scenarios/msa/ma2_gapped.aln
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/", "ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //2. Do MSA area context menu->Statistics->generate distance matrix
+    // 2. Do MSA area context menu->Statistics->generate distance matrix
     Runnable *dis = new DistanceMatrixDialogFiller(os, DistanceMatrixDialogFiller::CSV, testDir + "_common_data/scenarios/sandbox/matrix.html");
     GTUtilsDialog::waitForDialog(os, dis);
     Runnable *pop = new PopupChooser(os, QStringList() << MSAE_MENU_STATISTICS << "Generate distance matrix", GTGlobals::UseKey);
     GTUtilsDialog::waitForDialog(os, pop);
     GTMenu::showContextMenu(os, GTUtilsMdi::activeWindow(os));
     GTGlobals::sleep(500);
-    //Exptcted state: generata distance matrix dialog appeared
+    // Exptcted state: generata distance matrix dialog appeared
 
-    //3. Fill dialog: Distance Algorithm: Hamming dissimilarity
-    //        Profile mode: Counts
-    //        Exclude gakls: checked
-    //        Save profile to file: checked
-    //        File path: test/_common_data/scenarios/sandbox/matrix.html(matrix.csv)
-    //        Click "Generate"
+    // 3. Fill dialog: Distance Algorithm: Hamming dissimilarity
+    //         Profile mode: Counts
+    //         Exclude gakls: checked
+    //         Save profile to file: checked
+    //         File path: test/_common_data/scenarios/sandbox/matrix.html(matrix.csv)
+    //         Click "Generate"
     qint64 size = GTFile::getSize(os, testDir + "_common_data/scenarios/sandbox/matrix.csv");
     CHECK_SET_ERR(size != 0, "file not created");
-    //Expected state: Alignment profile file created
+    // Expected state: Alignment profile file created
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0036) {
-    //1. open document samples/CLUSTALW/COI.aln
+    // 1. open document samples/CLUSTALW/COI.aln
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW/", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
     GTGlobals::sleep(500);
-    //2. Press "build tree" button on toolbar
+    // 2. Press "build tree" button on toolbar
     GTUtilsDialog::waitForDialog(os, new BuildTreeDialogFiller(os, testDir + "_common_data/scenarios/sandbox/COI.nwk", 0));
     QAbstractButton *tree = GTAction::button(os, "Build Tree");
     GTWidget::click(os, tree);
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //Expected state: build tree dialog appeared
+    // Expected state: build tree dialog appeared
 
-    //3. Fill dialog:
-    //    Distanse matrix model: F84(Kimura/Jukes-Cantor/LogDet)
-    //    Press "Build"
+    // 3. Fill dialog:
+    //     Distanse matrix model: F84(Kimura/Jukes-Cantor/LogDet)
+    //     Press "Build"
     QGraphicsView *treeView = qobject_cast<QGraphicsView *>(GTWidget::findWidget(os, "treeView"));
     CHECK_SET_ERR(treeView != nullptr, "TreeView not found")
-    //Expected state: tree appeared
+    // Expected state: tree appeared
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0036_1) {
-    //1. open document samples/CLUSTALW/COI.aln
+    // 1. open document samples/CLUSTALW/COI.aln
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW/", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    //2. Press "build tree" button on toolbar
-    //Expected state: build tree dialog appeared
-    //3. Fill dialog:
-    //    Distanse matrix model: F84(Kimura/Jukes-Cantor/LogDet)
-    //    Press "Build"
+    // 2. Press "build tree" button on toolbar
+    // Expected state: build tree dialog appeared
+    // 3. Fill dialog:
+    //     Distanse matrix model: F84(Kimura/Jukes-Cantor/LogDet)
+    //     Press "Build"
     GTUtilsDialog::waitForDialog(os, new BuildTreeDialogFiller(os, testDir + "_common_data/scenarios/sandbox/COI.nwk", 1));
     GTWidget::click(os, GTAction::button(os, "Build Tree"));
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    //Expected state: tree appeared
+    // Expected state: tree appeared
     QGraphicsView *treeView = qobject_cast<QGraphicsView *>(GTWidget::findWidget(os, "treeView"));
     CHECK_SET_ERR(treeView != nullptr, "TreeView not found")
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0036_2) {
-    //1. open document samples/CLUSTALW/COI.aln
+    // 1. open document samples/CLUSTALW/COI.aln
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW/", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    //2. Press "build tree" button on toolbar
+    // 2. Press "build tree" button on toolbar
     GTUtilsDialog::waitForDialog(os, new BuildTreeDialogFiller(os, testDir + "_common_data/scenarios/sandbox/COI.nwk", 2));
     GTWidget::click(os, GTAction::button(os, "Build Tree"));
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //Expected state: build tree dialog appeared
+    // Expected state: build tree dialog appeared
 
-    //3. Fill dialog:
-    //    Distanse matrix model: F84(Kimura/Jukes-Cantor/LogDet)
-    //    Press "Build"
+    // 3. Fill dialog:
+    //     Distanse matrix model: F84(Kimura/Jukes-Cantor/LogDet)
+    //     Press "Build"
     QGraphicsView *treeView = qobject_cast<QGraphicsView *>(GTWidget::findWidget(os, "treeView"));
     CHECK_SET_ERR(treeView != nullptr, "TreeView not found")
-    //Expected state: tree appeared
+    // Expected state: tree appeared
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0036_3) {
-    //1. open document samples/CLUSTALW/COI.aln
+    // 1. open document samples/CLUSTALW/COI.aln
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW/", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    //2. Press "build tree" button on toolbar
+    // 2. Press "build tree" button on toolbar
     GTUtilsDialog::waitForDialog(os, new BuildTreeDialogFiller(os, testDir + "_common_data/scenarios/sandbox/COI.nwk", 3));
     GTWidget::click(os, GTAction::button(os, "Build Tree"));
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //Expected state: build tree dialog appeared
+    // Expected state: build tree dialog appeared
 
-    //3. Fill dialog:
-    //    Distanse matrix model: F84(Kimura/Jukes-Cantor/LogDet)
-    //    Press "Build"
+    // 3. Fill dialog:
+    //     Distanse matrix model: F84(Kimura/Jukes-Cantor/LogDet)
+    //     Press "Build"
     QGraphicsView *treeView = qobject_cast<QGraphicsView *>(GTWidget::findWidget(os, "treeView"));
     CHECK_SET_ERR(treeView != nullptr, "TreeView not found")
-    //Expected state: tree appeared
+    // Expected state: tree appeared
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0037) {
-    //1. open document samples/CLUSTALW/COI.aln
+    // 1. open document samples/CLUSTALW/COI.aln
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW/", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    //2. Press "build tree" button on toolbar
+    // 2. Press "build tree" button on toolbar
     GTUtilsDialog::waitForDialog(os, new BuildTreeDialogFiller(os, testDir + "_common_data/scenarios/sandbox/COI.nwk", 0, 0.5));
     GTWidget::click(os, GTAction::button(os, "Build Tree"));
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //Expected state: build tree dialog appeared
+    // Expected state: build tree dialog appeared
 
-    //3. Fill dialog:
-    //    Distanse matrix model: F84
-    //    Gamma distributed rates across sites: checked
-    //    Coefficient of variation: 0.50(50.00/99.00)
-    //    Press "Build"
+    // 3. Fill dialog:
+    //     Distanse matrix model: F84
+    //     Gamma distributed rates across sites: checked
+    //     Coefficient of variation: 0.50(50.00/99.00)
+    //     Press "Build"
     QGraphicsView *treeView = qobject_cast<QGraphicsView *>(GTWidget::findWidget(os, "treeView"));
     CHECK_SET_ERR(treeView != nullptr, "TreeView not found")
-    //Expected state: tree appeared
+    // Expected state: tree appeared
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0037_1) {
-    //1. open document samples/CLUSTALW/COI.aln
+    // 1. open document samples/CLUSTALW/COI.aln
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW/", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    //2. Press "build tree" button on toolbar
+    // 2. Press "build tree" button on toolbar
     GTUtilsDialog::waitForDialog(os, new BuildTreeDialogFiller(os, testDir + "_common_data/scenarios/sandbox/COI.nwk", 0, 50));
     GTWidget::click(os, GTAction::button(os, "Build Tree"));
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //Expected state: build tree dialog appeared
+    // Expected state: build tree dialog appeared
 
-    //3. Fill dialog:
-    //    Distanse matrix model: F84
-    //    Gamma distributed rates across sites: checked
-    //    Coefficient of variation: 0.50(50.00/99.00)
-    //    Press "Build"
+    // 3. Fill dialog:
+    //     Distanse matrix model: F84
+    //     Gamma distributed rates across sites: checked
+    //     Coefficient of variation: 0.50(50.00/99.00)
+    //     Press "Build"
     QGraphicsView *treeView = qobject_cast<QGraphicsView *>(GTWidget::findWidget(os, "treeView"));
     CHECK_SET_ERR(treeView != nullptr, "TreeView not found")
-    //Expected state: tree appeared
+    // Expected state: tree appeared
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0037_2) {
-    //1. open document samples/CLUSTALW/COI.aln
+    // 1. open document samples/CLUSTALW/COI.aln
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW/", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    //2. Press "build tree" button on toolbar
+    // 2. Press "build tree" button on toolbar
     GTUtilsDialog::waitForDialog(os, new BuildTreeDialogFiller(os, testDir + "_common_data/scenarios/sandbox/COI.nwk", 0, 99));
     GTWidget::click(os, GTAction::button(os, "Build Tree"));
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //Expected state: build tree dialog appeared
+    // Expected state: build tree dialog appeared
 
-    //3. Fill dialog:
-    //    Distanse matrix model: F84
-    //    Gamma distributed rates across sites: checked
-    //    Coefficient of variation: 0.50(50.00/99.00)
-    //    Press "Build"
+    // 3. Fill dialog:
+    //     Distanse matrix model: F84
+    //     Gamma distributed rates across sites: checked
+    //     Coefficient of variation: 0.50(50.00/99.00)
+    //     Press "Build"
     QGraphicsView *treeView = qobject_cast<QGraphicsView *>(GTWidget::findWidget(os, "treeView"));
     CHECK_SET_ERR(treeView != nullptr, "TreeView not found")
-    //Expected state: tree appeared
+    // Expected state: tree appeared
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0038) {
-    //1. open document samples/CLUSTALW/COI.aln
+    // 1. open document samples/CLUSTALW/COI.aln
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW/", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //2. Press "build tree" button on toolbar
+    // 2. Press "build tree" button on toolbar
     GTUtilsDialog::waitForDialog(os, new BuildTreeDialogFiller(os, 100, testDir + "_common_data/scenarios/sandbox/COI.nwk", 5, BuildTreeDialogFiller::MAJORITYEXT));
 
     QAbstractButton *tree = GTAction::button(os, "Build Tree");
     GTWidget::click(os, tree);
-    GTUtilsTaskTreeView::waitTaskFinished(os);    //some time is needed to build tree
-    //Expected state: build tree dialog appeared
+    GTUtilsTaskTreeView::waitTaskFinished(os);    // some time is needed to build tree
+    // Expected state: build tree dialog appeared
 
-    //3. Fill dialog:
-    //    Distanse matrix model: F84
-    //    Gamma distributed rates across sites: unchecked
-    //    Bootatraping and consensus tree: checked
-    //    Number of replications: 100
-    //    Seed: 5
-    //    Consensus type: Majority Rule extended(Strict/Majority Rule/M1)
-    //    Press "Build"
+    // 3. Fill dialog:
+    //     Distanse matrix model: F84
+    //     Gamma distributed rates across sites: unchecked
+    //     Bootatraping and consensus tree: checked
+    //     Number of replications: 100
+    //     Seed: 5
+    //     Consensus type: Majority Rule extended(Strict/Majority Rule/M1)
+    //     Press "Build"
     QGraphicsView *treeView = qobject_cast<QGraphicsView *>(GTWidget::findWidget(os, "treeView"));
     CHECK_SET_ERR(treeView != nullptr, "TreeView not found")
-    //Expected state: tree appeared
+    // Expected state: tree appeared
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0038_1) {
-    //1. open document samples/CLUSTALW/COI.aln
+    // 1. open document samples/CLUSTALW/COI.aln
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW/", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //2. Press "build tree" button on toolbar
+    // 2. Press "build tree" button on toolbar
     GTUtilsDialog::waitForDialog(os, new BuildTreeDialogFiller(os, 100, testDir + "_common_data/scenarios/sandbox/COI.nwk", 5, BuildTreeDialogFiller::STRICTCONSENSUS));
 
     QAbstractButton *tree = GTAction::button(os, "Build Tree");
     GTWidget::click(os, tree);
-    GTUtilsTaskTreeView::waitTaskFinished(os);    //some time is needed to build tree
-    //Expected state: build tree dialog appeared
+    GTUtilsTaskTreeView::waitTaskFinished(os);    // some time is needed to build tree
+    // Expected state: build tree dialog appeared
 
-    //3. Fill dialog:
-    //    Distanse matrix model: F84
-    //    Gamma distributed rates across sites: unchecked
-    //    Bootatraping and consensus tree: checked
-    //    Number of replications: 100
-    //    Seed: 5
-    //    Consensus type: Majority Rule extended(Strict/Majority Rule/M1)
-    //    Press "Build"
+    // 3. Fill dialog:
+    //     Distanse matrix model: F84
+    //     Gamma distributed rates across sites: unchecked
+    //     Bootatraping and consensus tree: checked
+    //     Number of replications: 100
+    //     Seed: 5
+    //     Consensus type: Majority Rule extended(Strict/Majority Rule/M1)
+    //     Press "Build"
     QGraphicsView *treeView = qobject_cast<QGraphicsView *>(GTWidget::findWidget(os, "treeView"));
     CHECK_SET_ERR(treeView != nullptr, "TreeView not found")
-    //Expected state: tree appeared
+    // Expected state: tree appeared
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0038_2) {
-    //1. open document samples/CLUSTALW/COI.aln
+    // 1. open document samples/CLUSTALW/COI.aln
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW/", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //2. Press "build tree" button on toolbar
+    // 2. Press "build tree" button on toolbar
     GTUtilsDialog::waitForDialog(os, new BuildTreeDialogFiller(os, 100, testDir + "_common_data/scenarios/sandbox/COI.nwk", 5, BuildTreeDialogFiller::MAJORITY));
 
     QAbstractButton *tree = GTAction::button(os, "Build Tree");
     GTWidget::click(os, tree);
-    //Expected state: build tree dialog appeared
+    // Expected state: build tree dialog appeared
 
-    //3. Fill dialog:
-    //    Distanse matrix model: F84
-    //    Gamma distributed rates across sites: unchecked
-    //    Bootatraping and consensus tree: checked
-    //    Number of replications: 100
-    //    Seed: 5
-    //    Consensus type: Majority Rule extended(Strict/Majority Rule/M1)
-    //    Press "Build"
+    // 3. Fill dialog:
+    //     Distanse matrix model: F84
+    //     Gamma distributed rates across sites: unchecked
+    //     Bootatraping and consensus tree: checked
+    //     Number of replications: 100
+    //     Seed: 5
+    //     Consensus type: Majority Rule extended(Strict/Majority Rule/M1)
+    //     Press "Build"
 
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
     QGraphicsView *treeView = qobject_cast<QGraphicsView *>(GTWidget::findWidget(os, "treeView"));
     CHECK_SET_ERR(treeView != nullptr, "TreeView not found")
-    //Expected state: tree appeared
+    // Expected state: tree appeared
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0038_3) {
-    //1. open document samples/CLUSTALW/COI.aln
+    // 1. open document samples/CLUSTALW/COI.aln
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW/", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //2. Press "build tree" button on toolbar
+    // 2. Press "build tree" button on toolbar
     GTUtilsDialog::waitForDialog(os, new BuildTreeDialogFiller(os, 100, testDir + "_common_data/scenarios/sandbox/COI.nwk", 5, BuildTreeDialogFiller::M1));
     QAbstractButton *tree = GTAction::button(os, "Build Tree");
     GTWidget::click(os, tree);
-    //Expected state: build tree dialog appeared
+    // Expected state: build tree dialog appeared
 
-    //3. Fill dialog:
-    //    Distanse matrix model: F84
-    //    Gamma distributed rates across sites: unchecked
-    //    Bootatraping and consensus tree: checked
-    //    Number of replications: 100
-    //    Seed: 5
-    //    Consensus type: Majority Rule extended(Strict/Majority Rule/M1)
-    //    Press "Build"
+    // 3. Fill dialog:
+    //     Distanse matrix model: F84
+    //     Gamma distributed rates across sites: unchecked
+    //     Bootatraping and consensus tree: checked
+    //     Number of replications: 100
+    //     Seed: 5
+    //     Consensus type: Majority Rule extended(Strict/Majority Rule/M1)
+    //     Press "Build"
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
     QGraphicsView *treeView = qobject_cast<QGraphicsView *>(GTWidget::findWidget(os, "treeView"));
     CHECK_SET_ERR(treeView != nullptr, "TreeView not found")
-    //Expected state: tree appeared
+    // Expected state: tree appeared
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0038_4) {
-    //1. open document samples/CLUSTALW/COI.aln
+    // 1. open document samples/CLUSTALW/COI.aln
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW/", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //2. Press "build tree" button on toolbar
+    // 2. Press "build tree" button on toolbar
     GTUtilsDialog::waitForDialog(os, new BuildTreeDialogFiller(os, 100, testDir + "_common_data/scenarios/sandbox/COI.nwk", 5, BuildTreeDialogFiller::M1, 1));
     QAbstractButton *tree = GTAction::button(os, "Build Tree");
     GTWidget::click(os, tree);
-    //Expected state: build tree dialog appeared
+    // Expected state: build tree dialog appeared
 
-    //3. Fill dialog:
-    //    Distanse matrix model: F84
-    //    Gamma distributed rates across sites: unchecked
-    //    Bootatraping and consensus tree: checked
-    //    Number of replications: 100
-    //    Seed: 5
-    //    Consensus type: Majority Rule extended(Strict/Majority Rule/M1)
-    //    Press "Build"
+    // 3. Fill dialog:
+    //     Distanse matrix model: F84
+    //     Gamma distributed rates across sites: unchecked
+    //     Bootatraping and consensus tree: checked
+    //     Number of replications: 100
+    //     Seed: 5
+    //     Consensus type: Majority Rule extended(Strict/Majority Rule/M1)
+    //     Press "Build"
 
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
     QGraphicsView *treeView = qobject_cast<QGraphicsView *>(GTWidget::findWidget(os, "treeView"));
     CHECK_SET_ERR(treeView != nullptr, "TreeView not found")
-    //Expected state: tree appeared
+    // Expected state: tree appeared
 }
 
 void test_0039_function(HI::GUITestOpStatus &os, int comboNum, const QString &extension) {
-    //1. open document samples/CLUSTALW/COI.aln
+    // 1. open document samples/CLUSTALW/COI.aln
     GTFileDialog::openFile(os, UGUITest::dataDir + "samples/CLUSTALW/", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    //2. Use project tree context menu->Export/Import->Export Nucleic Alignment to Amino Translation
-    //Expected state: Export Nucleic Alignment to Amino Translation dialog appeared
-    //3.Fill dialog:
-    //    File name: test/_common_data/scenarios/sandbox/transl.aln
-    //    File format: CLUSTALW(use other formats too, check extension change)
-    //    Amino translation: Standard genetic code
-    //    Add document to project: checked
+    // 2. Use project tree context menu->Export/Import->Export Nucleic Alignment to Amino Translation
+    // Expected state: Export Nucleic Alignment to Amino Translation dialog appeared
+    // 3.Fill dialog:
+    //     File name: test/_common_data/scenarios/sandbox/transl.aln
+    //     File format: CLUSTALW(use other formats too, check extension change)
+    //     Amino translation: Standard genetic code
+    //     Add document to project: checked
     GTUtilsDialog::waitForDialog(os, new PopupChooser(os, QStringList() << "action_project__export_import_menu_action"
                                                                         << "action_project__export_to_amino_action"));
     GTUtilsDialog::waitForDialog(os, new ExportMSA2MSADialogFiller(os, comboNum, UGUITest::testDir + "_common_data/scenarios/sandbox/COI_transl.aln"));
     GTUtilsProjectTreeView::click(os, "COI.aln", Qt::RightButton);
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    //Expected state: transl.aln appeared in project
+    // Expected state: transl.aln appeared in project
     GTMouseDriver::moveTo(GTUtilsProjectTreeView::getItemCenter(os, "COI_transl." + extension));
 }
 
@@ -2938,14 +2939,14 @@ GUI_TEST_CLASS_DEFINITION(test_0039_7) {
     test_0039_function(os, 7, "sto");
 }
 
-GUI_TEST_CLASS_DEFINITION(test_0040) {    //UGENE crashes when opening several files
+GUI_TEST_CLASS_DEFINITION(test_0040) {    // UGENE crashes when opening several files
     QFile human_T1(dataDir + "/samples/FASTA/human_T1.fa");
     human_T1.copy(dataDir + "/samples/CLUSTALW/human_T1.fa");
     GTFileDialog::openFileList(os, dataDir + "samples/CLUSTALW/", QStringList() << "COI.aln"
                                                                                 << "human_T1.fa");
 
-    //GTUtilsDialog::waitForDialog(os, new MessageBoxDialogFiller(os,QMessageBox::No));
-    GTUtilsProjectTreeView::findIndex(os, "human_T1.fa");    //checks inside
+    // GTUtilsDialog::waitForDialog(os, new MessageBoxDialogFiller(os,QMessageBox::No));
+    GTUtilsProjectTreeView::findIndex(os, "human_T1.fa");    // checks inside
     GTUtilsProjectTreeView::findIndex(os, "COI.aln");
 
     GTUtilsDialog::waitForDialog(os, new MessageBoxDialogFiller(os, QMessageBox::No));
@@ -3227,7 +3228,7 @@ GUI_TEST_CLASS_DEFINITION(test_0048) {
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0049) {
-    //save alignment buttons test
+    // save alignment buttons test
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW/", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
     GTUtilsDialog::waitForDialog(os, new ExportDocumentDialogFiller(os, sandBoxDir, "COI_test_0049.aln", ExportDocumentDialogFiller::CLUSTALW));
@@ -3350,11 +3351,11 @@ GUI_TEST_CLASS_DEFINITION(test_0052) {
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0053) {
-    //Copied formatted (context menu)
-    //1. Open amples\CLUSTALW\COI.aln
-    //2. Select the first three letters TAA
-    //3. Context menue {Copy-><<Copy formatted}
-    //Expected state: the buffer contatin the sequence in CLUSTALW format
+    // Copied formatted (context menu)
+    // 1. Open amples\CLUSTALW\COI.aln
+    // 2. Select the first three letters TAA
+    // 3. Context menue {Copy-><<Copy formatted}
+    // Expected state: the buffer contatin the sequence in CLUSTALW format
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
     GTGlobals::sleep();
@@ -3371,12 +3372,12 @@ GUI_TEST_CLASS_DEFINITION(test_0053) {
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0053_1) {
-    //Copied formatted (context menu), the format is changable
-    //1. Open samples\CLUSTALW\COI.aln
-    //2. Select the first three letters TAA
-    //3. In the general tab of the options panel find the Copy Type combobox and select the Mega format
-    //4. Context menu {Copy->Copy formatted}
-    //Expected state: the buffer contatin the sequence in Mega format
+    // Copied formatted (context menu), the format is changable
+    // 1. Open samples\CLUSTALW\COI.aln
+    // 2. Select the first three letters TAA
+    // 3. In the general tab of the options panel find the Copy Type combobox and select the Mega format
+    // 4. Context menu {Copy->Copy formatted}
+    // Expected state: the buffer contatin the sequence in Mega format
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
@@ -3399,12 +3400,12 @@ GUI_TEST_CLASS_DEFINITION(test_0053_1) {
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0053_2) {
-    //Copied formatted (toolbar), the format is changable
-    //1. Open samples\CLUSTALW\COI.aln
-    //2. Select the first three letters TAA
-    //3. In the general tab of the options panel find the Copy Type combobox and select the CLUSTALW format
-    //4. Toolbar {Copy->Copy formatted}
-    //Expected state: the buffer contatin the sequence in CLUSTALW format
+    // Copied formatted (toolbar), the format is changable
+    // 1. Open samples\CLUSTALW\COI.aln
+    // 2. Select the first three letters TAA
+    // 3. In the general tab of the options panel find the Copy Type combobox and select the CLUSTALW format
+    // 4. Toolbar {Copy->Copy formatted}
+    // Expected state: the buffer contatin the sequence in CLUSTALW format
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW", "COI.aln");
     GTUtilsMsaEditor::checkMsaEditorWindowIsActive(os);
 
@@ -3427,11 +3428,11 @@ GUI_TEST_CLASS_DEFINITION(test_0053_2) {
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0053_3) {
-    //Copied formatted (context menu) for a big alignment
-    //1. Open _common_data/clustal/100_sequences.aln
-    //2. Select the whole alignment
-    //3. Context menue {Copy->Copy formatted}
-    //Expected state: the buffer contatin the sequences in CLUSTALW format
+    // Copied formatted (context menu) for a big alignment
+    // 1. Open _common_data/clustal/100_sequences.aln
+    // 2. Select the whole alignment
+    // 3. Context menue {Copy->Copy formatted}
+    // Expected state: the buffer contatin the sequences in CLUSTALW format
     GTFileDialog::openFile(os, testDir + "_common_data/clustal/100_sequences.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
     GTGlobals::sleep();
@@ -3450,10 +3451,10 @@ GUI_TEST_CLASS_DEFINITION(test_0053_3) {
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0053_4) {
-    //Copied formatted (action is disabled when no selection
-    //1. Open samples\CLUSTALW\COI.aln
-    //2. Try context menue {Copy->Copy formatted}
-    //Expected state: the action is disabled
+    // Copied formatted (action is disabled when no selection
+    // 1. Open samples\CLUSTALW\COI.aln
+    // 2. Try context menue {Copy->Copy formatted}
+    // Expected state: the action is disabled
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
     GTGlobals::sleep();
@@ -3464,12 +3465,12 @@ GUI_TEST_CLASS_DEFINITION(test_0053_4) {
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0053_5) {
-    //Copied formatted (toolbar), the format is changable to RTF
-    //1. Open samples\CLUSTALW\COI.aln
-    //2. Select the first three letters TAA
-    //3. In the general tab of the options panel find the Copy Type combobox and select the RTF format
-    //4. Toolbar {Copy->Copy formatted}
-    //Expected state: the buffer contatin the sequence in RTF format
+    // Copied formatted (toolbar), the format is changable to RTF
+    // 1. Open samples\CLUSTALW\COI.aln
+    // 2. Select the first three letters TAA
+    // 3. In the general tab of the options panel find the Copy Type combobox and select the RTF format
+    // 4. Toolbar {Copy->Copy formatted}
+    // Expected state: the buffer contatin the sequence in RTF format
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
     GTGlobals::sleep();
@@ -4082,11 +4083,11 @@ GUI_TEST_CLASS_DEFINITION(test_0066) {
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0067) {
-    //TODO: write this test when UGENE-4803 is fixed
-    //    Open COI.aln
-    //    Build tree displayed with msa
-    //    Use context menu on tree tab(in tabWidget)
-    //    Check all actions in popup menu
+    // TODO: write this test when UGENE-4803 is fixed
+    //     Open COI.aln
+    //     Build tree displayed with msa
+    //     Use context menu on tree tab(in tabWidget)
+    //     Check all actions in popup menu
     CHECK_SET_ERR(false, "The test is not implemented");
 }
 
@@ -4720,6 +4721,66 @@ GUI_TEST_CLASS_DEFINITION(test_0094) {
     CHECK_SET_ERR(descendingNamesWithNoGroup == originalNamesWithNoGroup,
                   "Descending order was changed for non-group sequences: " + descendingNamesWithNoGroup.join(",") +
                       " Original: " + originalNamesWithNoGroup.join(","));
+}
+
+GUI_TEST_CLASS_DEFINITION(test_0095) {
+    // Check that sequences can be moved from one alignment into another.
+    QString sourceFile = "align.aln";    // {"IXI_234", "IXI_236", "IXI_237", "IXI_235"}
+    QString targetFile = "amino_from_wikipedia.aln";    // {"CYS1_DICDI", "ALEU_HORVU", "CATH_HUMAN"}
+
+    GTFileDialog::openFile(os, testDir + "_common_data/clustal/" + sourceFile);
+    GTUtilsMsaEditor::checkMsaEditorWindowIsActive(os);
+
+    // Check that 'Move' menu is disabled (no active selection).
+    GTUtilsDialog::waitForDialog(os, new PopupChecker(os, {MSAE_MENU_EXPORT, "move_selection_to_another_object"}, PopupChecker::IsDisabled));
+    GTUtilsMSAEditorSequenceArea::callContextMenu(os);
+
+    // Select a couple of sequences and check that 'Move' menu is enabled now and have a disabled "No other objects" item.
+    GTUtilsMsaEditor::selectRowsByName(os, {"IXI_234", "IXI_235"});
+    GTUtilsDialog::waitForDialog(os, new PopupChecker(os, {MSAE_MENU_EXPORT, "move_selection_to_another_object", "no_other_objects_item"}, PopupChecker::IsDisabled));
+    GTUtilsMSAEditorSequenceArea::callContextMenu(os);
+
+    // Open another file. Check that sequences can be moved now. Move them.
+    GTFileDialog::openFile(os, testDir + "_common_data/clustal/" + targetFile);
+    GTUtilsMsaEditor::checkMsaEditorWindowIsActive(os);
+
+    GTUtilsMdi::activateWindow(os, sourceFile);
+    GTUtilsDialog::waitForDialog(os, new PopupChooser(os, {MSAE_MENU_EXPORT, "move_selection_to_another_object", targetFile}));
+    GTUtilsMSAEditorSequenceArea::callContextMenu(os);
+    GTUtilsTaskTreeView::waitTaskFinished(os);
+
+    Document *doc1 = GTUtilsDocument::getDocument(os, sourceFile);
+    Document *doc2 = GTUtilsDocument::getDocument(os, targetFile);
+    CHECK_SET_ERR(doc1->isModified(), "Document 1 must be marked as modified");
+    CHECK_SET_ERR(doc2->isModified(), "Document 2 must be marked as modified");
+
+    QStringList nameList = GTUtilsMSAEditorSequenceArea::getNameList(os);
+    CHECK_SET_ERR(nameList == QStringList({"IXI_236", "IXI_237"}), "Unexpected source msa name list: " + nameList.join(","));
+
+    GTUtilsMdi::activateWindow(os, targetFile);
+    nameList = GTUtilsMSAEditorSequenceArea::getNameList(os);
+    CHECK_SET_ERR(nameList == QStringList({"CYS1_DICDI", "ALEU_HORVU", "CATH_HUMAN", "IXI_234", "IXI_235"}),
+                  "Unexpected target msa name list: " + nameList.join(","));
+
+    // Make the source document read-only. Check that menu is disabled.
+    GTUtilsMdi::activateWindow(os, sourceFile);
+    GTUtilsDocument::lockDocument(os, sourceFile);
+    GTUtilsMsaEditor::selectRowsByName(os, {"IXI_236"});
+    GTUtilsDialog::waitForDialog(os, new PopupChecker(os, {MSAE_MENU_EXPORT, "move_selection_to_another_object"}, PopupChecker::IsDisabled));
+    GTUtilsMSAEditorSequenceArea::callContextMenu(os);
+
+    // Make the target file read-only and the source not. Check that menu is enabled but is empty.
+    GTUtilsDocument::lockDocument(os, targetFile);
+    GTUtilsDocument::unlockDocument(os, sourceFile);
+    GTUtilsDialog::waitForDialog(os, new PopupChecker(os, {MSAE_MENU_EXPORT, "move_selection_to_another_object", "no_other_objects_item"}, PopupChecker::IsDisabled));
+    GTUtilsMSAEditorSequenceArea::callContextMenu(os);
+    GTUtilsDialog::waitForDialog(os, new PopupChecker(os, {MSAE_MENU_EXPORT, "move_selection_to_another_object", targetFile}, PopupChecker::NotExists));
+    GTUtilsMSAEditorSequenceArea::callContextMenu(os);
+
+    // Make the target file not read-only. Check that menu is back again.
+    GTUtilsDocument::unlockDocument(os, targetFile);
+    GTUtilsDialog::waitForDialog(os, new PopupChecker(os, {MSAE_MENU_EXPORT, "move_selection_to_another_object", targetFile}, PopupChecker::IsEnabled));
+    GTUtilsMSAEditorSequenceArea::callContextMenu(os);
 }
 
 }    // namespace GUITest_common_scenarios_msa_editor

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/GTTestsMsaEditor.h
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/GTTestsMsaEditor.h
@@ -254,6 +254,9 @@ GUI_TEST_CLASS_DECLARATION(test_0093_2)
 // Groups sort.
 GUI_TEST_CLASS_DECLARATION(test_0094)
 
+// Move to another alignment
+GUI_TEST_CLASS_DECLARATION(test_0095)
+
 #undef GUI_TEST_SUITE
 }    // namespace GUITest_common_scenarios_msa_editor
 


### PR DESCRIPTION
Some minor no-op refactoring was done as a part of the commit to make the final code cleaner:
1) 100% identical method to get sequence with gaps was moved from Mca&Msa impls into the base Ma class.
2) I introduced MaEditorContext to avoid endless multi-level getters like editor->getUi()->getCollapseModel()... and null checks for values that are never nulls. See docs in the related code.