### PR TITLE
UGENE-7376. Mouse selection & scrolling do not work in Sequence View …

### DIFF
--- a/src/corelibs/U2Gui/src/util/SelectionModificationHelper.h
+++ b/src/corelibs/U2Gui/src/util/SelectionModificationHelper.h
@@ -52,6 +52,9 @@ public:
     static QRect getNewSelection(MovableSide &movableSide, const QPoint &globalMousePos, const QSizeF &baseSize, const QRect &currentSelection);
     static QList<U2Region> getNewSelection(MovableSide &border, const double mouseAngle, const double rotation, const int sequenceLength, const int startBase, const int endBase, bool &isTwoRegions);
 
+    /** Maximum distance from border to show 'resize' shape for cursor. */
+    static const int PIXEL_OFFSET_FOR_BORDER_POINTING;
+
 private:
     static MovableSide getMovableSide(const int globalMousePos, const int selectionPos, const int selectionSize, const double baseSize);
     static U2Region getNewSelectionForBorderMoving(MovableSide &border, const int globalMousePos, const double baseSize, const U2Region &currentSelection);
@@ -60,7 +63,6 @@ private:
     static MovableSide getOppositeBorder(const MovableSide border);
     static MovableSide getNewMovableCorner(const MovableSide horizontalBorder, const MovableSide verticalBorder);
 
-    static const int PIXEL_OFFSET_FOR_BORDER_POINTING;
     static const double PIXEL_OFFSET_FOR_CIRCULAR_VIEW;
     /**
      *Must be equal to the similar named value in CircularView class

--- a/src/corelibs/U2View/src/ov_sequence/DetView.h
+++ b/src/corelibs/U2View/src/ov_sequence/DetView.h
@@ -77,7 +77,7 @@ public:
     int getShift() const;
     void setSelectedTranslations();
 
-    void ensurePositionVisible(int pos);
+    void ensurePositionVisible(qint64 pos);
 
 protected slots:
     void sl_sequenceChanged() override;
@@ -87,7 +87,7 @@ protected slots:
     void sl_showComplementToggle(bool v);
     void sl_showTranslationToggle(bool v);
     void sl_wrapSequenceToggle(bool v);
-    void sl_verticalSrcollBarMoved(int position);
+    void sl_verticalScrollBarMoved(int position);
     void sl_doNotTranslate();
     void sl_translateAnnotationsOrSelection();
     void sl_setUpFramesManually();
@@ -131,7 +131,10 @@ private:
     void setupGeneticCodeMenu();
     QPoint getRenderAreaPointAfterAutoScroll(const QPoint &pos);
     void moveBorder(const QPoint &p);
-    void setBorderCursor(const QPoint &p);
+
+    /** Returns whole rendering area height region for the normal mode & limited Y range for the wrap mode. */
+    U2Region getCapturingRenderAreaYRegionForPos(qint64 pos) const override;
+
     void setDefaultState();
 
     void updateTranslationRowsVisibilityBySelectionState();
@@ -170,7 +173,7 @@ public:
     int getSymbolsPerLine() const;
 
     /** Returns number of visible lines in the view. */
-    int getLinesCount() const;
+    qint64 getLinesCount() const;
 
     /** Returns number of bases in all visible lines.  */
     int getVisibleSymbolsCount() const;

--- a/src/corelibs/U2View/src/ov_sequence/DetViewSequenceEditor.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/DetViewSequenceEditor.cpp
@@ -164,7 +164,7 @@ bool DetViewSequenceEditor::eventFilter(QObject *, QEvent *event) {
     }
 }
 
