### PR TITLE
UGENE-6170. Correct names of document formats in two workflow elements

### DIFF
--- a/src/corelibs/U2Designer/src/DelegateEditors.cpp
+++ b/src/corelibs/U2Designer/src/DelegateEditors.cpp
@@ -25,7 +25,6 @@
 
 #include <U2Core/AppContext.h>
 #include <U2Core/DocumentModel.h>
-#include <U2Core/GUrlUtils.h>
 #include <U2Core/L10n.h>
 #include <U2Core/Log.h>
 #include <U2Core/QObjectScopedPointer.h>
@@ -36,7 +35,6 @@
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/ScriptEditorDialog.h>
 
-#include <U2Lang/IntegralBusModel.h>
 #include <U2Lang/WorkflowUtils.h>
 
 #include "PropertyWidget.h"
@@ -46,7 +44,7 @@ namespace U2 {
 DelegateEditor::DelegateEditor(const DelegateEditor &other)
     : ConfigurationEditor(other) {
     foreach (const QString &id, other.delegates.keys()) {
-        delegates[id] = other.delegates[id]->clone();
+        delegates[id] = other.delegates[id]->createCopy();
     }
 }
 
@@ -129,8 +127,8 @@ void SpinBoxDelegate::sl_commit() {
 }
 
 /********************************
-* DoubleSpinBoxDelegate
-********************************/
+ * DoubleSpinBoxDelegate
+ ********************************/
 const int DoubleSpinBoxDelegate::DEFAULT_DECIMALS_VALUE = 5;
 
 DoubleSpinBoxDelegate::DoubleSpinBoxDelegate(const QVariantMap &props, QObject *parent)
@@ -183,8 +181,8 @@ void DoubleSpinBoxDelegate::sl_commit() {
 }
 
 /********************************
-* ComboBoxDelegate
-********************************/
+ * ComboBoxDelegate
+ ********************************/
 ComboBoxDelegate::ComboBoxDelegate(const QVariantMap &items, QObject *parent)
     : PropertyDelegate(parent) {
     foreach (QString key, items.keys()) {
@@ -197,7 +195,7 @@ ComboBoxDelegate::ComboBoxDelegate(const QList<ComboItem> &items, QObject *paren
 }
 
 PropertyWidget *ComboBoxDelegate::createWizardWidget(U2OpStatus & /*os*/, QWidget *parent) const {
-    return new ComboBoxWidget(comboItems, parent);
+    return new ComboBoxWidget(comboItems, parent, propertyNameFormatter);
 }
 
 QWidget *ComboBoxDelegate::createEditor(QWidget *parent,
@@ -212,7 +210,7 @@ QWidget *ComboBoxDelegate::createEditor(QWidget *parent,
             l.append(qMakePair(key, m.value(key)));
         }
     }
-    ComboBoxWidget *editor = new ComboBoxWidget(l, parent);
+    auto editor = new ComboBoxWidget(l, parent, propertyNameFormatter);
     connect(editor, SIGNAL(valueChanged(const QString &)), SLOT(sl_commit()));
     connect(editor, SIGNAL(valueChanged(const QString &)), SIGNAL(si_valueChanged(const QString &)));
 
@@ -267,8 +265,8 @@ void ComboBoxDelegate::sl_commit() {
 }
 
 /********************************
-* ComboBoxWithUrlsDelegate
-********************************/
+ * ComboBoxWithUrlsDelegate
+ ********************************/
 
 PropertyWidget *ComboBoxWithUrlsDelegate::createWizardWidget(U2OpStatus & /*os*/, QWidget *parent) const {
     return new ComboBoxWithUrlWidget(items, isPath, parent);
@@ -307,8 +305,8 @@ QVariant ComboBoxWithUrlsDelegate::getDisplayValue(const QVariant &val) const {
 }
 
 /********************************
-* ComboBoxEditableDelegate
-********************************/
+ * ComboBoxEditableDelegate
+ ********************************/
 
 PropertyWidget *ComboBoxEditableDelegate::createWizardWidget(U2OpStatus & /*os*/, QWidget *parent) const {
     return new ComboBoxEditableWidget(items, parent);
@@ -347,8 +345,8 @@ QVariant ComboBoxEditableDelegate::getDisplayValue(const QVariant &val) const {
 }
 
 /********************************
-* ComboBoxWithDbUrlsDelegate
-********************************/
+ * ComboBoxWithDbUrlsDelegate
+ ********************************/
 ComboBoxWithDbUrlsDelegate::ComboBoxWithDbUrlsDelegate(QObject *parent)
     : PropertyDelegate(parent) {
 }
@@ -402,8 +400,8 @@ PropertyDelegate::Type ComboBoxWithDbUrlsDelegate::type() const {
 }
 
 /********************************
-* ComboBoxWithChecksDelegate
-********************************/
+ * ComboBoxWithChecksDelegate
+ ********************************/
 
 PropertyWidget *ComboBoxWithChecksDelegate::createWizardWidget(U2OpStatus & /*os*/, QWidget *parent) const {
     return new ComboBoxWithChecksWidget(items, parent);
@@ -412,7 +410,7 @@ PropertyWidget *ComboBoxWithChecksDelegate::createWizardWidget(U2OpStatus & /*os
 QWidget *ComboBoxWithChecksDelegate::createEditor(QWidget *parent,
                                                   const QStyleOptionViewItem & /* option */,
                                                   const QModelIndex & /* index */) const {
-    ComboBoxWithChecksWidget *editor = new ComboBoxWithChecksWidget(items, parent);
+    ComboBoxWithChecksWidget *editor = new ComboBoxWithChecksWidget(items, parent, propertyNameFormatter);
     connect(editor, SIGNAL(valueChanged(const QString &)), this, SIGNAL(si_valueChanged(const QString &)));
     connect(editor, SIGNAL(si_valueChanged(const QVariant &)), SLOT(sl_commit()));
     return editor;
@@ -448,8 +446,8 @@ void ComboBoxWithChecksDelegate::sl_commit() {
 }
 
 /********************************
-* ComboBoxWithBoolsDelegate
-********************************/
+ * ComboBoxWithBoolsDelegate
+ ********************************/
 
 ComboBoxWithBoolsDelegate::ComboBoxWithBoolsDelegate(QObject *parent)
     : ComboBoxDelegate(boolMap(), parent) {
@@ -463,8 +461,8 @@ QVariantMap ComboBoxWithBoolsDelegate::boolMap() {
 }
 
 /********************************
-* URLDelegate
-********************************/
+ * URLDelegate
+ ********************************/
 URLDelegate::URLDelegate(const QString &filter, const QString &type, const Options &_options, QObject *parent, const QString &format)
     : PropertyDelegate(parent),
       lastDirType(type),
@@ -585,8 +583,8 @@ PropertyDelegate::Type URLDelegate::type() const {
 }
 
 /********************************
-* FileModeDelegate
-********************************/
+ * FileModeDelegate
+ ********************************/
 FileModeDelegate::FileModeDelegate(bool appendSupported, QObject *parent)
     : ComboBoxDelegate(QVariantMap(), parent) {
     comboItems.append(qMakePair(U2::WorkflowUtils::tr("Overwrite"), SaveDoc_Overwrite));
@@ -615,8 +613,8 @@ void SchemaRunModeDelegate::sl_valueChanged(const QString &val) {
 }
 
 /********************************
-* ScriptSelectionWidget
-********************************/
+ * ScriptSelectionWidget
+ ********************************/
 const int NO_SCRIPT_ITEM_ID = 0;
 const int USER_SCRIPT_ITEM_ID = 1;
 const QPair<QString, int> NO_SCRIPT_ITEM_STR("no script", NO_SCRIPT_ITEM_ID);
@@ -676,8 +674,8 @@ void ScriptSelectionWidget::sl_comboCurrentIndexChanged(int itemId) {
 }
 
 /********************************
-* AttributeScriptDelegate
-********************************/
+ * AttributeScriptDelegate
+ ********************************/
 AttributeScriptDelegate::AttributeScriptDelegate(QObject *parent)
     : PropertyDelegate(parent) {
 }
@@ -832,7 +830,7 @@ void StringListDelegate::setModelData(QWidget *editor, QAbstractItemModel *model
 
 /********************************
  * StringSelectorDelegate
-********************************/
+ ********************************/
 QWidget *StringSelectorDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &) const {
     QWidget *editor = new QWidget(parent);
     valueEdit = new QLineEdit(editor);

--- a/src/corelibs/U2Designer/src/DelegateEditors.h
+++ b/src/corelibs/U2Designer/src/DelegateEditors.h
@@ -42,6 +42,7 @@
 #include <U2Designer/URLLineEdit.h>
 
 #include <U2Lang/ConfigurationEditor.h>
+#include <U2Lang/PropertyNameFormatter.h>
 
 #include "PropertyWidget.h"
 
@@ -206,8 +207,6 @@ class U2DESIGNER_EXPORT ComboBoxDelegate : public PropertyDelegate {
 public:
     ComboBoxDelegate(const QVariantMap &comboItems, QObject *parent = 0);    // items: visible name -> value
     ComboBoxDelegate(const QList<ComboItem> &comboItems, QObject *parent = 0);    // items: visible name -> value
-    virtual ~ComboBoxDelegate() {
-    }
 
     QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     virtual PropertyWidget *createWizardWidget(U2OpStatus &os, QWidget *parent) const;
@@ -328,9 +327,6 @@ public:
     ComboBoxWithChecksDelegate(const QVariantMap &items, QObject *parent = 0)
         : PropertyDelegate(parent), items(items) {
     }
-    virtual ~ComboBoxWithChecksDelegate() {
-    }
-
     QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     virtual PropertyWidget *createWizardWidget(U2OpStatus &os, QWidget *parent) const;
 

--- a/src/corelibs/U2Designer/src/PropertyWidget.cpp
+++ b/src/corelibs/U2Designer/src/PropertyWidget.cpp
@@ -39,7 +39,6 @@
 #include <U2Lang/SchemaConfig.h>
 #include <U2Lang/SharedDbUrlUtils.h>
 #include <U2Lang/URLContainer.h>
-#include <U2Lang/WorkflowSettings.h>
 #include <U2Lang/WorkflowUtils.h>
 
 #include "OutputFileDialog.h"
@@ -186,13 +185,13 @@ void DoubleSpinBoxWidget::sl_valueChanged(double value) {
 /************************************************************************/
 /* ComboBoxWidget */
 /************************************************************************/
-ComboBoxWidget::ComboBoxWidget(const QList<ComboItem> &items, QWidget *parent)
-    : PropertyWidget(parent) {
+ComboBoxWidget::ComboBoxWidget(const QList<ComboItem> &items, QWidget *parent, const QSharedPointer<PropertyNameFormatter> &propertyNameFormatter)
+    : PropertyWidget(parent, nullptr, propertyNameFormatter) {
     comboBox = new QComboBox(this);
     addMainWidget(comboBox);
 
-    foreach (const ComboItem p, items) {
-        comboBox->addItem(p.first, p.second);
+    for (const ComboItem &item : qAsConst(items)) {
+        comboBox->addItem(getFormattedPropertyName(item.first), item.second);
     }
     connect(comboBox, SIGNAL(activated(const QString &)), this, SIGNAL(valueChanged(const QString &)));
     connect(comboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(sl_valueChanged(int)));
@@ -409,8 +408,8 @@ QVariantMap ComboBoxWithDbUrlWidget::getItems() const {
 /************************************************************************/
 /* ComboBoxWithChecksWidget */
 /************************************************************************/
-ComboBoxWithChecksWidget::ComboBoxWithChecksWidget(const QVariantMap &_items, QWidget *parent)
-    : PropertyWidget(parent), cm(nullptr), items(_items) {
+ComboBoxWithChecksWidget::ComboBoxWithChecksWidget(const QVariantMap &_items, QWidget *parent, const QSharedPointer<PropertyNameFormatter> &propertyNameFormatter)
+    : PropertyWidget(parent, nullptr, propertyNameFormatter), cm(nullptr), items(_items) {
     comboBox = new QComboBox(this);
     addMainWidget(comboBox);
     initModelView();
@@ -472,7 +471,7 @@ void ComboBoxWithChecksWidget::initModelView() {
     cm->setItem(i++, ghostItem);
 
     for (auto it = items.begin(); it != items.end(); ++it) {
-        QStandardItem *item = new QStandardItem(it.key());
+        auto item = new QStandardItem(getFormattedPropertyName(it.key()));
         item->setCheckable(true);
         item->setEditable(false);
         item->setSelectable(false);

--- a/src/corelibs/U2Designer/src/PropertyWidget.h
+++ b/src/corelibs/U2Designer/src/PropertyWidget.h
@@ -33,6 +33,7 @@
 #include <U2Designer/URLLineEdit.h>
 
 #include <U2Lang/ConfigurationEditor.h>
+#include <U2Lang/PropertyNameFormatter.h>
 
 class QStandardItem;
 class QStandardItemModel;
@@ -143,9 +144,9 @@ private slots:
 class ComboBoxWidget : public PropertyWidget {
     Q_OBJECT
 public:
-    ComboBoxWidget(const QList<ComboItem> &items, QWidget *parent = nullptr);
-    virtual QVariant value();
-    virtual void setValue(const QVariant &value);
+    ComboBoxWidget(const QList<ComboItem> &items, QWidget *parent = nullptr, const QSharedPointer<PropertyNameFormatter> &propertyNameFormatter = nullptr);
+    QVariant value() override;
+    void setValue(const QVariant &value) override;
 
     static ComboBoxWidget *createBooleanWidget(QWidget *parent = nullptr);
 
@@ -231,7 +232,7 @@ private:
 class U2DESIGNER_EXPORT ComboBoxWithChecksWidget : public PropertyWidget {
     Q_OBJECT
 public:
-    ComboBoxWithChecksWidget(const QVariantMap &items, QWidget *parent = nullptr);
+    ComboBoxWithChecksWidget(const QVariantMap &items, QWidget *parent = nullptr, const QSharedPointer<PropertyNameFormatter> &propertyNameFormatter = nullptr);
     virtual QVariant value();
     virtual void setValue(const QVariant &value);
 

--- a/src/corelibs/U2Lang/U2Lang.pro
+++ b/src/corelibs/U2Lang/U2Lang.pro
@@ -37,6 +37,7 @@ HEADERS += src/library/BaseActorCategories.h \
            src/model/Peer.h \
            src/model/Port.h \
            src/model/PortRelation.h \
+           src/model/PropertyNameFormatter.h \
            src/model/QDConstraint.h \
            src/model/QDScheme.h \
            src/model/QueryDesignerRegistry.h \
@@ -153,6 +154,7 @@ SOURCES += src/library/BaseActorCategories.cpp \
            src/model/PairedReadsPortValidator.cpp \
            src/model/Port.cpp \
            src/model/PortRelation.cpp \
+           src/model/PropertyNameFormatter.cpp \
            src/model/QDConstraint.cpp \
            src/model/QDScheme.cpp \
            src/model/QueryDesignerRegistry.cpp \

--- a/src/corelibs/U2Lang/src/model/ConfigurationEditor.cpp
+++ b/src/corelibs/U2Lang/src/model/ConfigurationEditor.cpp
@@ -25,17 +25,20 @@
 
 #include <U2Core/U2SafePoints.h>
 
+#include <U2Lang/PropertyNameFormatter.h>
+
 namespace U2 {
 
-PropertyWidget::PropertyWidget(QWidget *parent, DelegateTags *_tags)
-    : QWidget(parent), _tags(_tags), schemaConfig(nullptr) {
+PropertyWidget::PropertyWidget(QWidget *parent, DelegateTags *_tags, const QSharedPointer<PropertyNameFormatter> &_propertyNameFormatter)
+    : QWidget(parent), _tags(_tags), schemaConfig(nullptr), propertyNameFormatter(_propertyNameFormatter) {
     QHBoxLayout *l = new QHBoxLayout();
     l->setContentsMargins(0, 0, 0, 0);
     l->setSpacing(0);
     this->setLayout(l);
 }
 
-PropertyWidget::~PropertyWidget() {
+QString PropertyWidget::getFormattedPropertyName(const QString &propertyName) const {
+    return propertyNameFormatter.isNull() ? propertyName : propertyNameFormatter->format(propertyName);
 }
 
 void PropertyWidget::addMainWidget(QWidget *w) {
@@ -81,8 +84,11 @@ QVariant PropertyDelegate::getDisplayValue(const QVariant &v) const {
     return v;
 }
 
-PropertyDelegate *PropertyDelegate::clone() {
-    return new PropertyDelegate(parent());
+PropertyDelegate *PropertyDelegate::createCopy() {
+    PropertyDelegate *copy = clone();
+    copy->setParent(parent());
+    copy->setPropertyNameFormatter(propertyNameFormatter);
+    return copy;
 }
 
 PropertyWidget *PropertyDelegate::createWizardWidget(U2OpStatus &os, QWidget * /*parent*/) const {
@@ -100,6 +106,14 @@ DelegateTags *PropertyDelegate::tags() const {
 
 void PropertyDelegate::setSchemaConfig(SchemaConfig *value) {
     schemaConfig = value;
+}
+
+const QSharedPointer<PropertyNameFormatter> &PropertyDelegate::getPropertyNameFormatter() const {
+    return propertyNameFormatter;
+}
+
+void PropertyDelegate::setPropertyNameFormatter(const QSharedPointer<PropertyNameFormatter> &newPropertyNameFormatter) {
+    propertyNameFormatter = newPropertyNameFormatter;
 }
 
 const QString DelegateTags::PLACEHOLDER_TEXT = "placeholder_text";

--- a/src/corelibs/U2Lang/src/model/ConfigurationEditor.h
+++ b/src/corelibs/U2Lang/src/model/ConfigurationEditor.h
@@ -36,6 +36,7 @@ namespace U2 {
 class ConfigurationEditor;
 class DelegateTags;
 class PropertyDelegate;
+class PropertyNameFormatter;
 
 /**
  * base class for controller of configuration editor
@@ -101,8 +102,7 @@ signals:
 class U2LANG_EXPORT PropertyWidget : public QWidget {
     Q_OBJECT
 public:
-    PropertyWidget(QWidget *parent = nullptr, DelegateTags *tags = nullptr);
-    virtual ~PropertyWidget();
+    PropertyWidget(QWidget *parent = nullptr, DelegateTags *tags = nullptr, const QSharedPointer<PropertyNameFormatter> &propertyNameFormatter = nullptr);
 
     virtual QVariant value() = 0;
     virtual void setRequired();
@@ -118,6 +118,9 @@ public:
     const DelegateTags *tags() const;
     void setSchemaConfig(SchemaConfig *value);
 
+    /** Returns formatter property name if formatter is set or the original property name is there is no formatter. */
+    QString getFormattedPropertyName(const QString &propertyName) const;
+
 public slots:
     virtual void setValue(const QVariant &value) = 0;
     virtual void processDelegateTags() {
@@ -132,6 +135,7 @@ protected:
 protected:
     const DelegateTags *_tags;
     SchemaConfig *schemaConfig;
+    QSharedPointer<PropertyNameFormatter> propertyNameFormatter;
 };
 
 /**
@@ -140,6 +144,7 @@ protected:
  */
 class U2LANG_EXPORT PropertyDelegate : public QItemDelegate {
     Q_OBJECT
+
 public:
     enum Type {
         NO_TYPE,
@@ -152,7 +157,6 @@ public:
     PropertyDelegate(QObject *parent = 0);
     virtual ~PropertyDelegate();
     virtual QVariant getDisplayValue(const QVariant &v) const;
-    virtual PropertyDelegate *clone();
     virtual PropertyWidget *createWizardWidget(U2OpStatus &os, QWidget *parent) const;
     virtual void getItems(QVariantMap &) const {
     }
@@ -163,9 +167,25 @@ public:
     DelegateTags *tags() const;
     void setSchemaConfig(SchemaConfig *value);
 
+    /** Returns current property name formatter instance. */
+    const QSharedPointer<PropertyNameFormatter> &getPropertyNameFormatter() const;
+
+    /** Sets property name formatter for the widget. */
+    void setPropertyNameFormatter(const QSharedPointer<PropertyNameFormatter> &propertyNameFormatter);
+
+    /** Creates an exact copy of the current delegate with all fields initialized. */
+    PropertyDelegate *createCopy();
+
 protected:
+    /**
+     * Instantiate a copy of the delegate and fills all fields not listed in the base PropertyDelegate class.
+     * The PropertyDelegate class itself is responsible to initialize all own fields.
+     */
+    virtual PropertyDelegate *clone() = 0;
+
     DelegateTags *_tags;
     SchemaConfig *schemaConfig;
+    QSharedPointer<PropertyNameFormatter> propertyNameFormatter;
 };    // PropertyDelegate
 
 class U2LANG_EXPORT DelegateTags : public QObject {

--- a/src/corelibs/U2Lang/src/model/PropertyNameFormatter.cpp
+++ b/src/corelibs/U2Lang/src/model/PropertyNameFormatter.cpp
@@ -1,0 +1,34 @@
+/**
+ * UGENE - Integrated Bioinformatics Tools.
+ * Copyright (C) 2008-2021 UniPro <ugene@unipro.ru>
+ * http://ugene.net
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#include "PropertyNameFormatter.h"
+
+#include <U2Core/AppContext.h>
+#include <U2Core/DocumentModel.h>
+
+namespace U2 {
+
+QString DocumentFormatIdPropertyFormatter::format(const QString &propertyName) const {
+    DocumentFormat *documentFormat = AppContext::getDocumentFormatRegistry()->getFormatById(propertyName);
+    return documentFormat == nullptr ? propertyName : documentFormat->getFormatName();
+}
+
+}    // namespace U2

--- a/src/corelibs/U2Lang/src/model/PropertyNameFormatter.h
+++ b/src/corelibs/U2Lang/src/model/PropertyNameFormatter.h
@@ -1,0 +1,46 @@
+/**
+ * UGENE - Integrated Bioinformatics Tools.
+ * Copyright (C) 2008-2021 UniPro <ugene@unipro.ru>
+ * http://ugene.net
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#ifndef _U2_PROPERTY_NAME_FORMATTER_H_
+#define _U2_PROPERTY_NAME_FORMATTER_H_
+
+#include <U2Core/global.h>
+
+namespace U2 {
+
+/** A class used to adjust formatting of WD property names. */
+class U2LANG_EXPORT PropertyNameFormatter {
+public:
+    virtual ~PropertyNameFormatter() = default;
+
+    /** Returns formatted text for the given property name. */
+    virtual QString format(const QString &propertyName) const = 0;
+};
+
+/** Interprets property name as document format id and returns the related document format name. */
+class U2LANG_EXPORT DocumentFormatIdPropertyFormatter : public PropertyNameFormatter {
+public:
+    QString format(const QString &propertyName) const override;
+};
+
+}    // namespace U2
+
+#endif    // _U2_PROPERTY_NAME_FORMATTER_H_

--- a/src/include/U2Lang/PropertyNameFormatter.h
+++ b/src/include/U2Lang/PropertyNameFormatter.h
@@ -1,0 +1,1 @@
+#include "../../corelibs/U2Lang/src/model/PropertyNameFormatter.h"

--- a/src/plugins/workflow_designer/src/library/ConvertFilesFormatWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/ConvertFilesFormatWorker.cpp
@@ -23,25 +23,18 @@
 
 #include <U2Core/AppContext.h>
 #include <U2Core/AppSettings.h>
-#include <U2Core/BaseDocumentFormats.h>
 #include <U2Core/DocumentImport.h>
 #include <U2Core/DocumentModel.h>
 #include <U2Core/DocumentUtils.h>
 #include <U2Core/FailTask.h>
-#include <U2Core/GObject.h>
-#include <U2Core/GObjectTypes.h>
-#include <U2Core/GUrlUtils.h>
 #include <U2Core/IOAdapter.h>
-#include <U2Core/IOAdapterUtils.h>
 #include <U2Core/SaveDocumentTask.h>
 #include <U2Core/TaskSignalMapper.h>
-#include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
 #include <U2Core/UserApplicationsSettings.h>
 
 #include <U2Designer/DelegateEditors.h>
 
-#include <U2Formats/BAMUtils.h>
 #include <U2Formats/ConvertFileTask.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
@@ -81,43 +74,45 @@ QString ConvertFilesFormatPrompter::composeRichDoc() {
 /************************************************************************/
 /* ConvertFilesFormatWorkerFactory */
 /************************************************************************/
-namespace {
 enum OutDirectory {
     FILE_DIRECTORY = 0,
-    WORKFLOW_INTERNAL,
-    CUSTOM
+    WORKFLOW_INTERNAL = 1,
+    CUSTOM = 2,
 };
-enum MapType { IDS,
-               BOOLEANS
+
+enum MapType {
+    IDS = 1,
+    BOOLEANS = 2,
 };
-QVariantMap getFormatsMap(MapType mapType) {
+
+static QVariantMap getFormatsMap(const MapType &mapType) {
     const QList<DocumentFormatId> allFormats = AppContext::getDocumentFormatRegistry()->getRegisteredFormats();
 
     QVariantMap result;
-    foreach (const DocumentFormatId &fid, allFormats) {
+    for (const DocumentFormatId &fid : qAsConst(allFormats)) {
         const DocumentFormat *format = AppContext::getDocumentFormatRegistry()->getFormatById(fid);
-        if (nullptr == format || format->checkFlags(DocumentFormatFlag_CannotBeCreated)) {
+        if (format == nullptr || format->checkFlags(DocumentFormatFlag_CannotBeCreated)) {
             continue;
         }
-        if (format->checkFlags(DocumentFormatFlag_SupportWriting) || (BOOLEANS == mapType)) {
-            if (BOOLEANS == mapType) {
-                result[fid] = false;
-            } else {
-                result[fid] = fid;
-            }
+        if (!format->checkFlags(DocumentFormatFlag_SupportWriting)) {
+            continue;
+        }
+        if (mapType == MapType::BOOLEANS) {
+            result[fid] = false;
+        } else {
+            result[fid] = fid;
         }
     }
     return result;
 }
-}    // namespace
 
 void ConvertFilesFormatWorkerFactory::init() {
     Descriptor desc(ACTOR_ID, ConvertFilesFormatWorker::tr("File Format Conversion"), ConvertFilesFormatWorker::tr("Converts the file to selected format if it is not excluded."));
 
     QList<PortDescriptor *> p;
     {
-        Descriptor inD(INPUT_PORT, ConvertFilesFormatWorker::tr("File"), ConvertFilesFormatWorker::tr("A file to perform format conversion"));
-        Descriptor outD(OUTPUT_PORT, ConvertFilesFormatWorker::tr("File"), ConvertFilesFormatWorker::tr("File of selected format"));
+        Descriptor inD(INPUT_PORT, ConvertFilesFormatWorker::tr("File"), ConvertFilesFormatWorker::tr("A source file to convert"));
+        Descriptor outD(OUTPUT_PORT, ConvertFilesFormatWorker::tr("File"), ConvertFilesFormatWorker::tr("A target file to save the converted result"));
 
         QMap<Descriptor, DataTypePtr> inM;
         inM[BaseSlots::URL_SLOT()] = BaseTypes::STRING_TYPE();
@@ -139,29 +134,33 @@ void ConvertFilesFormatWorkerFactory::init() {
         Descriptor customDir(CUSTOM_DIR_ID, ConvertFilesFormatWorker::tr("Custom folder"), ConvertFilesFormatWorker::tr("Select the custom output folder."));
 
         a << new Attribute(BaseAttributes::DOCUMENT_FORMAT_ATTRIBUTE(), BaseTypes::STRING_TYPE(), true);
-        a << new Attribute(outDir, BaseTypes::NUM_TYPE(), false, QVariant(WORKFLOW_INTERNAL));
+        a << new Attribute(outDir, BaseTypes::NUM_TYPE(), false, QVariant(OutDirectory::WORKFLOW_INTERNAL));
         Attribute *customDirAttr = new Attribute(customDir, BaseTypes::STRING_TYPE(), false, QVariant(""));
-        customDirAttr->addRelation(new VisibilityRelation(OUT_MODE_ID, CUSTOM));
+        customDirAttr->addRelation(new VisibilityRelation(OUT_MODE_ID, OutDirectory::CUSTOM));
         a << customDirAttr;
-        //a << new Attribute( customDir, BaseTypes::STRING_TYPE(), false, QString(""));
         a << new Attribute(excludedFormats, BaseTypes::STRING_TYPE(), false);
     }
 
     QMap<QString, PropertyDelegate *> delegates;
+    QSharedPointer<PropertyNameFormatter> formatNameByIdRenderer(new DocumentFormatIdPropertyFormatter());
     {
-        QVariantMap formatsIds = getFormatsMap(IDS);
-        delegates[BaseAttributes::DOCUMENT_FORMAT_ATTRIBUTE().getId()] = new ComboBoxDelegate(formatsIds);
+        QVariantMap formatsNameByIdMap = getFormatsMap(MapType::IDS);
+        auto formatByIdCombo = new ComboBoxDelegate(formatsNameByIdMap);
+        formatByIdCombo->setPropertyNameFormatter(formatNameByIdRenderer);
+        delegates[BaseAttributes::DOCUMENT_FORMAT_ATTRIBUTE().getId()] = formatByIdCombo;
 
-        QVariantMap formatsBooleans = getFormatsMap(BOOLEANS);
-        delegates[EXCLUDED_FORMATS_ID] = new ComboBoxWithChecksDelegate(formatsBooleans);
+        QVariantMap excludedFormatByIdMap = getFormatsMap(MapType::BOOLEANS);
+        auto excludedFormatIdCombo = new ComboBoxWithChecksDelegate(excludedFormatByIdMap);
+        excludedFormatIdCombo->setPropertyNameFormatter(formatNameByIdRenderer);
+        delegates[EXCLUDED_FORMATS_ID] = excludedFormatIdCombo;
 
         QVariantMap directoryMap;
         QString fileDir = ConvertFilesFormatWorker::tr("Input file");
         QString workflowDir = ConvertFilesFormatWorker::tr("Workflow");
         QString customD = ConvertFilesFormatWorker::tr("Custom");
-        directoryMap[fileDir] = FILE_DIRECTORY;
-        directoryMap[workflowDir] = WORKFLOW_INTERNAL;
-        directoryMap[customD] = CUSTOM;
+        directoryMap[fileDir] = OutDirectory::FILE_DIRECTORY;
+        directoryMap[workflowDir] = OutDirectory::WORKFLOW_INTERNAL;
+        directoryMap[customD] = OutDirectory::CUSTOM;
         delegates[OUT_MODE_ID] = new ComboBoxDelegate(directoryMap);
 
         delegates[CUSTOM_DIR_ID] = new URLDelegate("", "", false, true);

--- a/src/plugins/workflow_designer/src/library/ConvertFilesFormatWorker.h
+++ b/src/plugins/workflow_designer/src/library/ConvertFilesFormatWorker.h
@@ -56,7 +56,6 @@ private:
     IntegralBus *inputUrlPort;
     IntegralBus *outputUrlPort;
     QString targetFormat;
-    QStringList selectedFormatExtensions;
     QStringList excludedFormats;
 
 public slots:

--- a/src/plugins/workflow_designer/src/library/IncludedProtoFactoryImpl.cpp
+++ b/src/plugins/workflow_designer/src/library/IncludedProtoFactoryImpl.cpp
@@ -226,7 +226,7 @@ ActorPrototype *IncludedProtoFactoryImpl::_getSchemaActorProto(Schema *schema, c
                 attrs << new Attribute(attrDesc, origAttr->getAttributeType(), origAttr->getFlags(), origAttr->getAttributePureValue());
                 PropertyDelegate *d = ed->getDelegate(attrId);
                 if (nullptr != d) {
-                    delegateMap[attrDesc.getId()] = d->clone();
+                    delegateMap[attrDesc.getId()] = d->createCopy();
                 }
             }
         }


### PR DESCRIPTION
The patch is not complete: it needs GUI tests and other places in UGENE where format ids are used in WD updated.

I will update the patch description and add more people to the review once it is complete, but the current solution is already open for discussion.