### PR TITLE
Support multiple selection in consensus widget & zoomToSelection action

### DIFF
--- a/src/corelibs/U2View/src/ov_msa/MaCollapseModel.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaCollapseModel.cpp
@@ -244,4 +244,16 @@ QSet<qint64> MaCollapseModel::getAllRowIds() const {
     return rowIdSet;
 }
 
+QList<int> MaCollapseModel::getMaRowIndexesFromSelectionRects(const QList<QRect> &selectionRects) const {
+    QList<int> maRowIndexes;
+    for (const QRect &selectionRect : qAsConst(selectionRects)) {
+        for (int viewRowIndex = selectionRect.top(); viewRowIndex <= selectionRect.bottom(); viewRowIndex++) {
+            int maRowIndex = getMaRowIndexByViewRowIndex(viewRowIndex);
+            SAFE_POINT_EXT(maRowIndex >= 0, "Failed to map view row index: " + QString::number(viewRowIndex), {});
+            maRowIndexes.append(maRowIndex);
+        }
+    }
+    return maRowIndexes;
+}
+
 }  // namespace U2

--- a/src/corelibs/U2View/src/ov_msa/MaCollapseModel.h
+++ b/src/corelibs/U2View/src/ov_msa/MaCollapseModel.h
@@ -156,6 +156,9 @@ public:
     /** Returns all row ids in the model. */
     QSet<qint64> getAllRowIds() const;
 
+    /** Returns list of maRowIndexes for all rows in the selection. Asserts that all rows are mapped. */
+    QList<int> getMaRowIndexesFromSelectionRects(const QList<QRect> &selectionRects) const;
+
 signals:
     void si_aboutToBeToggled();
     void si_toggled();

--- a/src/corelibs/U2View/src/ov_msa/MaEditor.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditor.cpp
@@ -266,11 +266,9 @@ void MaEditor::sl_zoomToSelection() {
     ResizeMode oldMode = resizeMode;
     int seqAreaWidth = ui->getSequenceArea()->width();
     const MaEditorSelection &selection = getSelection();
-    if (selection.isEmpty()) {
-        return;
-    }
-    int selectionWidth = selection.toRect().width();
-    float pixelsPerBase = (seqAreaWidth / float(selectionWidth)) * zoomMult;
+    CHECK(!selection.isEmpty(), )
+    QRect selectionRect = selection.getRectList()[0];  // We need width (equal on all rects) + top-left of the first rect.
+    float pixelsPerBase = (seqAreaWidth / float(selectionRect.width())) * zoomMult;
     int fontPointSize = int(pixelsPerBase / fontPixelToPointSize);
     if (fontPointSize >= minimumFontPointSize) {
         fontPointSize = qMin(fontPointSize, maximumFontPointSize);
@@ -286,7 +284,6 @@ void MaEditor::sl_zoomToSelection() {
         setZoomFactor(pixelsPerBase / (minimumFontPointSize * fontPixelToPointSize));
         resizeMode = ResizeMode_OnlyContent;
     }
-    QRect selectionRect = selection.toRect();
     ui->getScrollController()->setFirstVisibleBase(selectionRect.x());
     ui->getScrollController()->setFirstVisibleViewRow(selectionRect.y());
 

--- a/src/corelibs/U2View/src/ov_msa/view_rendering/MaConsensusAreaRenderer.cpp
+++ b/src/corelibs/U2View/src/ov_msa/view_rendering/MaConsensusAreaRenderer.cpp
@@ -118,10 +118,9 @@ void MaConsensusAreaRenderer::drawContent(QPainter &painter,
 }
 
 ConsensusRenderData MaConsensusAreaRenderer::getConsensusRenderData(const QList<int> &seqIdx, const U2Region &region) const {
-    QRect selectionRect = editor->getSelection().toRect();
     ConsensusRenderData consensusRenderData;
     consensusRenderData.region = region;
-    consensusRenderData.selectedRegion = U2Region::fromXRange(selectionRect);
+    consensusRenderData.selectedRegion = editor->getSelection().getColumnRegion();
     consensusRenderData.mismatches.resize(static_cast<int>(region.length));
 
     MSAConsensusAlgorithm *algorithm = area->getConsensusAlgorithm();
@@ -307,8 +306,7 @@ ConsensusRenderData MaConsensusAreaRenderer::getScreenDataToRender() const {
     ConsensusRenderData consensusRenderData;
     consensusRenderData.region = ui->getDrawHelper()->getVisibleBases(area->width());
     const MaEditorSelection &selection = editor->getSelection();
-    QRect selectionRect = selection.toRect();
-    consensusRenderData.selectedRegion = U2Region(selectionRect.x(), selectionRect.width());
+    consensusRenderData.selectedRegion = selection.getColumnRegion();
     consensusRenderData.data = consensusCache->getConsensusLine(consensusRenderData.region, true);
     consensusRenderData.percentage << consensusCache->getConsensusPercents(consensusRenderData.region);
 

--- a/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorConsensusArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorConsensusArea.cpp
@@ -257,8 +257,8 @@ void MaEditorConsensusArea::sl_completeRedraw() {
 }
 
 void MaEditorConsensusArea::sl_selectionChanged(const MaEditorSelection &current, const MaEditorSelection &prev) {
-    U2Region currentRegion = U2Region::fromXRange(current.toRect());
-    U2Region prevRegion = U2Region::fromXRange(prev.toRect());
+    U2Region currentRegion = current.getColumnRegion();
+    U2Region prevRegion = prev.getColumnRegion();
     if (currentRegion != prevRegion) {
         sl_completeRedraw();
     }

--- a/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorSelection.cpp
+++ b/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorSelection.cpp
@@ -164,6 +164,13 @@ QList<int> MaEditorSelection::getSelectedRowIndexes() const {
     return selectedRowIndexes;
 }
 
+U2Region MaEditorSelection::getColumnRegion() const {
+    if (isEmpty()) {
+        return {};
+    }
+    return {rectList[0].x(), rectList[0].width()};
+}
+
 /************************************************************************/
 /* MaEditorSelectionController */
 /************************************************************************/
@@ -216,7 +223,7 @@ void McaEditorSelectionController::setSelection(const MaEditorSelection &newSele
         mcaEditor->getUI()->getReferenceArea()->clearSelection();
         return;
     }
-    const QList<QRect> selectedRects= newSelection.getRectList();
+    QList<QRect> selectedRects = newSelection.getRectList();
     if (newSelection.isSingleBaseSelection() && mcaEditor->getMaObject()->getMca()->isTrailingOrLeadingGap(selectedRects[0].y(), selectedRects[0].x())) {
         // Clear selection if gap is clicked.
         MaEditorSelectionController::setSelection({});

--- a/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorSelection.h
+++ b/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorSelection.h
@@ -75,6 +75,9 @@ public:
     /** Returns width of the selection. Note: all rects in the selection have unified width (left & right coordinates). */
     int getWidth() const;
 
+    /** Returns selected X region or an empty region if there is no active selection. */
+    U2Region getColumnRegion() const;
+
     /** Returns list of selected rects. */
     const QList<QRect> &getRectList() const;
 


### PR DESCRIPTION
The next step in the series of removal of the deprecated toRect method in MASelection.
Trivial changes only