### PR TITLE
Support multi-selection in simple MA overview

### DIFF
--- a/src/corelibs/U2View/src/ov_msa/MSAEditorOverviewArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorOverviewArea.cpp
@@ -38,10 +38,11 @@ const QString MSAEditorOverviewArea::OVERVIEW_AREA_OBJECT_NAME = "msa_overview_a
 MSAEditorOverviewArea::MSAEditorOverviewArea(MaEditorWgt *ui)
     : MaEditorOverviewArea(ui, OVERVIEW_AREA_OBJECT_NAME) {
     graphOverview = new MaGraphOverview(ui);
-    graphOverview->setObjectName(OVERVIEW_AREA_OBJECT_NAME + QString("_graph"));
+    graphOverview->setObjectName(OVERVIEW_AREA_OBJECT_NAME + "_graph");
 
     simpleOverview = new MaSimpleOverview(ui);
-    simpleOverview->setObjectName(OVERVIEW_AREA_OBJECT_NAME + QString("_simple"));
+    simpleOverview->setObjectName(OVERVIEW_AREA_OBJECT_NAME + "_simple");
+    simpleOverview->setVisible(false);  // "Simple Overview" is hidden by default.
 
     addOverview(simpleOverview);
     addOverview(graphOverview);

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorOverviewArea.h
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorOverviewArea.h
@@ -32,7 +32,6 @@
 namespace U2 {
 
 class MaEditorWgt;
-class MaSangerOverview;
 class MaSimpleOverview;
 class MaGraphOverview;
 class MaOverviewContextMenu;
@@ -42,18 +41,19 @@ class U2VIEW_EXPORT MSAEditorOverviewArea : public MaEditorOverviewArea {
 public:
     MSAEditorOverviewArea(MaEditorWgt *ui);
 
-    void contextMenuEvent(QContextMenuEvent *event);
-    void cancelRendering();
+    void contextMenuEvent(QContextMenuEvent *event) override;
+
+    void cancelRendering() override;
 
     static const QString OVERVIEW_AREA_OBJECT_NAME;
 
 private slots:
-    void sl_show();
+    void sl_show() override;
 
 private:
-    MaGraphOverview *graphOverview;
-    MaSimpleOverview *simpleOverview;
-    MaOverviewContextMenu *contextMenu;
+    MaGraphOverview *graphOverview = nullptr;
+    MaSimpleOverview *simpleOverview = nullptr;
+    MaOverviewContextMenu *contextMenu = nullptr;
 };
 
 }  // namespace U2

--- a/src/corelibs/U2View/src/ov_msa/overview/MaOverview.h
+++ b/src/corelibs/U2View/src/ov_msa/overview/MaOverview.h
@@ -81,7 +81,6 @@ protected:
     MaEditorSequenceArea *sequenceArea;
 
     QPixmap cachedView;
-    QRect cachedSelection;
     QRect cachedVisibleRange;
 
     bool visibleRangeIsMoving;

--- a/src/corelibs/U2View/src/ov_msa/overview/MaSimpleOverview.cpp
+++ b/src/corelibs/U2View/src/ov_msa/overview/MaSimpleOverview.cpp
@@ -42,21 +42,15 @@
 
 namespace U2 {
 
-MaSimpleOverview::MaSimpleOverview(MaEditorWgt *_ui)
-    : MaOverview(_ui),
-      redrawMsaOverview(true),
-      redrawSelection(true) {
+MaSimpleOverview::MaSimpleOverview(MaEditorWgt *ui)
+    : MaOverview(ui) {
     setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
     setFixedHeight(FIXED_HEIGTH);
-
-    setVisible(false);
 }
 
 bool MaSimpleOverview::isValid() const {
-    if (width() < editor->getAlignmentLen() || height() < editor->getNumSequences()) {
-        return false;
-    }
-    return true;
+    // The overview can be shown only if there are more on-screen pixels available than bases in the alignment. */
+    return width() >= editor->getAlignmentLen() && height() >= editor->getNumSequences();
 }
 
 QPixmap MaSimpleOverview::getView() {
@@ -71,11 +65,7 @@ QPixmap MaSimpleOverview::getView() {
 }
 
 void MaSimpleOverview::sl_selectionChanged() {
-    if (!isValid()) {
-        return;
-    }
-    redrawSelection = true;
-
+    CHECK(isValid(), );
     update();
 }
 
@@ -86,9 +76,7 @@ void MaSimpleOverview::sl_redraw() {
 }
 
 void MaSimpleOverview::sl_highlightingChanged() {
-    if (!isValid()) {
-        return;
-    }
+    CHECK(isValid(), );
     redrawMsaOverview = true;
     update();
 }
@@ -109,21 +97,14 @@ void MaSimpleOverview::paintEvent(QPaintEvent *e) {
     }
     cachedView = cachedMSAOverview;
 
-    QPainter pVisibleRange(&cachedView);
-    drawVisibleRange(pVisibleRange);
-    pVisibleRange.end();
+    QPainter cachedViewPainter(&cachedView);
+    drawVisibleRange(cachedViewPainter);
 
-    if (redrawSelection) {
-        recalculateSelection();
-        redrawSelection = false;
-    }
+    drawSelection(cachedViewPainter);
+    cachedViewPainter.end();
 
-    QPainter pSelection(&cachedView);
-    drawSelection(pSelection);
-    pSelection.end();
-
-    QPainter p(this);
-    p.drawPixmap(0, 0, cachedView);
+    QPainter painter(this);
+    painter.drawPixmap(0, 0, cachedView);
     QWidget::paintEvent(e);
 }
 
@@ -135,19 +116,16 @@ void MaSimpleOverview::resizeEvent(QResizeEvent *e) {
 
 void MaSimpleOverview::drawOverview(QPainter &p) {
     p.fillRect(cachedMSAOverview.rect(), Qt::white);
-
-    if (editor->isAlignmentEmpty()) {
-        return;
-    }
+    CHECK(!editor->isAlignmentEmpty(), );
 
     recalculateScale();
 
     QString highlightingSchemeId = sequenceArea->getCurrentHighlightingScheme()->getFactory()->getId();
 
     MultipleAlignmentObject *mAlignmentObj = editor->getMaObject();
-    SAFE_POINT(nullptr != mAlignmentObj, tr("Incorrect multiple alignment object!"), );
-    const MultipleAlignment ma = mAlignmentObj->getMultipleAlignment();
+    SAFE_POINT(mAlignmentObj != nullptr, tr("Incorrect multiple alignment object!"), );
 
+    const MultipleAlignment &ma = mAlignmentObj->getMultipleAlignment();
     U2OpStatusImpl os;
     for (int seq = 0; seq < editor->getNumSequences(); seq++) {
         for (int pos = 0; pos < editor->getAlignmentLen(); pos++) {
@@ -155,10 +133,10 @@ void MaSimpleOverview::drawOverview(QPainter &p) {
             U2Region xRange = ui->getBaseWidthController()->getBaseGlobalRange(pos);
 
             QRect rect;
-            rect.setX(qRound(xRange.startPos / stepX));
-            rect.setY(qRound(yRange.startPos / stepY));
-            rect.setWidth(qRound(xRange.length / stepX));
-            rect.setHeight(qRound(yRange.length / stepY));
+            rect.setLeft(qRound(xRange.startPos / stepX));
+            rect.setTop(qRound(yRange.startPos / stepY));
+            rect.setRight(qRound(xRange.endPos() / stepX));
+            rect.setBottom(qRound(yRange.endPos() / stepY));
 
             QColor color = sequenceArea->getCurrentColorScheme()->getBackgroundColor(seq, pos, mAlignmentObj->charAt(seq, pos));
             if (MaHighlightingOverviewCalculationTask::isGapScheme(highlightingSchemeId)) {
@@ -167,7 +145,7 @@ void MaSimpleOverview::drawOverview(QPainter &p) {
 
             bool drawColor = true;
             int refPos = -1;
-            ;
+
             qint64 refId = editor->getReferenceRowId();
             if (refId != U2MsaRow::INVALID_ROW_ID) {
                 refPos = ma->getRowIndexByRowId(refId, os);
@@ -194,8 +172,8 @@ void MaSimpleOverview::drawVisibleRange(QPainter &p) {
     if (editor->isAlignmentEmpty()) {
         setVisibleRangeForEmptyAlignment();
     } else {
-        const QPoint screenPosition = editor->getUI()->getScrollController()->getScreenPosition();
-        const QSize screenSize = editor->getUI()->getSequenceArea()->size();
+        QPoint screenPosition = editor->getUI()->getScrollController()->getScreenPosition();
+        QSize screenSize = editor->getUI()->getSequenceArea()->size();
 
         cachedVisibleRange.setX(qRound(screenPosition.x() / stepX));
         cachedVisibleRange.setWidth(qRound(screenSize.width() / stepX));
@@ -212,38 +190,34 @@ void MaSimpleOverview::drawVisibleRange(QPainter &p) {
 }
 
 void MaSimpleOverview::drawSelection(QPainter &p) {
-    p.fillRect(cachedSelection, SELECTION_COLOR);
-}
-
-void MaSimpleOverview::moveVisibleRange(QPoint _pos) {
-    QRect newVisibleRange(cachedVisibleRange);
-    const int newPosX = qBound((cachedVisibleRange.width()) / 2, _pos.x(), width() - (cachedVisibleRange.width() - 1) / 2);
-    const int newPosY = qBound((cachedVisibleRange.height()) / 2, _pos.y(), height() - (cachedVisibleRange.height() - 1) / 2);
-    const QPoint newPos(newPosX, newPosY);
-    newVisibleRange.moveCenter(newPos);
-
-    const int newHScrollBarValue = newVisibleRange.x() * stepX;
-    ui->getScrollController()->setHScrollbarValue(newHScrollBarValue);
-    const int newVScrollBarValue = newVisibleRange.y() * stepY;
-    ui->getScrollController()->setVScrollbarValue(newVScrollBarValue);
-}
-
-void MaSimpleOverview::recalculateSelection() {
-    recalculateScale();
-
     const MaEditorSelection &selection = editor->getSelection();
 
-    QRect selectionRect = selection.toRect();
-    U2Region selectionBasesRegion = ui->getBaseWidthController()->getBasesGlobalRange(selectionRect.x(), selectionRect.width());
-    U2Region yRegion(selectionRect.y(), selectionRect.height());
-    U2Region selectionRowsRegion = ui->getRowHeightController()->getGlobalYRegionByViewRowsRegion(yRegion);
+    QList<QRect> selectedRects = selection.getRectList();
+    for (const QRect &selectedRect : qAsConst(selectedRects)) {
+        U2Region columnRange = ui->getBaseWidthController()->getBasesGlobalRange(selectedRect.x(), selectedRect.width());
+        U2Region rowRange = U2Region::fromYRange(selectedRect);
+        U2Region sequenceViewYRegion = ui->getRowHeightController()->getGlobalYRegionByViewRowsRegion(rowRange);
 
-    cachedSelection.setX(qRound(selectionBasesRegion.startPos / stepX));
-    cachedSelection.setY(qRound(selectionRowsRegion.startPos / stepY));
+        QRect drawRect;
+        drawRect.setLeft(qRound(columnRange.startPos / stepX));
+        drawRect.setRight(qRound(columnRange.endPos() / stepX));
+        drawRect.setTop(qRound(sequenceViewYRegion.startPos / stepY));
+        drawRect.setBottom(qRound(sequenceViewYRegion.endPos() / stepY));
+        p.fillRect(drawRect, SELECTION_COLOR);
+    }
+}
 
-    //(!) [(a - b)*c] != [a*c] - [b*c]
-    cachedSelection.setWidth(qRound((selectionBasesRegion.startPos + selectionBasesRegion.length) / stepX) - qRound(selectionBasesRegion.startPos / stepX));
-    cachedSelection.setHeight(qRound((selectionRowsRegion.startPos + selectionRowsRegion.length) / stepY) - qRound(selectionRowsRegion.startPos / stepY));
+void MaSimpleOverview::moveVisibleRange(QPoint pos) {
+    QRect newVisibleRange(cachedVisibleRange);
+    int newPosX = qBound(cachedVisibleRange.width() / 2, pos.x(), width() - (cachedVisibleRange.width() - 1) / 2);
+    int newPosY = qBound(cachedVisibleRange.height() / 2, pos.y(), height() - (cachedVisibleRange.height() - 1) / 2);
+    QPoint newPos(newPosX, newPosY);
+    newVisibleRange.moveCenter(newPos);
+
+    int newHScrollBarValue = newVisibleRange.x() * stepX;
+    ui->getScrollController()->setHScrollbarValue(newHScrollBarValue);
+    int newVScrollBarValue = newVisibleRange.y() * stepY;
+    ui->getScrollController()->setVScrollbarValue(newVScrollBarValue);
 }
 
 }  // namespace U2

--- a/src/corelibs/U2View/src/ov_msa/overview/MaSimpleOverview.h
+++ b/src/corelibs/U2View/src/ov_msa/overview/MaSimpleOverview.h
@@ -30,43 +30,39 @@
 
 namespace U2 {
 
-class MSAEditor;
-class MaEditorWgt;
-class MSAEditorSequenceArea;
-class MsaColorScheme;
-class MsaHighlightingScheme;
-
 class U2VIEW_EXPORT MaSimpleOverview : public MaOverview {
     Q_OBJECT
 public:
     MaSimpleOverview(MaEditorWgt *ui);
+
+    /** Height of the overview. */
     const static int FIXED_HEIGTH = 70;
-    bool isValid() const;
-    QPixmap getView();
+
+    bool isValid() const override;
+
+    QPixmap getView() override;
 
 public slots:
-    void sl_selectionChanged();
-    void sl_redraw();
+    void sl_selectionChanged() override;
+    void sl_redraw() override;
     void sl_highlightingChanged();
 
 protected:
-    void paintEvent(QPaintEvent *e);
-    void resizeEvent(QResizeEvent *e);
+    void paintEvent(QPaintEvent *e) override;
+    void resizeEvent(QResizeEvent *e) override;
 
 private:
-    void drawOverview(QPainter &p);
-    void drawVisibleRange(QPainter &p);
-    void drawSelection(QPainter &p);
+    void drawOverview(QPainter &p) override;
+    void drawVisibleRange(QPainter &p) override;
+    void drawSelection(QPainter &p) override;
 
-    void moveVisibleRange(QPoint pos);
-
-    void recalculateSelection();
+    void moveVisibleRange(QPoint pos) override;
 
 private:
-    mutable QPixmap cachedMSAOverview;
+    QPixmap cachedMSAOverview;
 
-    mutable bool redrawMsaOverview;
-    mutable bool redrawSelection;
+    bool redrawMsaOverview = true;
+    bool redrawSelection = true;
 };
 
 }  // namespace U2

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/overview/GTTestsMSAEditorOverview.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/overview/GTTestsMSAEditorOverview.cpp
@@ -66,16 +66,18 @@ GUI_TEST_CLASS_DEFINITION(test_0001) {
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0002) {
-    // 1. Open "_common_data/clustal/10000_sequences.aln".
     GTFileDialog::openFile(os, testDir + "_common_data/clustal", "10000_sequences.aln");
+    GTUtilsMsaEditor::checkMsaEditorWindowIsActive(os);
+
+    // Wait until overview rendering is finished.
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    GTUtilsTaskTreeView::waitTaskFinished(os);
-    // Expected state: simple overview is disabled, graph overview is displayed.
+
+    // Expected state: simple overview is hidden, graph overview is visible.
     QWidget *simple = GTWidget::findWidget(os, "msa_overview_area_simple");
-    CHECK_SET_ERR(!simple->isVisible(), "simple overveiw is visiable");
+    CHECK_SET_ERR(!simple->isVisible(), "simple overview is visiable");
 
     QWidget *graph = GTWidget::findWidget(os, "msa_overview_area_graph");
-    CHECK_SET_ERR(graph->isVisible(), "graph overveiw is visiable");
+    CHECK_SET_ERR(graph->isVisible(), "graph overview is visiable");
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0003) {


### PR DESCRIPTION
The next patch in a series of removal of deprecated toRect method call on MA selection
I also fixed the rounding errors in overview rendering (see attached images)
Before:
![overview-before](https://user-images.githubusercontent.com/17791039/129593177-d9c3f502-a914-4291-8830-da1b561ee577.png)
After:
![overview-after](https://user-images.githubusercontent.com/17791039/129593176-4f1b5982-49a4-40c6-b78b-c04cc27946b3.png)