-void DetViewSequenceEditor::setCursor(int newPos) {
+void DetViewSequenceEditor::setCursor(qint64 newPos) {
     CHECK(newPos >= 0 && newPos <= view->getSequenceLength(), );
     if (cursor != newPos) {
         cursor = newPos;
@@ -173,13 +173,13 @@ void DetViewSequenceEditor::setCursor(int newPos) {
     }
 }
 
-void DetViewSequenceEditor::navigate(int newPos, bool shiftPressed) {
+void DetViewSequenceEditor::navigate(qint64 newPos, bool shiftPressed) {
     CHECK(newPos != cursor, );
-    newPos = qBound(0, newPos, (int)view->getSequenceLength());
+    newPos = qBound((qint64)0, newPos, view->getSequenceLength());
 
     DNASequenceSelection *selection = view->getSequenceContext()->getSequenceSelection();
     if (shiftPressed) {
-        int extension = qAbs(cursor - newPos);
+        qint64 extension = qAbs(cursor - newPos);
         if (selection->isEmpty()) {
             // if selection is empty - start a new one!
             selection->setRegion(U2Region(qMin(cursor, newPos), extension));

--- a/src/corelibs/U2View/src/ov_sequence/DetViewSequenceEditor.h
+++ b/src/corelibs/U2View/src/ov_sequence/DetViewSequenceEditor.h
@@ -62,8 +62,8 @@ public:
     }
 
 private:
-    void setCursor(int newPos);
-    void navigate(int newPos, bool shiftPressed = false);
+    void setCursor(qint64 newPos);
+    void navigate(qint64 newPos, bool shiftPressed = false);
 
     void insertChar(int character);
     void deleteChar(int key);
@@ -81,7 +81,7 @@ private slots:
     void sl_paste(Task *pasteTask);
 
 private:
-    int cursor;  // TODO_SVEDIT: can be separate class
+    qint64 cursor = 0;  // TODO_SVEDIT: can be separate class
     QColor cursorColor;
     QTimer animationTimer;
     DetView *view;

--- a/src/corelibs/U2View/src/ov_sequence/GSequenceLineView.h
+++ b/src/corelibs/U2View/src/ov_sequence/GSequenceLineView.h
@@ -186,15 +186,23 @@ protected slots:
 
 protected:
     QPoint toRenderAreaPoint(const QPoint &p) const;
+
+    /**
+     * Returns a valid Y-range to react to mouse events for the given 'pos'.
+     * Normally this is a whole vertical range of the widget area, but in some widgets, like DetView it may be a limited space.
+     * Reason for this is that DetView is a 'multi-line', while all methods inside GSequenceLineView are 'single-line'.
+     * Uses 'renderArea' local coordinates.
+     */
+    virtual U2Region getCapturingRenderAreaYRegionForPos(qint64 pos) const;
+
     virtual void updateScrollBar();
     virtual void setSelection(const U2Region &r);
     void addSelection(const U2Region &r);
-    void removeSelection(const U2Region &r);
-    virtual void setBorderCursor(const QPoint &p);
+    virtual void updateCursorShapeOnMouseMove(const QPoint &p);
     virtual void moveBorder(const QPoint &p);
     virtual void pack();
-    virtual int getSingleStep() const;
-    virtual int getPageStep() const;
+    virtual qint64 getSingleStep() const;
+    virtual qint64 getPageStep() const;
     void autoScrolling(const QPoint &areaPoint);
     virtual void resizeSelection(const QPoint &areaPoint);
     void cancelSelectionResizing();
@@ -214,7 +222,6 @@ protected:
     GSequenceLineView *frameView;
     GSequenceLineView *coherentRangeView;
     double coefScrollBarMapping;
-    SelectionModificationHelper::MovableSide movableBorder;
 
     // special flag setup by child classes that tells to this class do or skip
     // any changes to selection on mouse ops
@@ -266,12 +273,12 @@ protected:
     QFont smallSequenceFont;
     QFont rulerFont;
 
-    int charWidth;
-    int smallCharWidth;
+    int charWidth = 0;
+    int smallCharWidth = 0;
 
-    int lineHeight;
-    int yCharOffset;
-    int xCharOffset;
+    int lineHeight = 0;
+    int yCharOffset = 0;
+    int xCharOffset = 0;
 };
 
 }  // namespace U2

--- a/src/corelibs/U2View/src/ov_sequence/PanView.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/PanView.cpp
@@ -540,6 +540,10 @@ void PanView::setSyncOffset(int o) {
     update();
 }
 
+int PanView::getSyncOffset() const {
+    return syncOffset;
+}
+
 void PanView::sl_sequenceChanged() {
     seqLen = ctx->getSequenceLength();
     U2Region curSource(0, ctx->getSequenceLength()), newRange(0, 0);
@@ -573,7 +577,7 @@ void PanView::sl_updateRows() {
     updateRows();
 }
 
-const U2Region PanView::getRegionToZoom() const {
+U2Region PanView::getRegionToZoom() const {
     const QVector<U2Region> &sel = ctx->getSequenceSelection()->getSelectedRegions();
     const QList<Annotation *> annotationSel = getSequenceContext()->getAnnotationsSelection()->getAnnotations();
     U2Region selRegion;
@@ -586,8 +590,48 @@ const U2Region PanView::getRegionToZoom() const {
     return selRegion;
 }
 
+QAction *PanView::getZoomInAction() const {
+    return zoomInAction;
+}
+
+QAction *PanView::getZoomOutAction() const {
+    return zoomOutAction;
+}
+
+QAction *PanView::getZoomToSelectionAction() const {
+    return zoomToSelectionAction;
+}
+
+QAction *PanView::getZoomToSequenceAction() const {
+    return zoomToSequenceAction;
+}
+
+PVRowsManager *PanView::getRowsManager() const {
+    return rowsManager;
+}
+
+QAction *PanView::getToggleMainRulerAction() const {
+    return toggleMainRulerAction;
+}
+
+QAction *PanView::getToggleCustomRulersAction() const {
+    return toggleCustomRulersAction;
+}
+
+PanViewLinesSettings *PanView::getLinesSettings() const {
+    return settings;
+}
+
+qint64 PanView::getSingleStep() const {
+    return qMax((qint64)1, visibleRange.length / 10);
+}
+
+qint64 PanView::getPageStep() const {
+    return qMax((qint64)1, visibleRange.length / 5);
+}
+
 //////////////////////////////////////////////////////////////////////////
-/// render
+/// PanViewRenderArea
 PanViewRenderArea::PanViewRenderArea(PanView *d, PanViewRenderer *renderer)
     : GSequenceLineViewGridAnnotationRenderArea(d),
       panView(d),

--- a/src/corelibs/U2View/src/ov_sequence/PanView.h
+++ b/src/corelibs/U2View/src/ov_sequence/PanView.h
@@ -108,36 +108,24 @@ public:
         return frameView->getVisibleRange();
     }
 
-    virtual QAction *getZoomInAction() const {
-        return zoomInAction;
-    }
+    QAction *getZoomInAction() const override;
 
-    virtual QAction *getZoomOutAction() const {
-        return zoomOutAction;
-    }
+    QAction *getZoomOutAction() const override;
 
-    virtual QAction *getZoomToSelectionAction() const {
-        return zoomToSelectionAction;
-    }
+    QAction *getZoomToSelectionAction() const override;
 
-    virtual QAction *getZoomToSequenceAction() const {
-        return zoomToSequenceAction;
-    }
+    QAction *getZoomToSequenceAction() const override;
 
     // [0..seqLen)
-    virtual void setVisibleRange(const U2Region &reg, bool signal = true);
+    void setVisibleRange(const U2Region &reg, bool signal = true) override;
 
-    PVRowsManager *getRowsManager() const {
-        return rowsManager;
-    }
+    PVRowsManager *getRowsManager() const;
 
     virtual void setNumBasesVisible(qint64 n);
 
     void setSyncOffset(int o);
 
-    int getSyncOffset() const {
-        return syncOffset;
-    }
+    int getSyncOffset() const;
 
     QList<RulerInfo> getCustomRulers() const;
 
@@ -147,39 +135,32 @@ public:
 
     void removeAllCustomRulers();
 
-    QAction *getToggleMainRulerAction() const {
-        return toggleMainRulerAction;
-    }
+    QAction *getToggleMainRulerAction() const;
 
-    QAction *getToggleCustomRulersAction() const {
-        return toggleCustomRulersAction;
-    }
+    QAction *getToggleCustomRulersAction() const;
 
-    void hideEvent(QHideEvent *ev);
+    void hideEvent(QHideEvent *ev) override;
 
-    void showEvent(QShowEvent *ev);
+    void showEvent(QShowEvent *ev) override;
 
-    PanViewLinesSettings *getLinesSettings() const {
-        return settings;
-    }
+    PanViewLinesSettings *getLinesSettings() const;
 
 protected:
-    virtual int getSingleStep() const {
-        return qMax(1, int(visibleRange.length) / 10);
-    }
-    virtual int getPageStep() const {
-        return qMax(1, int(visibleRange.length) / 5);
-    }
-    virtual void onVisibleRangeChanged(bool signal = true);
-    virtual void pack();
+    qint64 getSingleStep() const override;
 
-    virtual void registerAnnotations(const QList<Annotation *> &l);
-    virtual void unregisterAnnotations(const QList<Annotation *> &l);
-    virtual void ensureVisible(Annotation *a, int locationIdx);
+    qint64 getPageStep() const override;
+
+    void onVisibleRangeChanged(bool signal = true) override;
+
+    void pack() override;
+
+    void registerAnnotations(const QList<Annotation *> &l) override;
+    void unregisterAnnotations(const QList<Annotation *> &l) override;
+    void ensureVisible(Annotation *a, int locationIdx) override;
 
 protected slots:
-    virtual void sl_sequenceChanged();
-    virtual void sl_onAnnotationsModified(const QList<AnnotationModification> &annotationModifications);
+    void sl_sequenceChanged() override;
+    void sl_onAnnotationsModified(const QList<AnnotationModification> &annotationModifications) override;
 
 private slots:
     void sl_zoomInAction();
@@ -191,8 +172,8 @@ private slots:
 
     void sl_onRangeChangeRequest(qint64 start, qint64 end);
 
-    virtual void sl_onDNASelectionChanged(LRegionsSelection *s, const QVector<U2Region> &added, const QVector<U2Region> &removed);
-    virtual void sl_onAnnotationSettingsChanged(const QStringList &changedSettings);
+    void sl_onDNASelectionChanged(LRegionsSelection *s, const QVector<U2Region> &added, const QVector<U2Region> &removed) override;
+    void sl_onAnnotationSettingsChanged(const QStringList &changedSettings) override;
 
     void sl_toggleMainRulerVisibility(bool visible);
     void sl_toggleCustomRulersVisibility(bool visible);
@@ -219,7 +200,7 @@ public:
     PanViewRenderArea *getRenderArea() const;
 
 private:
-    const U2Region getRegionToZoom() const;
+    U2Region getRegionToZoom() const;
 
 public:
     U2Region frameRange;

--- a/src/corelibs/U2View/src/ov_sequence/view_rendering/DetViewMultiLineRenderer.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/view_rendering/DetViewMultiLineRenderer.cpp
@@ -52,7 +52,7 @@ qint64 DetViewMultiLineRenderer::coordToPos(const QPoint &p, const QSize &canvas
     return qMin(ctx->getSequenceLength(), posOnFirstLine + line * symbolsPerLine);
 }
 
-int DetViewMultiLineRenderer::posToXCoord(const qint64 pos, const QSize &canvasSize, const U2Region &visibleRange) const {
+int DetViewMultiLineRenderer::posToXCoord(qint64 pos, const QSize &canvasSize, const U2Region &visibleRange) const {
     CHECK(visibleRange.contains(pos), -1);
 
     qint64 symbolsPerLine = getSymbolsPerLine(canvasSize.width());

--- a/src/corelibs/U2View/src/ov_sequence/view_rendering/DetViewMultiLineRenderer.h
+++ b/src/corelibs/U2View/src/ov_sequence/view_rendering/DetViewMultiLineRenderer.h
@@ -37,7 +37,7 @@ public:
     ~DetViewMultiLineRenderer();
 
     qint64 coordToPos(const QPoint &p, const QSize &canvasSize, const U2Region &visibleRange) const override;
-    int posToXCoord(const qint64 pos, const QSize &canvasSize, const U2Region &visibleRange) const override;
+    int posToXCoord(qint64 pos, const QSize &canvasSize, const U2Region &visibleRange) const override;
 
     /** Returns all y regions used to draw the given location of the annotation. */
     QList<U2Region> getAnnotationYRegions(Annotation *annotation, int locationRegionIndex, const AnnotationSettings *annotationSettings, const QSize &canvasSize, const U2Region &visibleRange) const override;

--- a/src/corelibs/U2View/src/ov_sequence/view_rendering/SequenceViewAnnotatedRenderer.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/view_rendering/SequenceViewAnnotatedRenderer.cpp
@@ -387,7 +387,7 @@ void SequenceViewAnnotatedRenderer::addArrowPath(QPainterPath &path, const QRect
     path = path.united(arrowPath);
 }
 
-qint64 SequenceViewAnnotatedRenderer::correctCutPos(const qint64 pos) const {
+qint64 SequenceViewAnnotatedRenderer::correctCutPos(qint64 pos) const {
     const bool isCircular = ctx->getSequenceObject()->isCircular();
     const qint64 sequenceLength = ctx->getSequenceLength();
     qint64 result = pos;

--- a/src/corelibs/U2View/src/ov_sequence/view_rendering/SequenceViewAnnotatedRenderer.h
+++ b/src/corelibs/U2View/src/ov_sequence/view_rendering/SequenceViewAnnotatedRenderer.h
@@ -120,7 +120,7 @@ protected:
 
     void addArrowPath(QPainterPath &path, const QRect &rect, bool leftArrow) const;
 
-    qint64 correctCutPos(const qint64 pos) const;
+    qint64 correctCutPos(qint64 pos) const;
 
     AnnotationViewMetrics annMetrics;
 

--- a/src/corelibs/U2View/src/ov_sequence/view_rendering/SequenceViewRenderer.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/view_rendering/SequenceViewRenderer.cpp
@@ -55,15 +55,14 @@ SequenceViewRenderer::SequenceViewRenderer(SequenceObjectContext *ctx)
     : ctx(ctx) {
 }
 
-int SequenceViewRenderer::posToXCoord(const qint64 pos, const QSize &canvasSize, const U2Region &visibleRange) const {
-    Q_UNUSED(canvasSize);
+int SequenceViewRenderer::posToXCoord(qint64 pos, const QSize &, const U2Region &visibleRange) const {
     CHECK(visibleRange.contains(pos) || pos == visibleRange.endPos(), -1);
 
-    double res = (pos - visibleRange.startPos) * getCurrentScale();
+    double res = (double)(pos - visibleRange.startPos) * getCurrentScale();
     return qRound(res);
 }
 
-qint64 SequenceViewRenderer::getRowLineHeight() const {
+int SequenceViewRenderer::getRowLineHeight() const {
     return commonMetrics.lineHeight;
 }
 

--- a/src/corelibs/U2View/src/ov_sequence/view_rendering/SequenceViewRenderer.h
+++ b/src/corelibs/U2View/src/ov_sequence/view_rendering/SequenceViewRenderer.h
@@ -55,9 +55,9 @@ public:
 
     virtual qint64 coordToPos(const QPoint &p, const QSize &canvasSize, const U2Region &visibleRange) const = 0;
 
-    virtual int posToXCoord(const qint64 pos, const QSize &canvasSize, const U2Region &visibleRange) const;
+    virtual int posToXCoord(qint64 pos, const QSize &canvasSize, const U2Region &visibleRange) const;
 
-    virtual qint64 getRowLineHeight() const;
+    virtual int getRowLineHeight() const;
 
     virtual double getCurrentScale() const = 0;
 


### PR DESCRIPTION
I fixed mouse selection & scrolling as reported in the issue.

There are still some "big-size" issues left on other places: in dialog inputs that use int32 fields & validators.
These dialogs will be fixed separately.

The patch fixes most of the int32-int64 compiler warnings. Some of "non-essential" ones left unfixed to avoid patch size growth even more - will do it in a dedicated patches.

Unfortunately I can't use directly SelectionModificationHelper because it relies on 32-bit values a lot (QPoint/QRect) and any changes in that class will affect MSA/MCA selection. 