### PR TITLE
Keep complete MSA selection on view rows reordering

### DIFF
--- a/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorSequenceArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorSequenceArea.cpp
@@ -796,20 +796,15 @@ void MaEditorSequenceArea::restoreViewSelectionFromMaSelection() {
 
     // Select the longest continuous region for the new selection
     QList<int> selectedMaRowIndexes = editor->getMaObject()->convertMaRowIdsToMaRowIndexes(selectedMaRowIds);
-    QSet<int> selectedViewIndexesSet;
     MaCollapseModel *collapseModel = editor->getCollapseModel();
+    QList<QRect> newSelectedRects;
     for (int i = 0; i < selectedMaRowIndexes.size(); i++) {
-        selectedViewIndexesSet << collapseModel->getViewRowIndexByMaRowIndex(selectedMaRowIndexes[i]);
+        int viewRowIndex = collapseModel->getViewRowIndexByMaRowIndex(selectedMaRowIndexes[i]);
+        if (viewRowIndex >= 0) {
+            newSelectedRects << QRect(columnsRegions.startPos, viewRowIndex, columnsRegions.length, 1);
+        }
     }
-    QList<int> selectedViewIndexes = selectedViewIndexesSet.values();
-    std::sort(selectedViewIndexes.begin(), selectedViewIndexes.end());
-    U2Region selectedViewRegion = findLongestRegion(selectedViewIndexes);
-    if (selectedViewRegion.length == 0) {
-        editor->getSelectionController()->clearSelection();
-    } else {
-        QRect newSelectionRect(columnsRegions.startPos, selectedViewRegion.startPos, columnsRegions.length, selectedViewRegion.length);
-        setSelectionRect(newSelectionRect);
-    }
+    editor->getSelectionController()->setSelection(MaEditorSelection(newSelectedRects));
 
     ui->getScrollController()->updateVerticalScrollBar();
 }

--- a/src/corelibs/U2View/src/ov_msa/view_rendering/SequenceWithChromatogramAreaRenderer.cpp
+++ b/src/corelibs/U2View/src/ov_msa/view_rendering/SequenceWithChromatogramAreaRenderer.cpp
@@ -81,11 +81,12 @@ void SequenceWithChromatogramAreaRenderer::drawReferenceSelection(QPainter &pain
 }
 
 void SequenceWithChromatogramAreaRenderer::drawNameListSelection(QPainter &painter) const {
-    QRect selectionRect = getSeqArea()->getEditor()->getSelection().toRect();
-    CHECK(!selectionRect.isEmpty(), );
-    U2Region selectedRowsRegion = U2Region::fromYRange(selectionRect);
-    U2Region selectionPxl = ui->getRowHeightController()->getScreenYRegionByViewRowsRegion(selectedRowsRegion);
-    painter.fillRect(0, (int)selectionPxl.startPos, seqAreaWgt->width(), (int)selectionPxl.length, Theme::selectionBackgroundColor());
+    const QList<QRect>& selectedRects = getSeqArea()->getEditor()->getSelection().getRectList();
+    for (const QRect& selectedRect: qAsConst(selectedRects)) {
+        U2Region selectedRowsRegion = U2Region::fromYRange(selectedRect);
+        U2Region selectionPxl = ui->getRowHeightController()->getScreenYRegionByViewRowsRegion(selectedRowsRegion);
+        painter.fillRect(0, (int)selectionPxl.startPos, seqAreaWgt->width(), (int)selectionPxl.length, Theme::selectionBackgroundColor());
+    }
 }
 
 void SequenceWithChromatogramAreaRenderer::setAreaHeight(int h) {


### PR DESCRIPTION
With the new spatial MSA editor selection it is possible to keep a complete selection even when rows are re-ordered.

This one of the minor fixes. I expect 20-30 mini-fixes like this until deprecated MASelection.toRect() method is not removed completely. 