### PR TITLE
Remove trivial and not-needed Q_UNUSED statements 

### DIFF
--- a/src/corelibs/U2Algorithm/src/smith_waterman/SmithWatermanReportCallback.cpp
+++ b/src/corelibs/U2Algorithm/src/smith_waterman/SmithWatermanReportCallback.cpp
@@ -399,7 +399,6 @@ QString SmithWatermanReportCallbackMAImpl::planFor_MSA_Alignment_InCurrentWindow
     MaDbiUtils::splitBytesToCharsAndGaps(ptrnSequenceData, notUsedOutputParam, ptrnRow->gaps);
 
     U2UseCommonUserModStep userModStep(sourceMsaRef, os);
-    Q_UNUSED(userModStep);
     SAFE_POINT_OP(os, QString());
     msaDbi->updateGapModel(sourceMsaRef.entityId, refRow->rowId, refRow->gaps, os);
     CHECK_OP(os, tr("Failed to update row gap model"));

--- a/src/corelibs/U2Core/src/datatype/AnnotationGroup.cpp
+++ b/src/corelibs/U2Core/src/datatype/AnnotationGroup.cpp
@@ -111,7 +111,6 @@ QList<Annotation *> AnnotationGroup::addAnnotations(const QList<SharedAnnotation
 
     U2OpStatusImpl os;
     DbiOperationsBlock opBlock(parentObject->getEntityRef().dbiRef, os);
-    Q_UNUSED(opBlock);
     CHECK_OP(os, result);
 
     foreach (const SharedAnnotationData &d, anns) {

--- a/src/corelibs/U2Core/src/datatype/udr/RawDataUdrSchema.cpp
+++ b/src/corelibs/U2Core/src/datatype/udr/RawDataUdrSchema.cpp
@@ -190,10 +190,8 @@ QByteArray RawDataUdrSchema::readAllContent(const U2EntityRef &objRef, U2OpStatu
 
 void RawDataUdrSchema::cloneObject(const U2EntityRef &srcObjRef, const U2DbiRef &dstDbiRef, const QString &dstFolder, U2RawData &dstObject, U2OpStatus &os) {
     DbiOperationsBlock srcOpBlock(srcObjRef.dbiRef, os);
-    Q_UNUSED(srcOpBlock);
     CHECK_OP(os, );
     DbiOperationsBlock dstOpBlock(dstDbiRef, os);
-    Q_UNUSED(dstOpBlock);
     CHECK_OP(os, );
 
     // Prepare dbi connection

--- a/src/corelibs/U2Core/src/dbi/U2DbiRegistry.cpp
+++ b/src/corelibs/U2Core/src/dbi/U2DbiRegistry.cpp
@@ -211,11 +211,7 @@ bool useDatabaseFromCMDLine(const QString &alias) {
     // Check if the connection can be established
     U2OpStatus2Log os;
     DbiConnection con(ref, true, os);
-    Q_UNUSED(con);
-    if (os.hasError()) {
-        return false;
-    }
-    return true;
+    return !os.hasError();
 }
 
 U2DbiRef getDbiRef(const QString &alias, U2OpStatus &os, const U2DbiFactoryId &factoryId) {
@@ -239,7 +235,6 @@ U2DbiRef U2DbiRegistry::allocateTmpDbi(const QString &alias, U2OpStatus &os, con
     if (SQLITE_DBI_ID == factoryId) {
         // Create a tmp dbi file (the DbiConnection is opened with "bool create = true", and released)
         DbiConnection con(res, true, os);
-        Q_UNUSED(con);
     }
     CHECK_OP(os, U2DbiRef());
 

--- a/src/corelibs/U2Core/src/globals/UserActionsWriter.cpp
+++ b/src/corelibs/U2Core/src/globals/UserActionsWriter.cpp
@@ -44,7 +44,6 @@ namespace U2 {
 
 bool UserActionsWriter::eventFilter(QObject *obj, QEvent *event) {
     QMutexLocker locker(&guard);
-    Q_UNUSED(locker);
 
     if (event->type() == QEvent::MouseButtonPress ||
         event->type() == QEvent::MouseButtonRelease ||

--- a/src/corelibs/U2Core/src/gobjects/AnnotationTableObject.cpp
+++ b/src/corelibs/U2Core/src/gobjects/AnnotationTableObject.cpp
@@ -123,7 +123,6 @@ GObject *AnnotationTableObject::clone(const U2DbiRef &ref, U2OpStatus &os, const
     gHints.setAll(hints);
 
     DbiOperationsBlock opBlock(ref, os);
-    Q_UNUSED(opBlock);
     CHECK_OP(os, nullptr);
 
     AnnotationTableObject *cln = new AnnotationTableObject(getGObjectName(), ref, gHints.getMap());

--- a/src/corelibs/U2Core/src/gobjects/DNASequenceObject.cpp
+++ b/src/corelibs/U2Core/src/gobjects/DNASequenceObject.cpp
@@ -225,7 +225,6 @@ void U2SequenceObject::removeRegion(U2OpStatus &os, const U2Region &region) {
 
 GObject *U2SequenceObject::clone(const U2DbiRef &dbiRef, U2OpStatus &os, const QVariantMap &hints) const {
     DbiOperationsBlock opBlock(dbiRef, os);
-    Q_UNUSED(opBlock);
     CHECK_OP(os, nullptr);
 
     DbiConnection srcCon(this->entityRef.dbiRef, os);

--- a/src/corelibs/U2Core/src/gobjects/MultipleAlignmentObject.cpp
+++ b/src/corelibs/U2Core/src/gobjects/MultipleAlignmentObject.cpp
@@ -739,7 +739,6 @@ void MultipleAlignmentObject::releaseState() {
 
 void MultipleAlignmentObject::loadDataCore(U2OpStatus &os) {
     DbiConnection con(entityRef.dbiRef, os);
-    Q_UNUSED(con);
     CHECK_OP(os, );
     loadAlignment(os);
 }

--- a/src/corelibs/U2Core/src/gobjects/MultipleChromatogramAlignmentObject.cpp
+++ b/src/corelibs/U2Core/src/gobjects/MultipleChromatogramAlignmentObject.cpp
@@ -56,7 +56,6 @@ MultipleChromatogramAlignmentObject::~MultipleChromatogramAlignmentObject() {
 
 GObject *MultipleChromatogramAlignmentObject::clone(const U2DbiRef &dstDbiRef, U2OpStatus &os, const QVariantMap &hints) const {
     DbiOperationsBlock opBlock(dstDbiRef, os);
-    Q_UNUSED(opBlock);
     CHECK_OP(os, nullptr);
 
     QScopedPointer<GHintsDefaultImpl> gHints(new GHintsDefaultImpl(getGHintsMap()));

--- a/src/corelibs/U2Core/src/gobjects/MultipleSequenceAlignmentObject.cpp
+++ b/src/corelibs/U2Core/src/gobjects/MultipleSequenceAlignmentObject.cpp
@@ -52,7 +52,6 @@ const MultipleSequenceAlignment MultipleSequenceAlignmentObject::getMsaCopy() co
 
 MultipleSequenceAlignmentObject *MultipleSequenceAlignmentObject::clone(const U2DbiRef &dstDbiRef, U2OpStatus &os, const QVariantMap &hints) const {
     DbiOperationsBlock opBlock(dstDbiRef, os);
-    Q_UNUSED(opBlock);
     CHECK_OP(os, nullptr);
 
     QScopedPointer<GHintsDefaultImpl> gHints(new GHintsDefaultImpl(getGHintsMap()));

--- a/src/corelibs/U2Core/src/gobjects/PFMatrixObject.cpp
+++ b/src/corelibs/U2Core/src/gobjects/PFMatrixObject.cpp
@@ -84,7 +84,6 @@ const PFMatrix &PFMatrixObject::getMatrix() const {
 
 GObject *PFMatrixObject::clone(const U2DbiRef &dstDbiRef, U2OpStatus &os, const QVariantMap &hints) const {
     DbiOperationsBlock opBlock(dstDbiRef, os);
-    Q_UNUSED(opBlock);
     CHECK_OP(os, nullptr);
 
     GHintsDefaultImpl gHints(getGHintsMap());

--- a/src/corelibs/U2Core/src/gobjects/PWMatrixObject.cpp
+++ b/src/corelibs/U2Core/src/gobjects/PWMatrixObject.cpp
@@ -84,7 +84,6 @@ const PWMatrix &PWMatrixObject::getMatrix() const {
 
 GObject *PWMatrixObject::clone(const U2DbiRef &dstDbiRef, U2OpStatus &os, const QVariantMap &hints) const {
     DbiOperationsBlock opBlock(dstDbiRef, os);
-    Q_UNUSED(opBlock);
     CHECK_OP(os, nullptr);
 
     GHintsDefaultImpl gHints(getGHintsMap());

--- a/src/corelibs/U2Core/src/gobjects/PhyTreeObject.cpp
+++ b/src/corelibs/U2Core/src/gobjects/PhyTreeObject.cpp
@@ -117,7 +117,6 @@ const PhyTree &PhyTreeObject::getTree() const {
 
 GObject *PhyTreeObject::clone(const U2DbiRef &dstDbiRef, U2OpStatus &os, const QVariantMap &hints) const {
     DbiOperationsBlock opBlock(dstDbiRef, os);
-    Q_UNUSED(opBlock);
     CHECK_OP(os, nullptr);
 
     ensureDataLoaded();

--- a/src/corelibs/U2Core/src/gobjects/VariantTrackObject.cpp
+++ b/src/corelibs/U2Core/src/gobjects/VariantTrackObject.cpp
@@ -78,7 +78,6 @@ U2VariantTrack VariantTrackObject::getVariantTrack(U2OpStatus &os) const {
 
 GObject *VariantTrackObject::clone(const U2DbiRef &dstDbiRef, U2OpStatus &os, const QVariantMap &hints) const {
     DbiOperationsBlock opBlock(dstDbiRef, os);
-    Q_UNUSED(opBlock);
     CHECK_OP(os, nullptr);
 
     DbiConnection srcCon(entityRef.dbiRef, true, os);

--- a/src/corelibs/U2Core/src/models/DocumentModel.cpp
+++ b/src/corelibs/U2Core/src/models/DocumentModel.cpp
@@ -94,7 +94,6 @@ Document *DocumentFormat::loadDocument(IOAdapterFactory *iof, const GUrl &url, c
     if (dbiRef.isValid()) {
         DbiConnection con(dbiRef, os);
         CHECK_OP(os, nullptr);
-        Q_UNUSED(con);
 
         res = loadDocument(io.data(), dbiRef, hints, os);
         CHECK_OP(os, nullptr);
@@ -782,7 +781,6 @@ void Document::removeObjectsDataFromDbi(QList<GObject *> objects) {
         U2OpStatus2Log os;
         DbiOperationsBlock opBlock(dbiRef, os);
         CHECK_OP(os, );
-        Q_UNUSED(opBlock);
 
         DbiConnection con(dbiRef, os);
         CHECK_OP(os, );

--- a/src/corelibs/U2Core/src/tasks/CreateAnnotationTask.cpp
+++ b/src/corelibs/U2Core/src/tasks/CreateAnnotationTask.cpp
@@ -70,7 +70,6 @@ void CreateAnnotationsTask::run() {
     CHECK_EXT(annotationTableObject != nullptr, setError(tr("Annotation table has been removed unexpectedly")), );
 
     DbiOperationsBlock opBlock(annotationTableObject->getEntityRef().dbiRef, stateInfo);
-    Q_UNUSED(opBlock);
     CHECK_OP(stateInfo, );
 
     const U2DataId rootFeatureId = annotationTableObject->getRootFeatureId();

--- a/src/corelibs/U2Core/src/tasks/SequenceDbiWalkerTask.h
+++ b/src/corelibs/U2Core/src/tasks/SequenceDbiWalkerTask.h
@@ -49,8 +49,7 @@ public:
     /* implement this to give SequenceDbiWalkerSubtask required resources
      * here are resources for ONE(!) SequenceDbiWalkerSubtask execution e.g. for one execution of onRegion function
      */
-    virtual QList<TaskResourceUsage> getResources(SequenceDbiWalkerSubtask *t) {
-        Q_UNUSED(t);
+    virtual QList<TaskResourceUsage> getResources(SequenceDbiWalkerSubtask *) {
         return QList<TaskResourceUsage>();
     }
 };

--- a/src/corelibs/U2Core/src/tasks/SequenceWalkerTask.h
+++ b/src/corelibs/U2Core/src/tasks/SequenceWalkerTask.h
@@ -67,8 +67,7 @@ public:
     /* implement this to give SequenceWalkerSubtask required resources
      * here are resources for ONE(!) SequenceWalkerSubtask execution e.g. for one execution of onRegion function
      */
-    virtual QList<TaskResourceUsage> getResources(SequenceWalkerSubtask *t) {
-        Q_UNUSED(t);
+    virtual QList<TaskResourceUsage> getResources(SequenceWalkerSubtask *) {
         return QList<TaskResourceUsage>();
     }
 };

--- a/src/corelibs/U2Core/src/util/MSAUtils.cpp
+++ b/src/corelibs/U2Core/src/util/MSAUtils.cpp
@@ -339,7 +339,6 @@ MultipleSequenceAlignmentObject *MSAUtils::seqObjs2msaObj(const QList<GObject *>
 
     DbiOperationsBlock opBlock(dbiRef, os);
     CHECK_OP(os, nullptr);
-    Q_UNUSED(opBlock);
 
     const bool useGenbankHeader = hints.value(ObjectConvertion_UseGenbankHeader, false).toBool();
     MultipleSequenceAlignment ma = seq2ma(objects, os, useGenbankHeader, recheckAlphabetFromDataIfRaw);

--- a/src/corelibs/U2Formats/src/ABIFormat.cpp
+++ b/src/corelibs/U2Formats/src/ABIFormat.cpp
@@ -432,7 +432,6 @@ static void replace_nl(char *string) {
 Document *ABIFormat::parseABI(const U2DbiRef &dbiRef, SeekableBuf *fp, IOAdapter *io, const QVariantMap &fs, U2OpStatus &os) {
     DbiOperationsBlock opBlock(dbiRef, os);
     CHECK_OP(os, nullptr);
-    Q_UNUSED(opBlock);
     DNASequence dna;
     DNAChromatogram cd;
 

--- a/src/corelibs/U2Formats/src/BedFormat.cpp
+++ b/src/corelibs/U2Formats/src/BedFormat.cpp
@@ -115,7 +115,6 @@ Document *BedFormat::loadTextDocument(IOAdapter *io, const U2DbiRef &dbiRef, con
 void BedFormat::load(IOAdapter *io, QList<GObject *> &objects, const U2DbiRef &dbiRef, U2OpStatus &os, const QVariantMap &fs) {
     DbiOperationsBlock opBlock(dbiRef, os);
     CHECK_OP(os, );
-    Q_UNUSED(opBlock);
 
     QString defaultAnnotName = "misc_feature";
     BedFormatParser parser(io, defaultAnnotName, os);

--- a/src/corelibs/U2Formats/src/DifferentialFormat.cpp
+++ b/src/corelibs/U2Formats/src/DifferentialFormat.cpp
@@ -164,7 +164,6 @@ QList<SharedAnnotationData> DifferentialFormat::parseAnnotations(const ColumnDat
 Document *DifferentialFormat::loadTextDocument(IOAdapterReader &reader, const U2DbiRef &dbiRef, const QVariantMap &hints, U2OpStatus &os) {
     DbiOperationsBlock opBlock(dbiRef, os);
     CHECK_OP(os, nullptr);
-    Q_UNUSED(opBlock);
 
     QList<SharedAnnotationData> anns = parseAnnotations(reader, os);
     CHECK_OP(os, nullptr);

--- a/src/corelibs/U2Formats/src/EMBLGenbankAbstractDocument.cpp
+++ b/src/corelibs/U2Formats/src/EMBLGenbankAbstractDocument.cpp
@@ -91,7 +91,6 @@ const QString EMBLGenbankAbstractDocument::LOCUS_TAG_LINEAR("linear");
 void EMBLGenbankAbstractDocument::load(const U2DbiRef &dbiRef, IOAdapter *io, QList<GObject *> &objects, QVariantMap &fs, U2OpStatus &os, QString &writeLockReason) {
     DbiOperationsBlock opBlock(dbiRef, os);
     CHECK_OP(os, );
-    Q_UNUSED(opBlock);
     writeLockReason.clear();
 
     io->setFormatMode(IOAdapter::TextMode);

--- a/src/corelibs/U2Formats/src/FastaFormat.cpp
+++ b/src/corelibs/U2Formats/src/FastaFormat.cpp
@@ -149,7 +149,6 @@ static QString readHeader(IOAdapterReader &reader, U2OpStatus &os) {
 static void load(IOAdapterReader &reader, const U2DbiRef &dbiRef, const QVariantMap &hints, QList<GObject *> &objects, int gapSize, QString &writeLockReason, U2OpStatus &os) {
     DbiOperationsBlock opBlock(dbiRef, os);
     CHECK_OP(os, );
-    Q_UNUSED(opBlock);
 
     MemoryLocker memoryLocker(os, 1);
     CHECK_OP(os, );

--- a/src/corelibs/U2Formats/src/FastqFormat.cpp
+++ b/src/corelibs/U2Formats/src/FastqFormat.cpp
@@ -242,7 +242,6 @@ static bool errorLoggingBreak(U2OpStatus &os, QMap<QString, QString> &skippedLin
 static void load(IOAdapter *io, const U2DbiRef &dbiRef, const QVariantMap &hints, QList<GObject *> &objects, U2OpStatus &os, int gapSize, int predictedSize, QString &writeLockReason, QMap<QString, QString> &skippedLines) {
     DbiOperationsBlock opBlock(dbiRef, os);
     CHECK_OP(os, );
-    Q_UNUSED(opBlock);
     writeLockReason.clear();
 
     bool merge = gapSize != -1;

--- a/src/corelibs/U2Formats/src/GTFFormat.cpp
+++ b/src/corelibs/U2Formats/src/GTFFormat.cpp
@@ -250,7 +250,6 @@ QMap<QString, QList<SharedAnnotationData>> GTFFormat::parseDocument(IOAdapter *i
 void GTFFormat::load(IOAdapter *io, QList<GObject *> &objects, const U2DbiRef &dbiRef, const QVariantMap &hints, U2OpStatus &os) {
     DbiOperationsBlock opBlock(dbiRef, os);
     CHECK_OP(os, );
-    Q_UNUSED(opBlock);
 
     QMultiMap<QString, QList<SharedAnnotationData>> annotationsMap = parseDocument(io, os);
 

--- a/src/corelibs/U2Formats/src/NEXUSFormat.cpp
+++ b/src/corelibs/U2Formats/src/NEXUSFormat.cpp
@@ -717,7 +717,6 @@ QList<GObject *> NEXUSFormat::loadObjects(IOAdapter *io, const U2DbiRef &dbiRef,
     assert(io && "io must exist");
     DbiOperationsBlock opBlock(dbiRef, ti);
     CHECK_OP(ti, QList<GObject *>());
-    Q_UNUSED(opBlock);
 
     const int HEADER_LEN = 6;
     QByteArray header(HEADER_LEN, 0);

--- a/src/corelibs/U2Formats/src/NewickFormat.cpp
+++ b/src/corelibs/U2Formats/src/NewickFormat.cpp
@@ -135,7 +135,6 @@ static QList<GObject *> parseTrees(IOAdapterReader &reader, const U2DbiRef &dbiR
     QList<GObject *> objects;
     DbiOperationsBlock opBlock(dbiRef, si);
     CHECK_OP(si, objects);
-    Q_UNUSED(opBlock);
     QList<PhyTree> trees = NewickPhyTreeSerializer::parseTrees(reader, si);
     CHECK_OP(si, objects);
 

--- a/src/corelibs/U2Formats/src/PDBFormat.cpp
+++ b/src/corelibs/U2Formats/src/PDBFormat.cpp
@@ -797,7 +797,6 @@ QHash<QByteArray, int> PDBFormat::createAtomNumMap() {
 Document *PDBFormat::createDocumentFromBioStruct3D(const U2DbiRef &dbiRef, BioStruct3D &bioStruct, DocumentFormat *format, IOAdapterFactory *iof, const GUrl &url, U2OpStatus &os, const QVariantMap &fs) {
     DbiOperationsBlock opBlock(dbiRef, os);
     CHECK_OP(os, nullptr);
-    Q_UNUSED(opBlock);
 
     QList<GObject *> objects;
     QSet<QString> uniqueNames;

--- a/src/corelibs/U2Formats/src/PDWFormat.cpp
+++ b/src/corelibs/U2Formats/src/PDWFormat.cpp
@@ -73,7 +73,6 @@ FormatCheckResult PDWFormat::checkRawTextData(const QByteArray &rawData, const G
 void PDWFormat::load(IOAdapter *io, const U2DbiRef &dbiRef, const QVariantMap &fs, const GUrl &docUrl, QList<GObject *> &objects, U2OpStatus &os, U2SequenceObject *&seqObj, AnnotationTableObject *&annObj) {
     DbiOperationsBlock opBlock(dbiRef, os);
     CHECK_OP(os, );
-    Q_UNUSED(opBlock);
 
     QByteArray readBuff(READ_BUFF_SIZE + 1, 0);
     char *buff = readBuff.data();

--- a/src/corelibs/U2Formats/src/PlainTextFormat.cpp
+++ b/src/corelibs/U2Formats/src/PlainTextFormat.cpp
@@ -49,7 +49,6 @@ Document *PlainTextFormat::loadTextDocument(IOAdapterReader &reader, const U2Dbi
 
     DbiOperationsBlock opBlock(dbiRef, os);
     CHECK_OP(os, nullptr);
-    Q_UNUSED(opBlock);
 
     QVariantMap textObjectHints;
     textObjectHints.insert(DBI_FOLDER_HINT, hints.value(DBI_FOLDER_HINT, U2ObjectDbi::ROOT_FOLDER));

--- a/src/corelibs/U2Formats/src/RawDNASequenceFormat.cpp
+++ b/src/corelibs/U2Formats/src/RawDNASequenceFormat.cpp
@@ -59,7 +59,6 @@ static void finishSequenceImport(QList<GObject *> &objects, const QString &url, 
 static void load(IOAdapterReader &reader, const U2DbiRef &dbiRef, QList<GObject *> &objects, const QVariantMap &hints, U2OpStatus &os) {
     DbiOperationsBlock opBlock(dbiRef, os);
     CHECK_OP(os, );
-    Q_UNUSED(opBlock);
 
     U2SequenceImporter seqImporter(hints, true);
     QString folder = hints.value(DocumentFormat::DBI_FOLDER_HINT, U2ObjectDbi::ROOT_FOLDER).toString();

--- a/src/corelibs/U2Formats/src/SCFFormat.cpp
+++ b/src/corelibs/U2Formats/src/SCFFormat.cpp
@@ -529,7 +529,6 @@ static uchar getMaxProb(uchar probA, uchar probC, uchar probG, uchar probT) {
 Document *SCFFormat::parseSCF(const U2DbiRef &dbiRef, IOAdapter *io, const QVariantMap &fs, U2OpStatus &os) {
     DbiOperationsBlock opBlock(dbiRef, os);
     CHECK_OP(os, nullptr);
-    Q_UNUSED(opBlock);
 
     DNASequence dna;
     DNAChromatogram cd;

--- a/src/corelibs/U2Formats/src/mysql_dbi/MysqlAssemblyDbi.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/MysqlAssemblyDbi.cpp
@@ -48,7 +48,6 @@ MysqlAssemblyDbi::~MysqlAssemblyDbi() {
 
 void MysqlAssemblyDbi::initSqlSchema(U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     // assembly object
     // reference            - reference sequence id
@@ -205,7 +204,6 @@ void MysqlAssemblyDbi::createAssemblyObject(U2Assembly &assembly,
                                             U2AssemblyReadsImportInfo &importInfo,
                                             U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     U2Object fakeObject;
     fakeObject.visualName = assembly.visualName;
@@ -265,7 +263,6 @@ void MysqlAssemblyDbi::finalizeAssemblyObject(U2Assembly &assembly, U2OpStatus &
 
 void MysqlAssemblyDbi::removeAssemblyData(const U2DataId &assemblyId, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
     CHECK_OP(os, );
 
     removeTables(assemblyId, os);
@@ -275,7 +272,6 @@ void MysqlAssemblyDbi::removeAssemblyData(const U2DataId &assemblyId, U2OpStatus
 
 void MysqlAssemblyDbi::updateAssemblyObject(U2Assembly &assembly, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     U2SqlQuery q("UPDATE Assembly SET reference = :reference WHERE object = :object", db, os);
     q.bindDataId(":reference", assembly.referenceId);
@@ -314,7 +310,6 @@ void MysqlAssemblyDbi::addReads(MysqlAssemblyAdapter *a, U2DbiIterator<U2Assembl
 
 void MysqlAssemblyDbi::removeTables(const U2DataId &assemblyId, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
     CHECK_OP(os, );
 
     AssemblyAdapter *adapter = getAdapter(assemblyId, os);
@@ -324,7 +319,6 @@ void MysqlAssemblyDbi::removeTables(const U2DataId &assemblyId, U2OpStatus &os) 
 
 void MysqlAssemblyDbi::removeAssemblyEntry(const U2DataId &assemblyId, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
     CHECK_OP(os, );
 
     static const QString queryString("DELETE FROM Assembly WHERE object = :object");

--- a/src/corelibs/U2Formats/src/mysql_dbi/MysqlAttributeDbi.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/MysqlAttributeDbi.cpp
@@ -33,7 +33,6 @@ MysqlAttributeDbi::MysqlAttributeDbi(MysqlDbi *dbi)
 
 void MysqlAttributeDbi::initSqlSchema(U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     // object attribute main table
     // object -> object id this attribute is for
@@ -194,7 +193,6 @@ Requires U2DbiFeature_WriteAttribute feature support
 */
 void MysqlAttributeDbi::removeAttributes(const QList<U2DataId> &attributeIds, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString mainQueryStr("DELETE FROM Attribute WHERE id = :attribute");
     static const QString secQueryStr("DELETE FROM %1 WHERE attribute = :attribute");
@@ -239,7 +237,6 @@ void MysqlAttributeDbi::removeAttributes(const QList<U2DataId> &attributeIds, U2
 
 void MysqlAttributeDbi::removeObjectAttributes(const U2DataId &objectId, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     QList<U2DataId> attributes = getObjectAttributes(objectId, "", os);
     CHECK_OP(os, );
@@ -254,7 +251,6 @@ void MysqlAttributeDbi::removeObjectAttributes(const U2DataId &objectId, U2OpSta
  */
 void MysqlAttributeDbi::createIntegerAttribute(U2IntegerAttribute &a, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     qint64 id = createAttribute(a, U2Type::AttributeInteger, os);
     CHECK_OP(os, );
@@ -273,7 +269,6 @@ Requires U2DbiFeature_WriteAttribute feature support
 */
 void MysqlAttributeDbi::createRealAttribute(U2RealAttribute &a, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     qint64 id = createAttribute(a, U2Type::AttributeReal, os);
     CHECK_OP(os, );
@@ -292,7 +287,6 @@ Requires U2DbiFeature_WriteAttribute feature support
 */
 void MysqlAttributeDbi::createStringAttribute(U2StringAttribute &a, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     qint64 id = createAttribute(a, U2Type::AttributeString, os);
     CHECK_OP(os, );
@@ -311,7 +305,6 @@ Requires U2DbiFeature_WriteAttribute feature support
 */
 void MysqlAttributeDbi::createByteArrayAttribute(U2ByteArrayAttribute &a, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     qint64 id = createAttribute(a, U2Type::AttributeByteArray, os);
     CHECK_OP(os, );
@@ -326,7 +319,6 @@ void MysqlAttributeDbi::createByteArrayAttribute(U2ByteArrayAttribute &a, U2OpSt
 
 qint64 MysqlAttributeDbi::createAttribute(U2Attribute &attr, U2DataType type, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString("INSERT INTO Attribute(type, object, child, otype, ctype, oextra, cextra, version, name) "
                                      " VALUES(:type, :object, :child, :otype, :ctype, :oextra, :cextra, :version, :name)");

--- a/src/corelibs/U2Formats/src/mysql_dbi/MysqlBlobOutputStream.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/MysqlBlobOutputStream.cpp
@@ -40,7 +40,6 @@ void MysqlBlobOutputStream::write(const char *buffer, int length, U2OpStatus &os
     SAFE_POINT_EXT(nullptr != buffer, os.setError("Invalid data buffer detected!"), );
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     QByteArray blobData;
     if (Q_LIKELY(wasUsed)) {

--- a/src/corelibs/U2Formats/src/mysql_dbi/MysqlCrossDatabaseReferenceDbi.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/MysqlCrossDatabaseReferenceDbi.cpp
@@ -35,7 +35,6 @@ MysqlCrossDatabaseReferenceDbi::MysqlCrossDatabaseReferenceDbi(MysqlDbi *dbi)
 
 void MysqlCrossDatabaseReferenceDbi::initSqlSchema(U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     // cross database reference object
     // factory - remote dbi factory
@@ -52,7 +51,6 @@ void MysqlCrossDatabaseReferenceDbi::initSqlSchema(U2OpStatus &os) {
 
 void MysqlCrossDatabaseReferenceDbi::createCrossReference(U2CrossDatabaseReference &reference, const QString &folder, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     dbi->getMysqlObjectDbi()->createObject(reference, folder, U2DbiObjectRank_TopLevel, os);
     CHECK_OP(os, );
@@ -69,7 +67,6 @@ void MysqlCrossDatabaseReferenceDbi::createCrossReference(U2CrossDatabaseReferen
 
 void MysqlCrossDatabaseReferenceDbi::removeCrossReferenceData(const U2DataId &referenceId, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "DELETE FROM CrossDatabaseReference WHERE object = :object";
     U2SqlQuery q(queryString, db, os);
@@ -98,7 +95,6 @@ U2CrossDatabaseReference MysqlCrossDatabaseReferenceDbi::getCrossReference(const
 
 void MysqlCrossDatabaseReferenceDbi::updateCrossReference(const U2CrossDatabaseReference &reference, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "UPDATE CrossDatabaseReference SET factory = :factory, dbi = :dbi, rid = :rid, version = :version WHERE object = :object";
     U2SqlQuery q(queryString, db, os);

--- a/src/corelibs/U2Formats/src/mysql_dbi/MysqlDbi.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/MysqlDbi.cpp
@@ -216,7 +216,6 @@ QString MysqlDbi::getProperty(const QString &name, const QString &defaultValue, 
 
 void MysqlDbi::setProperty(const QString &name, const QString &value, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     U2SqlQuery q1("DELETE FROM Meta WHERE name = :name", db, os);
     q1.bindString(":name", name);

--- a/src/corelibs/U2Formats/src/mysql_dbi/MysqlFeatureDbi.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/MysqlFeatureDbi.cpp
@@ -37,7 +37,6 @@ MysqlFeatureDbi::MysqlFeatureDbi(MysqlDbi *dbi)
 
 void MysqlFeatureDbi::initSqlSchema(U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     // nameHash is used for better indexing
     U2SqlQuery("CREATE TABLE Feature (id BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT, "
@@ -126,7 +125,6 @@ void MysqlFeatureDbi::createAnnotationTableObject(U2AnnotationTable &table,
                                                   const QString &folder,
                                                   U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     dbi->getMysqlObjectDbi()->createObject(table, folder, U2DbiObjectRank_TopLevel, os);
     CHECK_OP(os, );
@@ -163,7 +161,6 @@ void MysqlFeatureDbi::removeAnnotationTableData(const U2DataId &tableId, U2OpSta
     DBI_TYPE_CHECK(tableId, U2Type::AnnotationTable, os, );
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     U2SqlQuery removeFeaturesQuery("DELETE F.* FROM Feature AS F INNER JOIN AnnotationTable AS A "
                                    "ON A.rootId = F.root OR A.rootId = F.id WHERE A.object = :object",
@@ -499,7 +496,6 @@ void addFeatureKeys(const QList<U2FeatureKey> &keys, const U2DataId &featureId, 
     CHECK(!keys.isEmpty(), );
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     const QString insertQueryStr = getFeatureKeyInsertQuery(keys.size());
 
@@ -518,7 +514,6 @@ void addFeatureKeys(const QList<U2FeatureKey> &keys, const U2DataId &featureId, 
 
 void MysqlFeatureDbi::createFeature(U2Feature &feature, const QList<U2FeatureKey> &keys, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryStringf("INSERT INTO Feature(class, type, parent, root, name, sequence, strand, start, len, end, nameHash) "
                                       "VALUES(:class, :type, :parent, :root, :name, :sequence, :strand, :start, :len, :end, :nameHash)");
@@ -542,7 +537,6 @@ void MysqlFeatureDbi::createFeature(U2Feature &feature, const QList<U2FeatureKey
 
 void MysqlFeatureDbi::addKey(const U2DataId &featureId, const U2FeatureKey &key, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "INSERT INTO FeatureKey(feature, name, value) VALUES(:feature, :name, :value)";
     U2SqlQuery qk(queryString, db, os);
@@ -553,7 +547,6 @@ void MysqlFeatureDbi::removeAllKeys(const U2DataId &featureId, const QString &ke
     DBI_TYPE_CHECK(featureId, U2Type::Feature, os, );
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "DELETE FROM FeatureKey WHERE feature = :feature AND name = :name";
     U2SqlQuery q(queryString, db, os);
@@ -566,7 +559,6 @@ void MysqlFeatureDbi::removeKey(const U2DataId &featureId, const U2FeatureKey &k
     DBI_TYPE_CHECK(featureId, U2Type::Feature, os, );
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "DELETE FROM FeatureKey WHERE feature = :feature AND name = :name AND value = :value LIMIT 1";
     U2SqlQuery q(queryString, db, os);
@@ -595,7 +587,6 @@ void MysqlFeatureDbi::updateParentId(const U2DataId &featureId, const U2DataId &
     DBI_TYPE_CHECK(parentId, U2Type::Feature, os, );
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "UPDATE Feature SET parent = :parent WHERE id = :id";
     U2SqlQuery qf(queryString, db, os);
@@ -609,7 +600,6 @@ void MysqlFeatureDbi::updateSequenceId(const U2DataId &featureId, const U2DataId
     DBI_TYPE_CHECK(seqId, U2Type::Sequence, os, );
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "UPDATE Feature SET sequence = :sequence WHERE id = :id";
     U2SqlQuery qf(queryString, db, os);
@@ -622,7 +612,6 @@ void MysqlFeatureDbi::updateKeyValue(const U2DataId &featureId, const U2FeatureK
     DBI_TYPE_CHECK(featureId, U2Type::Feature, os, );
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "UPDATE FeatureKey SET value = :value WHERE feature = :feature AND name = :name";
     U2SqlQuery q(queryString, db, os);
@@ -653,7 +642,6 @@ bool MysqlFeatureDbi::getKeyValue(const U2DataId &featureId, U2FeatureKey &key, 
 void MysqlFeatureDbi::updateLocation(const U2DataId &featureId, const U2FeatureLocation &location, U2OpStatus &os) {
     DBI_TYPE_CHECK(featureId, U2Type::Feature, os, );
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString updFeatureString = "UPDATE Feature SET strand = :strand, start = :start, len = :len, end = :end WHERE id = :id";
     U2SqlQuery qf(updFeatureString, db, os);
@@ -669,7 +657,6 @@ void MysqlFeatureDbi::updateType(const U2DataId &featureId, U2FeatureType newTyp
     DBI_TYPE_CHECK(featureId, U2Type::Feature, os, );
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "UPDATE Feature SET type = :type WHERE id = :id";
     U2SqlQuery qf(queryString, db, os);
@@ -681,7 +668,6 @@ void MysqlFeatureDbi::updateType(const U2DataId &featureId, U2FeatureType newTyp
 void MysqlFeatureDbi::removeFeature(const U2DataId &featureId, U2OpStatus &os) {
     DBI_TYPE_CHECK(featureId, U2Type::Feature, os, );
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     QSharedPointer<U2DbiIterator<U2Feature>> subfeaturesIter(getFeaturesByParent(featureId,
                                                                                  QString(),
@@ -705,7 +691,6 @@ void MysqlFeatureDbi::removeFeaturesByParent(const U2DataId &parentId, U2OpStatu
     const bool includeParent = SelectParentFeature == mode;
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     U2SqlQuery qf("DELETE FROM Feature WHERE parent = :parent" + (includeParent ? QString(" OR id = :id") : ""), db, os);
     qf.bindDataId(":parent", parentId);
@@ -738,7 +723,6 @@ void executeDeleteFeaturesByParentsQuery(const QList<U2DataId> &parentIds, Mysql
 
 void MysqlFeatureDbi::removeFeaturesByParents(const QList<U2DataId> &parentIds, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     int parentsNumber = parentIds.count();
     if (parentsNumber <= MysqlDbi::BIND_PARAMETERS_LIMIT) {
@@ -760,7 +744,6 @@ void MysqlFeatureDbi::removeFeaturesByRoot(const U2DataId &rootId, U2OpStatus &o
     const bool includeParent = SelectParentFeature == mode;
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     U2SqlQuery qf("DELETE FROM Feature WHERE root = :root" + (includeParent ? QString(" OR id = :id") : ""), db, os);
     qf.bindDataId(":root", rootId);

--- a/src/corelibs/U2Formats/src/mysql_dbi/MysqlObjectDbi.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/MysqlObjectDbi.cpp
@@ -48,7 +48,6 @@ MysqlObjectDbi::MysqlObjectDbi(MysqlDbi *dbi)
 
 void MysqlObjectDbi::initSqlSchema(U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     // objects table - stores IDs and types for all objects. It also stores 'top_level' flag to simplify queries
     // rank: see U2DbiObjectRank
@@ -191,7 +190,6 @@ QHash<U2Object, QString> MysqlObjectDbi::getObjectFolders(U2OpStatus &os) {
 void MysqlObjectDbi::renameFolder(const QString &oldPath, const QString &newPath, U2OpStatus &os) {
     MysqlTransaction t(db, os);
     CHECK_OP(os, );
-    Q_UNUSED(t);
 
     const QString oldCPath = U2DbiUtils::makeFolderCanonical(oldPath);
     const QString newCPath = U2DbiUtils::makeFolderCanonical(newPath);
@@ -334,7 +332,6 @@ bool MysqlObjectDbi::removeObjects(const QList<U2DataId> &dataIds, bool force, U
     CHECK(!dataIds.isEmpty(), true);
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     // remove specific objects' data first
     foreach (const U2DataId &objectId, dataIds) {
@@ -385,7 +382,6 @@ bool MysqlObjectDbi::removeObjects(const QList<U2DataId> &dataIds, U2OpStatus &o
 
 void MysqlObjectDbi::renameObject(const U2DataId &id, const QString &newName, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "UPDATE Object SET name = :name WHERE id = :id";
     U2SqlQuery q(queryString, db, os);
@@ -402,7 +398,6 @@ void MysqlObjectDbi::renameObject(const U2DataId &id, const QString &newName, U2
 
 void MysqlObjectDbi::createFolder(const QString &path, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
     CHECK_OP(os, );
 
     const QString canonicalPath = U2DbiUtils::makeFolderCanonical(path);
@@ -430,7 +425,6 @@ void MysqlObjectDbi::createFolder(const QString &path, U2OpStatus &os) {
 
 bool MysqlObjectDbi::removeFolder(const QString &folder, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     const QString canonicalFolder = U2DbiUtils::makeFolderCanonical(folder);
     const QByteArray hash = QCryptographicHash::hash(canonicalFolder.toLatin1(), QCryptographicHash::Md5).toHex();
@@ -473,7 +467,6 @@ bool MysqlObjectDbi::removeFolder(const QString &folder, U2OpStatus &os) {
 
 void MysqlObjectDbi::addObjectsToFolder(const QList<U2DataId> &objectIds, const QString &folder, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     const QString canonicalFolder = U2DbiUtils::makeFolderCanonical(folder);
 
@@ -514,7 +507,6 @@ void MysqlObjectDbi::addObjectsToFolder(const QList<U2DataId> &objectIds, const 
 
 void MysqlObjectDbi::moveObjects(const QList<U2DataId> &objectIds, const QString &fromFolder, const QString &toFolder, U2OpStatus &os, bool saveFromFolder) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     const QString canonicalFromFolder = U2DbiUtils::makeFolderCanonical(fromFolder);
     const QString canonicalToFolder = U2DbiUtils::makeFolderCanonical(toFolder);
@@ -553,7 +545,6 @@ void MysqlObjectDbi::moveObjects(const QList<U2DataId> &objectIds, const QString
 
 QStringList MysqlObjectDbi::restoreObjects(const QList<U2DataId> &objectIds, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     U2AttributeDbi *attrDbi = dbi->getAttributeDbi();
     QList<U2DataId> attributesWithStoredPath;
@@ -589,7 +580,6 @@ QStringList MysqlObjectDbi::restoreObjects(const QList<U2DataId> &objectIds, U2O
 
 void MysqlObjectDbi::updateObjectAccessTime(const U2DataId &objectId, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "UPDATE ObjectAccessTrack SET lastAccessTime = NOW() WHERE object = :object";
     U2SqlQuery q(queryString, db, os);
@@ -602,7 +592,6 @@ void MysqlObjectDbi::updateObjectAccessTime(const U2DataId &objectId, U2OpStatus
 
 void MysqlObjectDbi::undo(const U2DataId &objId, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     QString errorDescr = U2DbiL10n::tr("Can't undo an operation for the object");
 
@@ -665,7 +654,6 @@ void MysqlObjectDbi::undo(const U2DataId &objId, U2OpStatus &os) {
 
 void MysqlObjectDbi::redo(const U2DataId &objId, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     QString errorDescr = U2DbiL10n::tr("Can't redo an operation for the object");
 
@@ -727,7 +715,6 @@ bool MysqlObjectDbi::canRedo(const U2DataId &objId, U2OpStatus &os) {
 
 U2DataId MysqlObjectDbi::createObject(U2Object &object, const QString &folder, U2DbiObjectRank rank, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     U2DataType type = object.getType();
     const QString &vname = object.visualName;
@@ -843,7 +830,6 @@ QHash<U2DataId, QString> MysqlObjectDbi::getObjectNames(qint64 offset, qint64 co
 
 void MysqlObjectDbi::updateObject(U2Object &obj, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     updateObjectCore(obj, os);
     CHECK_OP(os, );
@@ -870,7 +856,6 @@ qint64 MysqlObjectDbi::getFolderId(const QString &path, bool mustExist, MysqlDbR
 
 void MysqlObjectDbi::incrementVersion(const U2DataId &objectId, MysqlDbRef *db, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "UPDATE Object SET version = version + 1 WHERE id = :id";
     U2SqlQuery q(queryString, db, os);
@@ -892,7 +877,6 @@ qint64 MysqlObjectDbi::getObjectVersion(const U2DataId &objectId, U2OpStatus &os
 
 void MysqlObjectDbi::setTrackModType(const U2DataId &objectId, U2TrackModType trackModType, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString updateObjectString = "UPDATE Object AS O LEFT OUTER JOIN Parent AS P ON O.id = P.child "
                                               "SET O.trackMod = :trackMod WHERE O.id = :id OR P.parent = :parent";
@@ -923,7 +907,6 @@ U2TrackModType MysqlObjectDbi::getTrackModType(const U2DataId &objectId, U2OpSta
 
 void MysqlObjectDbi::removeParent(const U2DataId &parentId, const U2DataId &childId, bool removeDeadChild, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "DELETE FROM Parent WHERE parent = :parent AND child = :child";
     U2SqlQuery q(queryString, db, os);
@@ -950,7 +933,6 @@ void MysqlObjectDbi::removeParent(const U2DataId &parentId, const U2DataId &chil
 
 void MysqlObjectDbi::setParent(const U2DataId &parentId, const U2DataId &childId, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString insertString = "INSERT IGNORE INTO Parent (parent, child) VALUES (:parent, :child)";
     U2SqlQuery insertQ(insertString, db, os);
@@ -964,7 +946,6 @@ void MysqlObjectDbi::setParent(const U2DataId &parentId, const U2DataId &childId
 
 void MysqlObjectDbi::updateObjectCore(U2Object &obj, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "UPDATE Object SET name = :name, version = version WHERE id = :id";
     U2SqlQuery q(queryString, db, os);
@@ -975,7 +956,6 @@ void MysqlObjectDbi::updateObjectCore(U2Object &obj, U2OpStatus &os) {
 
 void MysqlObjectDbi::updateObjectType(U2Object &obj, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "UPDATE Object SET type = :type WHERE id = :id";
     U2SqlQuery q(queryString, db, os);
@@ -1003,7 +983,6 @@ QList<U2DataId> MysqlObjectDbi::getAllObjectsInUse(U2OpStatus &os) {
 
 void MysqlObjectDbi::removeObjectFromFolder(const U2DataId &id, const QString &folder, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     const qint64 folderId = getFolderId(folder, true, db, os);
     CHECK_OP(os, );
@@ -1018,7 +997,6 @@ void MysqlObjectDbi::removeObjectFromFolder(const U2DataId &id, const QString &f
 
 void MysqlObjectDbi::removeObjectFromAllFolders(const U2DataId &id, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString deleteString = "DELETE FROM FolderContent WHERE object = :object";
     U2SqlQuery deleteQ(deleteString, db, os);
@@ -1029,7 +1007,6 @@ void MysqlObjectDbi::removeObjectFromAllFolders(const U2DataId &id, U2OpStatus &
 
 bool MysqlObjectDbi::removeObjectImpl(const U2DataId &objectId, bool force, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     if (!force && isObjectInUse(objectId, os)) {
         return false;
@@ -1085,7 +1062,6 @@ void MysqlObjectDbi::removeObjectModHistory(const U2DataId &id, U2OpStatus &os) 
 
 void MysqlObjectDbi::incrementVersion(const U2DataId &id, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "UPDATE Object SET version = version + 1 WHERE id = :id";
     U2SqlQuery q(queryString, db, os);
@@ -1095,7 +1071,6 @@ void MysqlObjectDbi::incrementVersion(const U2DataId &id, U2OpStatus &os) {
 
 void MysqlObjectDbi::setVersion(const U2DataId &id, qint64 version, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "UPDATE Object SET version = :version WHERE id = :id";
     U2SqlQuery q(queryString, db, os);
@@ -1154,7 +1129,6 @@ void MysqlObjectDbi::redoCore(const U2DataId &objId, qint64 modType, const QByte
 
 void MysqlObjectDbi::undoUpdateObjectName(const U2DataId &id, const QByteArray &modDetails, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     QString oldName;
     QString newName;
@@ -1172,7 +1146,6 @@ void MysqlObjectDbi::undoUpdateObjectName(const U2DataId &id, const QByteArray &
 
 void MysqlObjectDbi::redoUpdateObjectName(const U2DataId &id, const QByteArray &modDetails, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     QString oldName;
     QString newName;

--- a/src/corelibs/U2Formats/src/mysql_dbi/MysqlObjectRelationsDbi.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/MysqlObjectRelationsDbi.cpp
@@ -34,7 +34,6 @@ MysqlObjectRelationsDbi::MysqlObjectRelationsDbi(MysqlDbi *dbi)
 
 void MysqlObjectRelationsDbi::initSqlSchema(U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     U2SqlQuery("CREATE TABLE ObjectRelation (object BIGINT NOT NULL, "
                "reference BIGINT NOT NULL, role INTEGER NOT NULL, "
@@ -52,7 +51,6 @@ void MysqlObjectRelationsDbi::initSqlSchema(U2OpStatus &os) {
 
 void MysqlObjectRelationsDbi::createObjectRelation(U2ObjectRelation &relation, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString("INSERT INTO ObjectRelation (object, reference, role) VALUES(:object, :reference, :role)");
     U2SqlQuery q(queryString, db, os);
@@ -110,7 +108,6 @@ QList<U2DataId> MysqlObjectRelationsDbi::getReferenceRelatedObjects(const U2Data
 
 void MysqlObjectRelationsDbi::removeObjectRelation(U2ObjectRelation &relation, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString("DELETE FROM ObjectRelation "
                                      "WHERE object = :object AND reference = :reference");
@@ -123,7 +120,6 @@ void MysqlObjectRelationsDbi::removeObjectRelation(U2ObjectRelation &relation, U
 
 void MysqlObjectRelationsDbi::removeAllObjectRelations(const U2DataId &object, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString("DELETE FROM ObjectRelation WHERE object = :object OR reference = :reference");
     U2SqlQuery q(queryString, db, os);
@@ -135,7 +131,6 @@ void MysqlObjectRelationsDbi::removeAllObjectRelations(const U2DataId &object, U
 
 void MysqlObjectRelationsDbi::removeReferencesForObject(const U2DataId &object, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString("DELETE FROM ObjectRelation WHERE object = :object");
     U2SqlQuery q(queryString, db, os);

--- a/src/corelibs/U2Formats/src/mysql_dbi/MysqlSequenceDbi.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/MysqlSequenceDbi.cpp
@@ -38,7 +38,6 @@ MysqlSequenceDbi::MysqlSequenceDbi(MysqlDbi *dbi)
 
 void MysqlSequenceDbi::initSqlSchema(U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     // sequence object
     U2SqlQuery("CREATE TABLE Sequence (object BIGINT PRIMARY KEY, length BIGINT NOT NULL DEFAULT 0, alphabet TEXT NOT NULL, "
@@ -60,7 +59,6 @@ void MysqlSequenceDbi::initSqlSchema(U2OpStatus &os) {
 
 U2Sequence MysqlSequenceDbi::getSequenceObject(const U2DataId &sequenceId, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     U2Sequence res;
     DBI_TYPE_CHECK(sequenceId, U2Type::Sequence, os, res);
@@ -136,7 +134,6 @@ QByteArray MysqlSequenceDbi::getSequenceData(const U2DataId &sequenceId, const U
 
 void MysqlSequenceDbi::createSequenceObject(U2Sequence &sequence, const QString &folder, U2OpStatus &os, U2DbiObjectRank rank) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     dbi->getMysqlObjectDbi()->createObject(sequence, folder, rank, os);
     CHECK_OP(os, );
@@ -152,7 +149,6 @@ void MysqlSequenceDbi::createSequenceObject(U2Sequence &sequence, const QString 
 
 void MysqlSequenceDbi::updateSequenceObject(U2Sequence &sequence, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "UPDATE Sequence SET alphabet = :alphabet, circular = :circular WHERE object = :object";
     U2SqlQuery q(queryString, db, os);
@@ -216,7 +212,6 @@ void MysqlSequenceDbi::updateSequenceData(const U2DataId &sequenceId, const U2Re
 
 void MysqlSequenceDbi::updateSequenceData(const U2DataId &masterId, const U2DataId &sequenceId, const U2Region &regionToReplace, const QByteArray &dataToInsert, const QVariantMap &hints, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     MysqlModificationAction updateAction(dbi, masterId);
     updateAction.prepare(os);
@@ -230,7 +225,6 @@ void MysqlSequenceDbi::updateSequenceData(const U2DataId &masterId, const U2Data
 
 void MysqlSequenceDbi::updateSequenceData(MysqlModificationAction &updateAction, const U2DataId &sequenceId, const U2Region &regionToReplace, const QByteArray &dataToInsert, const QVariantMap &hints, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     QByteArray modDetails;
     if (TrackOnUpdate == updateAction.getTrackModType()) {
@@ -271,7 +265,6 @@ void MysqlSequenceDbi::updateSequenceDataCore(const U2DataId &sequenceId, const 
     bool updateLenght = hints.value(U2SequenceDbiHints::UPDATE_SEQUENCE_LENGTH, true).toBool();
     bool emptySequence = hints.value(U2SequenceDbiHints::EMPTY_SEQUENCE, false).toBool();
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     // algorithm:
     //  find all regions affected -> remove them

--- a/src/corelibs/U2Formats/src/mysql_dbi/MysqlUdrDbi.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/MysqlUdrDbi.cpp
@@ -53,7 +53,6 @@ void MysqlUdrDbi::undo(const U2SingleModStep &modStep, U2OpStatus &os) {
     SAFE_POINT_EXT(modStep.modType == U2ModType::udrUpdated, os.setError("Unknown modStep"), );
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     QByteArray oldData;
     QByteArray newData;
@@ -67,7 +66,6 @@ void MysqlUdrDbi::redo(const U2SingleModStep &modStep, U2OpStatus &os) {
     SAFE_POINT_EXT(modStep.modType == U2ModType::udrUpdated, os.setError("Unknown modStep"), );
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     QByteArray oldData;
     QByteArray newData;
@@ -84,7 +82,6 @@ UdrRecordId MysqlUdrDbi::addRecord(const UdrSchemaId &schemaId, const QList<UdrV
     CHECK_EXT(data.size() == schema->size(), os.setError("Size mismatch"), result);
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     U2SqlQuery q(insertDef(schema, os), db, os);
     CHECK_OP(os, result);
@@ -102,7 +99,6 @@ void MysqlUdrDbi::updateRecord(const UdrRecordId &recordId, const QList<UdrValue
     CHECK_EXT(data.size() == schema->size(), os.setError("Size mismatch"), );
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     U2SqlQuery q(updateDef(schema, os), db, os);
     CHECK_OP(os, );
@@ -195,7 +191,6 @@ QList<UdrRecord> MysqlUdrDbi::getRecords(const UdrSchemaId &schemaId, U2OpStatus
 
 void MysqlUdrDbi::removeRecord(const UdrRecordId &recordId, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     U2SqlQuery q("DELETE FROM " + tableName(recordId.getSchemaId()) + " WHERE " + UdrSchema::RECORD_ID_FIELD_NAME + " = :id", db, os);
     q.bindDataId(":id", recordId.getRecordId());
@@ -237,7 +232,6 @@ void MysqlUdrDbi::initSqlSchema(U2OpStatus &os) {
     SAFE_POINT_EXT(nullptr != udrRegistry, os.setError("NULL UDR registry"), );
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     foreach (const UdrSchemaId &id, udrRegistry->getRegisteredSchemas()) {
         const UdrSchema *schema = udrSchema(id, os);
@@ -249,7 +243,6 @@ void MysqlUdrDbi::initSqlSchema(U2OpStatus &os) {
 
 void MysqlUdrDbi::initSchema(const UdrSchema *schema, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     CHECK_EXT(nullptr != schema, os.setError("NULL schema"), );
     createTable(schema, os);
@@ -277,7 +270,6 @@ void MysqlUdrDbi::createTable(const UdrSchema *schema, U2OpStatus &os) {
     query += ") ENGINE=InnoDB DEFAULT CHARSET=utf8";
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     U2SqlQuery(query, db, os).execute();
 }
@@ -286,7 +278,6 @@ void MysqlUdrDbi::createIndex(const UdrSchemaId &schemaId, const QStringList &fi
     QString query = "CREATE INDEX " + tableName(schemaId) + "_" + fields.join("_") + " " + "on " + tableName(schemaId) + "(" + fields.join(", ") + ")";
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     U2SqlQuery(query, db, os).execute();
 }

--- a/src/corelibs/U2Formats/src/mysql_dbi/MysqlVariantDbi.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/MysqlVariantDbi.cpp
@@ -89,7 +89,6 @@ MysqlVariantDbi::MysqlVariantDbi(MysqlDbi *dbi)
 
 void MysqlVariantDbi::initSqlSchema(U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     // Variant track object
     U2SqlQuery(" CREATE TABLE VariantTrack (object BIGINT PRIMARY KEY, sequence BIGINT, sequenceName TEXT NOT NULL,"
@@ -147,7 +146,6 @@ U2VariantTrack MysqlVariantDbi::getVariantTrack(const U2DataId &variantTrackId, 
     U2VariantTrack res;
     DBI_TYPE_CHECK(variantTrackId, U2Type::VariantTrack, os, res);
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     dbi->getMysqlObjectDbi()->getObject(res, variantTrackId, os);
     CHECK_OP(os, res);
@@ -175,7 +173,6 @@ U2VariantTrack MysqlVariantDbi::getVariantTrackofVariant(const U2DataId &variant
     U2VariantTrack res;
     DBI_TYPE_CHECK(variantId, U2Type::VariantType, os, res);
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "SELECT track FROM Variant WHERE id = :id";
     U2SqlQuery q(queryString, db, os);
@@ -192,7 +189,6 @@ U2VariantTrack MysqlVariantDbi::getVariantTrackofVariant(const U2DataId &variant
 void MysqlVariantDbi::addVariantsToTrack(const U2VariantTrack &track, U2DbiIterator<U2Variant> *it, U2OpStatus &os) {
     CHECK_EXT(!track.sequenceName.isEmpty(), os.setError(U2DbiL10n::tr("Sequence name is not set")), );
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "INSERT INTO Variant(track, startPos, endPos, refData, obsData, publicId, additionalInfo) "
                                        "VALUES(:track, :startPos, :endPos, :refData, :obsData, :publicId, :additionalInfo)";
@@ -215,7 +211,6 @@ void MysqlVariantDbi::addVariantsToTrack(const U2VariantTrack &track, U2DbiItera
 
 void MysqlVariantDbi::createVariationsIndex(U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     U2SqlQuery("CREATE INDEX IF NOT EXISTS VariantIndex ON Variant(track)", db, os).execute();
     CHECK_OP(os, );
@@ -225,7 +220,6 @@ void MysqlVariantDbi::createVariationsIndex(U2OpStatus &os) {
 void MysqlVariantDbi::createVariantTrack(U2VariantTrack &track, VariantTrackType trackType, const QString &folder, U2OpStatus &os) {
     CHECK_EXT(!track.sequenceName.isEmpty(), os.setError(U2DbiL10n::tr("Sequence name is not set")), );
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     dbi->getMysqlObjectDbi()->createObject(track, folder, U2DbiObjectRank_TopLevel, os);
     CHECK_OP(os, );
@@ -245,7 +239,6 @@ void MysqlVariantDbi::createVariantTrack(U2VariantTrack &track, VariantTrackType
 
 void MysqlVariantDbi::updateVariantTrack(U2VariantTrack &track, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString queryString = "UPDATE VariantTrack SET sequence = :sequence, sequenceName = :sequenceName, trackType = :trackType, fileHeader = :fileHeader WHERE object = :object";
     U2SqlQuery q(queryString, db, os);
@@ -308,7 +301,6 @@ int MysqlVariantDbi::getVariantCount(const U2DataId &trackId, U2OpStatus &os) {
 
 void MysqlVariantDbi::removeTrack(const U2DataId &trackId, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString variantString = "DELETE FROM Variant WHERE track = :track";
     U2SqlQuery variantQuery(variantString, db, os);
@@ -328,7 +320,6 @@ void MysqlVariantDbi::updateVariantPublicId(const U2DataId &track, const U2DataI
     CHECK_EXT(!newId.isEmpty(), os.setError(U2DbiL10n::tr("New variant public ID is empty")), );
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static QString qvString("UPDATE Variant SET publicId = :publicId WHERE track = :track AND id = :id");
     U2SqlQuery qv(qvString, db, os);
@@ -344,7 +335,6 @@ void MysqlVariantDbi::updateTrackIDofVariant(const U2DataId &variant, const U2Da
     CHECK_EXT(!newTrackId.isEmpty(), os.setError(U2DbiL10n::tr("New variant track ID is empty")), );
 
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static QString qvString("UPDATE Variant SET track = :track WHERE id = :id");
     U2SqlQuery qv(qvString, db, os);

--- a/src/corelibs/U2Formats/src/mysql_dbi/util/MysqlDbiUtils.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/util/MysqlDbiUtils.cpp
@@ -122,7 +122,6 @@ void MysqlDbiUtils::renameObject(MysqlDbi *dbi, U2Object &object, const QString 
     CHECK_OP(os, );
     SAFE_POINT(nullptr != dbi, "NULL dbi", );
     MysqlTransaction t(dbi->getDbRef(), os);
-    Q_UNUSED(t);
 
     MysqlModificationAction updateAction(dbi, object.id);
     updateAction.prepare(os);
@@ -139,7 +138,6 @@ void MysqlDbiUtils::renameObject(MysqlModificationAction &updateAction, MysqlDbi
     CHECK_OP(os, );
     SAFE_POINT(nullptr != dbi, "NULL dbi", );
     MysqlTransaction t(dbi->getDbRef(), os);
-    Q_UNUSED(t);
 
     QByteArray modDetails;
     if (TrackOnUpdate == updateAction.getTrackModType()) {

--- a/src/corelibs/U2Formats/src/mysql_dbi/util/MysqlModificationAction.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/util/MysqlModificationAction.cpp
@@ -37,7 +37,6 @@ MysqlModificationAction::MysqlModificationAction(MysqlDbi *_dbi, const U2DataId 
 U2TrackModType MysqlModificationAction::prepare(U2OpStatus &os) {
     CHECK_OP(os, NoTrack);
     MysqlTransaction t(getDbi()->getDbRef(), os);
-    Q_UNUSED(t);
 
     trackMod = dbi->getObjectDbi()->getTrackModType(masterObjId, os);
     if (os.hasError()) {
@@ -99,7 +98,6 @@ void MysqlModificationAction::complete(U2OpStatus &os) {
     // TODO: rewrite it with another U2UseCommonMultiModStep
     CHECK_OP(os, );
     MysqlTransaction t(getDbi()->getDbRef(), os);
-    Q_UNUSED(t);
 
     // Save modification tracks, if required
     if (TrackOnUpdate == trackMod) {

--- a/src/corelibs/U2Formats/src/mysql_dbi/util/MysqlSingleTableAssemblyAdapter.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/util/MysqlSingleTableAssemblyAdapter.cpp
@@ -60,7 +60,6 @@ MysqlSingleTableAssemblyAdapter::MysqlSingleTableAssemblyAdapter(MysqlDbi *dbi,
 
 void MysqlSingleTableAssemblyAdapter::createReadsTables(U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     // id - id of the read
     // name - read name hash
@@ -97,7 +96,6 @@ static const QString CREATE_INDEX_IF_NOT_EXISTS_QUERY =
 
 void MysqlSingleTableAssemblyAdapter::createReadsIndexes(U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     U2SqlQuery(CREATE_INDEX_IF_NOT_EXISTS_QUERY.arg(db->handle.databaseName())
                    .arg(readsTable)
@@ -179,7 +177,6 @@ U2DbiIterator<U2AssemblyRead> *MysqlSingleTableAssemblyAdapter::getReadsByName(c
 
 void MysqlSingleTableAssemblyAdapter::addReads(U2DbiIterator<U2AssemblyRead> *it, U2AssemblyReadsImportInfo &ii, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     if (!inited) {
         createReadsTables(os);
@@ -225,7 +222,6 @@ void MysqlSingleTableAssemblyAdapter::addReads(U2DbiIterator<U2AssemblyRead> *it
 
 void MysqlSingleTableAssemblyAdapter::removeReads(const QList<U2DataId> &readIds, U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     // TODO: add transaction per pack or reads
     // TODO: remove multiple reads in 1 SQL at once
@@ -287,7 +283,6 @@ QString MysqlSingleTableAssemblyAdapter::getReadsTableName(const U2DataId &assem
 
 void MysqlSingleTableAssemblyAdapter::dropReadsIndexes(U2OpStatus &os) {
     MysqlTransaction t(db, os);
-    Q_UNUSED(t);
 
     static const QString q1 = "DROP INDEX IF EXISTS %1_gstart";
     U2SqlQuery(q1.arg(readsTable), db, os).execute();

--- a/src/corelibs/U2Formats/src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_14_To_1_15.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_14_To_1_15.cpp
@@ -40,7 +40,6 @@ MysqlUpgraderFrom_1_14_To_1_15::MysqlUpgraderFrom_1_14_To_1_15(MysqlDbi *dbi)
 
 void MysqlUpgraderFrom_1_14_To_1_15::upgrade(U2OpStatus &os) const {
     MysqlTransaction t(dbi->getDbRef(), os);
-    Q_UNUSED(t);
 
     upgradeObjectDbi(os, dbi->getDbRef());
     CHECK_OP(os, );
@@ -64,7 +63,6 @@ void MysqlUpgraderFrom_1_14_To_1_15::upgradeObjectDbi(U2OpStatus &os, MysqlDbRef
     }
 
     MysqlTransaction t(dbRef, os);
-    Q_UNUSED(t);
 
     const QStringList folders = dbi->getObjectDbi()->getFolders(os);
     const QString recycleBinPrefix = U2ObjectDbi::ROOT_FOLDER + U2ObjectDbi::RECYCLE_BIN_FOLDER + U2ObjectDbi::PATH_SEP;

--- a/src/corelibs/U2Formats/src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_15_To_1_16.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_15_To_1_16.cpp
@@ -44,7 +44,6 @@ MysqlUpgraderFrom_1_15_To_1_16::MysqlUpgraderFrom_1_15_To_1_16(MysqlDbi *dbi)
 
 void MysqlUpgraderFrom_1_15_To_1_16::upgrade(U2OpStatus &os) const {
     MysqlTransaction t(dbi->getDbRef(), os);
-    Q_UNUSED(t);
 
     upgradeFeatureDbi(os, dbi->getDbRef());
     CHECK_OP(os, );

--- a/src/corelibs/U2Formats/src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_16_To_1_17.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_16_To_1_17.cpp
@@ -35,7 +35,6 @@ MysqlUpgraderFrom_1_16_To_1_17::MysqlUpgraderFrom_1_16_To_1_17(MysqlDbi *dbi)
 
 void MysqlUpgraderFrom_1_16_To_1_17::upgrade(U2OpStatus &os) const {
     MysqlTransaction t(dbi->getDbRef(), os);
-    Q_UNUSED(t);
 
     upgradeFeatureDbi(os, dbi->getDbRef());
     CHECK_OP(os, );

--- a/src/corelibs/U2Formats/src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_16_To_1_24.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_16_To_1_24.cpp
@@ -39,7 +39,6 @@ MysqlUpgraderFrom_1_16_To_1_24::MysqlUpgraderFrom_1_16_To_1_24(MysqlDbi *dbi)
 
 void MysqlUpgraderFrom_1_16_To_1_24::upgrade(U2OpStatus &os) const {
     MysqlTransaction t(dbi->getDbRef(), os);
-    Q_UNUSED(t);
 
     upgradeVariantDbi(os);
     CHECK_OP(os, );
@@ -51,7 +50,6 @@ void MysqlUpgraderFrom_1_16_To_1_24::upgradeVariantDbi(U2OpStatus &os) const {
     coreLog.trace("Variant DBI upgrading");
 
     MysqlTransaction t(dbi->getDbRef(), os);
-    Q_UNUSED(t);
 
     QMap<U2DataId, QStringList> trackId2header;
 
@@ -101,7 +99,6 @@ void MysqlUpgraderFrom_1_16_To_1_24::repackInfo(U2OpStatus &os, const QMap<U2Dat
     coreLog.trace("Additional info repacking");
 
     MysqlTransaction t(dbi->getDbRef(), os);
-    Q_UNUSED(t);
 
     const qint64 variantsCount = U2SqlQuery("SELECT count(*) from Variant", dbi->getDbRef(), os).selectInt64();
 

--- a/src/corelibs/U2Formats/src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_24_To_1_25.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_24_To_1_25.cpp
@@ -38,7 +38,6 @@ MysqlUpgraderFrom_1_24_To_1_25::MysqlUpgraderFrom_1_24_To_1_25(MysqlDbi *dbi)
 
 void MysqlUpgraderFrom_1_24_To_1_25::upgrade(U2OpStatus &os) const {
     MysqlTransaction t(dbi->getDbRef(), os);
-    Q_UNUSED(t);
 
     dropOldPrecedure(os, dbi->getDbRef());
     CHECK_OP(os, );

--- a/src/corelibs/U2Formats/src/sqlite_dbi/SQLiteAssemblyDbi.cpp
+++ b/src/corelibs/U2Formats/src/sqlite_dbi/SQLiteAssemblyDbi.cpp
@@ -236,7 +236,6 @@ void SQLiteAssemblyDbi::finalizeAssemblyObject(U2Assembly &assembly, U2OpStatus 
 
 void SQLiteAssemblyDbi::removeAssemblyData(const U2DataId &assemblyId, U2OpStatus &os) {
     SQLiteTransaction t(db, os);
-    Q_UNUSED(t);
     CHECK_OP(os, );
 
     removeTables(assemblyId, os);
@@ -246,7 +245,6 @@ void SQLiteAssemblyDbi::removeAssemblyData(const U2DataId &assemblyId, U2OpStatu
 
 void SQLiteAssemblyDbi::updateAssemblyObject(U2Assembly &assembly, U2OpStatus &os) {
     SQLiteTransaction t(db, os);
-    Q_UNUSED(t);
 
     SQLiteWriteQuery q("UPDATE Assembly SET reference = ?1 WHERE object = ?2", db, os);
     q.bindDataId(1, assembly.referenceId);

--- a/src/corelibs/U2Formats/src/sqlite_dbi/SQLiteFeatureDbi.cpp
+++ b/src/corelibs/U2Formats/src/sqlite_dbi/SQLiteFeatureDbi.cpp
@@ -478,7 +478,6 @@ QString getFeatureKeyInsertQuery(int keyCount) {
 
 void addFeatureKeys(const QList<U2FeatureKey> &keys, const U2DataId &featureId, DbRef *db, U2OpStatus &os) {
     SQLiteTransaction t(db, os);
-    Q_UNUSED(t);
 
     const int keyCount = keys.count();
     CHECK(keyCount > 0, );
@@ -705,7 +704,6 @@ void executeDeleteFeaturesByParentsQuery(const QList<U2DataId> &parentIds, DbRef
 
 void SQLiteFeatureDbi::removeFeaturesByParents(const QList<U2DataId> &parentIds, U2OpStatus &os) {
     SQLiteTransaction t(db, os);
-    Q_UNUSED(t);
 
     int parentsNumber = parentIds.count();
     if (parentsNumber <= SQLiteDbi::BIND_PARAMETERS_LIMIT) {

--- a/src/corelibs/U2Formats/src/sqlite_dbi/SQLiteModDbi.cpp
+++ b/src/corelibs/U2Formats/src/sqlite_dbi/SQLiteModDbi.cpp
@@ -241,7 +241,6 @@ void SQLiteModDbi::createModStep(const U2DataId &masterObjId, U2SingleModStep &s
 
 void SQLiteModDbi::removeModsWithGreaterVersion(const U2DataId &masterObjId, qint64 masterObjVersion, U2OpStatus &os) {
     SQLiteTransaction t(db, os);
-    Q_UNUSED(t);
 
     // Get user step IDs
     QList<qint64> userStepIds;
@@ -264,7 +263,6 @@ void SQLiteModDbi::removeModsWithGreaterVersion(const U2DataId &masterObjId, qin
 
 void SQLiteModDbi::removeDuplicateUserStep(const U2DataId &masterObjId, qint64 masterObjVersion, U2OpStatus &os) {
     SQLiteTransaction t(db, os);
-    Q_UNUSED(t);
 
     // Get user step IDs
     QList<qint64> userStepIds;
@@ -299,7 +297,6 @@ void SQLiteModDbi::removeSteps(QList<qint64> userStepIds, U2OpStatus &os) {
     }
 
     SQLiteTransaction t(db, os);
-    Q_UNUSED(t);
 
     // Get multiple steps IDs
     QList<qint64> multiStepIds;
@@ -345,7 +342,6 @@ void SQLiteModDbi::removeSteps(QList<qint64> userStepIds, U2OpStatus &os) {
 
 void SQLiteModDbi::removeObjectMods(const U2DataId &objectId, U2OpStatus &os) {
     SQLiteTransaction t(db, os);
-    Q_UNUSED(t);
 
     // Get user step IDs
     QList<qint64> userStepIds;
@@ -368,7 +364,6 @@ void SQLiteModDbi::removeObjectMods(const U2DataId &objectId, U2OpStatus &os) {
 void SQLiteModDbi::cleanUpAllStepsOnError() {
     U2OpStatus2Log os;
     SQLiteTransaction t(db, os);
-    Q_UNUSED(t);
 
     SQLiteWriteQuery("DELETE FROM SingleModStep", db, os).execute();
     SQLiteWriteQuery("DELETE FROM MultiModStep", db, os).execute();
@@ -416,7 +411,6 @@ void SQLiteModDbi::endCommonUserModStep(const U2DataId &userMasterObjId, U2OpSta
 
     if (-1 == multiModStepId) {
         SQLiteTransaction t(db, os);
-        Q_UNUSED(t);
 
         // Get multiple steps IDs
         SQLiteReadQuery qSelectMultiSteps("SELECT id FROM MultiModStep WHERE userStepId = ?1", db, os);

--- a/src/corelibs/U2Formats/src/sqlite_dbi/util/SqliteUpgraderFrom_0_To_1_13.cpp
+++ b/src/corelibs/U2Formats/src/sqlite_dbi/util/SqliteUpgraderFrom_0_To_1_13.cpp
@@ -38,7 +38,6 @@ SqliteUpgraderFrom_0_To_1_13::SqliteUpgraderFrom_0_To_1_13(SQLiteDbi *dbi)
 
 void SqliteUpgraderFrom_0_To_1_13::upgrade(U2OpStatus &os) const {
     SQLiteTransaction t(dbi->getDbRef(), os);
-    Q_UNUSED(t);
 
     upgradeObjectDbi(os);
     CHECK_OP(os, );

--- a/src/corelibs/U2Formats/src/sqlite_dbi/util/SqliteUpgraderFrom_1_13_To_1_25.cpp
+++ b/src/corelibs/U2Formats/src/sqlite_dbi/util/SqliteUpgraderFrom_1_13_To_1_25.cpp
@@ -41,7 +41,6 @@ SqliteUpgraderFrom_1_13_To_1_25::SqliteUpgraderFrom_1_13_To_1_25(SQLiteDbi *dbi)
 
 void SqliteUpgraderFrom_1_13_To_1_25::upgrade(U2OpStatus &os) const {
     SQLiteTransaction t(dbi->getDbRef(), os);
-    Q_UNUSED(t);
 
     upgradeCoverageAttribute(os);
     CHECK_OP(os, );

--- a/src/corelibs/U2Gui/src/util/project/ProjectViewModel.cpp
+++ b/src/corelibs/U2Gui/src/util/project/ProjectViewModel.cpp
@@ -521,7 +521,6 @@ void ProjectViewModel::moveObject(Document *doc, GObject *obj, const QString &ne
 
     U2OpStatus2Log os;
     DbiOperationsBlock opBlock(doc->getDbiRef(), os);
-    Q_UNUSED(opBlock);
     CHECK_OP(os, );
 
     DbiConnection con(doc->getDbiRef(), os);
@@ -560,7 +559,6 @@ bool ProjectViewModel::restoreObjectItemFromRecycleBin(Document *doc, GObject *o
 
     U2OpStatus2Log os;
     DbiOperationsBlock opBlock(doc->getDbiRef(), os);
-    Q_UNUSED(opBlock);
     CHECK_OP(os, false);
 
     const QString oldFolder = folders[doc]->getObjectFolder(obj);
@@ -592,7 +590,6 @@ bool ProjectViewModel::restoreObjectItemFromRecycleBin(Document *doc, GObject *o
 bool ProjectViewModel::restoreFolderItemFromRecycleBin(Document *doc, const QString &oldPath) {
     U2OpStatus2Log os;
     DbiOperationsBlock opBlock(doc->getDbiRef(), os);
-    Q_UNUSED(opBlock);
     CHECK_OP(os, false);
 
     ConnectionHelper con(doc->getDbiRef(), os);
@@ -670,7 +667,6 @@ void ProjectViewModel::createFolder(Document *doc, QString &path) {
 bool ProjectViewModel::renameFolderInDb(Document *doc, const QString &oldPath, QString &newPath) const {
     U2OpStatus2Log os;
     DbiOperationsBlock opBlock(doc->getDbiRef(), os);
-    Q_UNUSED(opBlock);
     CHECK_OP(os, false);
     DbiConnection con(doc->getDbiRef(), os);
     CHECK_OP(os, false);

--- a/src/libs_3rdparty/QSpec/src/core/MainThreadTimer.cpp
+++ b/src/libs_3rdparty/QSpec/src/core/MainThreadTimer.cpp
@@ -36,13 +36,11 @@ MainThreadTimer::MainThreadTimer(int interval)
 
 qint64 MainThreadTimer::getCounter() const {
     QMutexLocker locker(&guard);
-    Q_UNUSED(locker);
     return counter;
 }
 
 void MainThreadTimer::sl_timerTick() {
     QMutexLocker locker(&guard);
-    Q_UNUSED(locker);
     counter++;
 }
 

--- a/src/plugins/CoreTests/src/AnnotationTableObjectTest.cpp
+++ b/src/plugins/CoreTests/src/AnnotationTableObjectTest.cpp
@@ -47,9 +47,7 @@ namespace U2 {
 #define LOCATION_ATTR "location"
 #define INDEX_ATTR "index"
 
-void GTest_CheckNumAnnotations::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CheckNumAnnotations::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -85,9 +83,7 @@ Task::ReportResult GTest_CheckNumAnnotations::report() {
 
 //////////////////////////////////////////////////////////////////////////
 
-void GTest_FindAnnotationByNum::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_FindAnnotationByNum::init(XMLTestFormat *, const QDomElement &el) {
     result = nullptr;
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
@@ -146,9 +142,7 @@ void GTest_FindAnnotationByNum::cleanup() {
 
 //---------------------------------------------------------------
 
-void GTest_FindAnnotationByName::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_FindAnnotationByName::init(XMLTestFormat *, const QDomElement &el) {
     result = nullptr;
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
@@ -228,9 +222,7 @@ void GTest_FindAnnotationByName::cleanup() {
 
 //---------------------------------------------------------------
 
-void GTest_CheckAnnotationName::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CheckAnnotationName::init(XMLTestFormat *, const QDomElement &el) {
     annCtxName = el.attribute(ANNOTATION_ATTR);
     if (annCtxName.isEmpty()) {
         failMissingValue(ANNOTATION_ATTR);
@@ -259,9 +251,7 @@ Task::ReportResult GTest_CheckAnnotationName::report() {
 
 //---------------------------------------------------------------
 
-void GTest_CheckAnnotationSequence::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CheckAnnotationSequence::init(XMLTestFormat *, const QDomElement &el) {
     aCtxName = el.attribute(ANNOTATION_ATTR);
     if (aCtxName.isEmpty()) {
         failMissingValue(ANNOTATION_ATTR);
@@ -309,9 +299,7 @@ Task::ReportResult GTest_CheckAnnotationSequence::report() {
 
 //---------------------------------------------------------------
 
-void GTest_CheckAnnotationLocation::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CheckAnnotationLocation::init(XMLTestFormat *, const QDomElement &el) {
     annCtxName = el.attribute(ANNOTATION_ATTR);
     if (annCtxName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -388,9 +376,7 @@ Task::ReportResult GTest_CheckAnnotationLocation::report() {
     return ReportResult_Finished;
 }
 
-void GTest_CheckAnnotationQualifier::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CheckAnnotationQualifier::init(XMLTestFormat *, const QDomElement &el) {
     annCtxName = el.attribute(ANNOTATION_ATTR);
     if (annCtxName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -436,9 +422,7 @@ Task::ReportResult GTest_CheckAnnotationQualifier::report() {
     return ReportResult_Finished;
 }
 
-void GTest_CheckAnnotationQualifierIsAbsent::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CheckAnnotationQualifierIsAbsent::init(XMLTestFormat *, const QDomElement &el) {
     annCtxName = el.attribute(ANNOTATION_ATTR);
     if (annCtxName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -468,9 +452,7 @@ Task::ReportResult GTest_CheckAnnotationQualifierIsAbsent::report() {
 }
 
 //---------------------------------------------------------------
-void GTest_CheckAnnotationsNumInTwoObjects::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CheckAnnotationsNumInTwoObjects::init(XMLTestFormat *, const QDomElement &el) {
     docContextName = el.attribute(DOC_ATTR);
     if (docContextName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -563,9 +545,7 @@ Task::ReportResult GTest_CheckAnnotationsNumInTwoObjects::report() {
 }
 
 //---------------------------------------------------------------
-void GTest_CheckAnnotationsLocationsInTwoObjects::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CheckAnnotationsLocationsInTwoObjects::init(XMLTestFormat *, const QDomElement &el) {
     docContextName = el.attribute(DOC_ATTR);
     if (docContextName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -671,9 +651,7 @@ Task::ReportResult GTest_CheckAnnotationsLocationsInTwoObjects::report() {
 }
 
 //---------------------------------------------------------------
-void GTest_CheckAnnotationsLocationsAndNumReorderdered::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CheckAnnotationsLocationsAndNumReorderdered::init(XMLTestFormat *, const QDomElement &el) {
     doc1CtxName = el.attribute(DOC_ATTR);
     if (doc1CtxName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -745,9 +723,7 @@ Task::ReportResult GTest_CheckAnnotationsLocationsAndNumReorderdered::report() {
 }
 
 //---------------------------------------------------------------
-void GTest_CheckAnnotationsQualifiersInTwoObjects::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CheckAnnotationsQualifiersInTwoObjects::init(XMLTestFormat *, const QDomElement &el) {
     docContextName = el.attribute(DOC_ATTR);
     if (docContextName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -830,9 +806,7 @@ Task::ReportResult GTest_CheckAnnotationsQualifiersInTwoObjects::report() {
 }
 
 //---------------------------------------------------------------
-void GTest_CheckAnnotationsNamesInTwoObjects::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CheckAnnotationsNamesInTwoObjects::init(XMLTestFormat *, const QDomElement &el) {
     docContextName = el.attribute(DOC_ATTR);
     if (docContextName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -911,9 +885,7 @@ Task::ReportResult GTest_CheckAnnotationsNamesInTwoObjects::report() {
     return ReportResult_Finished;
 }
 
-void GTest_FindAnnotationByLocation::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_FindAnnotationByLocation::init(XMLTestFormat *, const QDomElement &el) {
     result = nullptr;
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
@@ -1008,9 +980,7 @@ void GTest_FindAnnotationByLocation::cleanup() {
 
 //---------------------------------------------------------------
 
-void GTest_CreateTmpAnnotationObject::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CreateTmpAnnotationObject::init(XMLTestFormat *, const QDomElement &el) {
     aobj = nullptr;
     objContextName = el.attribute(NAME_ATTR);
     if (objContextName.isEmpty()) {

--- a/src/plugins/CoreTests/src/AnnotationUtilsTests.cpp
+++ b/src/plugins/CoreTests/src/AnnotationUtilsTests.cpp
@@ -37,8 +37,7 @@ QList<XMLTestFactory *> AnnotationUtilsTests::createTestFactories() {
     return res;
 }
 
-void GTest_ShiftSequence::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_ShiftSequence::init(XMLTestFormat *, const QDomElement &el) {
     bool isOk;
     locationStringBefore = el.attribute("location-before");
     locationStringAfter = el.attribute("location-after");

--- a/src/plugins/CoreTests/src/BinaryFindOpenCLTests.cpp
+++ b/src/plugins/CoreTests/src/BinaryFindOpenCLTests.cpp
@@ -40,9 +40,7 @@ QList<XMLTestFactory *> BinaryFindOpenCLTests::createTestFactories() {
     return res;
 }
 
-void GTest_BinaryFindOpenCL::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_BinaryFindOpenCL::init(XMLTestFormat *, const QDomElement &el) {
     QString buf;
 
     buf = el.attribute(NUMBERS);

--- a/src/plugins/CoreTests/src/BioStruct3DObjectTests.cpp
+++ b/src/plugins/CoreTests/src/BioStruct3DObjectTests.cpp
@@ -41,9 +41,7 @@ namespace U2 {
 #define CHAIN_IND_ATTR "chain-index"
 #define MOL_NAME_ATTR "molecule-name"
 
-void GTest_BioStruct3DNumberOfAtoms::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_BioStruct3DNumberOfAtoms::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -87,9 +85,7 @@ Task::ReportResult GTest_BioStruct3DNumberOfAtoms::report() {
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-void GTest_BioStruct3DNumberOfChains::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_BioStruct3DNumberOfChains::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -133,8 +129,7 @@ Task::ReportResult GTest_BioStruct3DNumberOfChains::report() {
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-void GTest_BioStruct3DAtomCoordinates::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_BioStruct3DAtomCoordinates::init(XMLTestFormat *, const QDomElement &el) {
     modelId = -1;
 
     objContextName = el.attribute(OBJ_ATTR);
@@ -237,8 +232,7 @@ Task::ReportResult GTest_BioStruct3DAtomCoordinates::report() {
 }
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-void GTest_BioStruct3DAtomChainIndex::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_BioStruct3DAtomChainIndex::init(XMLTestFormat *, const QDomElement &el) {
     modelId = -1;
 
     objContextName = el.attribute(OBJ_ATTR);
@@ -314,8 +308,7 @@ Task::ReportResult GTest_BioStruct3DAtomChainIndex::report() {
 }
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-void GTest_BioStruct3DAtomResidueName::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_BioStruct3DAtomResidueName::init(XMLTestFormat *, const QDomElement &el) {
     // default model id
     modelId = -1;
 
@@ -448,10 +441,7 @@ Task::ReportResult GTest_BioStruct3DMoleculeName::report() {
 
 #define PDB_DIR_NAME_ENV "DIR_WITH_PDB_FILES"
 
-void GTest_PDBFormatStressTest::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-    Q_UNUSED(el);
-
+void GTest_PDBFormatStressTest::init(XMLTestFormat *, const QDomElement &) {
     QString dirName = getEnv()->getVar(PDB_DIR_NAME_ENV);
 
     QDir dir(dirName);
@@ -500,10 +490,7 @@ QList<Task *> GTest_PDBFormatStressTest::onSubTaskFinished(Task *subTask) {
 
 #define ASN_DIR_NAME_ENV "DIR_WITH_ASN_FILES"
 
-void GTest_ASNFormatStressTest::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-    Q_UNUSED(el);
-
+void GTest_ASNFormatStressTest::init(XMLTestFormat *, const QDomElement &) {
     QString dirName = getEnv()->getVar(ASN_DIR_NAME_ENV);
 
     if (dirName.isEmpty()) {

--- a/src/plugins/CoreTests/src/CMDLineTests.cpp
+++ b/src/plugins/CoreTests/src/CMDLineTests.cpp
@@ -49,8 +49,7 @@ namespace U2 {
 /************************
  * GTest_RunCMDLine
  ************************/
-void GTest_RunCMDLine::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_RunCMDLine::init(XMLTestFormat *, const QDomElement &el) {
     setUgeneclPath();
     setArgs(el);
     proc = new QProcess(this);

--- a/src/plugins/CoreTests/src/DNASequenceObjectTests.cpp
+++ b/src/plugins/CoreTests/src/DNASequenceObjectTests.cpp
@@ -43,9 +43,7 @@ namespace U2 {
 #define QUALITY_ATTR "quality"
 #define POSITION_ATTR "pos"
 
-void GTest_DNASequenceSize::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNASequenceSize::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -83,9 +81,7 @@ Task::ReportResult GTest_DNASequenceSize::report() {
     return ReportResult_Finished;
 }
 
-void GTest_DNASequenceAlphabet::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNASequenceAlphabet::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -122,9 +118,7 @@ Task::ReportResult GTest_DNASequenceAlphabet::report() {
     return ReportResult_Finished;
 }
 
-void GTest_DNASequencePart::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNASequencePart::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -175,9 +169,7 @@ Task::ReportResult GTest_DNASequencePart::report() {
     }
     return ReportResult_Finished;
 }
-void GTest_DNASequenceAlphabetType::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNASequenceAlphabetType::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -222,9 +214,7 @@ Task::ReportResult GTest_DNASequenceAlphabetType::report() {
     }
     return ReportResult_Finished;
 }
-void GTest_DNASequenceAlphabetId::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNASequenceAlphabetId::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -258,9 +248,7 @@ Task::ReportResult GTest_DNASequenceAlphabetId::report() {
 }
 
 //----------------------------------------------------------
-void GTest_DNAcompareSequencesNamesInTwoObjects::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNAcompareSequencesNamesInTwoObjects::init(XMLTestFormat *, const QDomElement &el) {
     docContextName = el.attribute(DOC_ATTR);
     if (docContextName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -327,9 +315,7 @@ Task::ReportResult GTest_DNAcompareSequencesNamesInTwoObjects::report() {
 }
 
 //----------------------------------------------------------
-void GTest_DNAcompareSequencesInTwoObjects::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNAcompareSequencesInTwoObjects::init(XMLTestFormat *, const QDomElement &el) {
     docContextName = el.attribute(DOC_ATTR);
     if (docContextName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -398,9 +384,7 @@ Task::ReportResult GTest_DNAcompareSequencesInTwoObjects::report() {
 }
 
 //----------------------------------------------------------
-void GTest_DNAcompareSequencesAlphabetsInTwoObjects::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNAcompareSequencesAlphabetsInTwoObjects::init(XMLTestFormat *, const QDomElement &el) {
     docContextName = el.attribute(DOC_ATTR);
     if (docContextName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -467,9 +451,7 @@ Task::ReportResult GTest_DNAcompareSequencesAlphabetsInTwoObjects::report() {
 }
 
 //-----------------------------------------------------------------------------
-void GTest_DNAMulSequenceAlphabetId::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNAMulSequenceAlphabetId::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -504,9 +486,7 @@ Task::ReportResult GTest_DNAMulSequenceAlphabetId::report() {
 
 //-----------------------------------------------------------------------------
 
-void GTest_DNAMulSequenceSize::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNAMulSequenceSize::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -546,9 +526,7 @@ Task::ReportResult GTest_DNAMulSequenceSize::report() {
 
 //-----------------------------------------------------------------------------
 
-void GTest_DNAMulSequencePart::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNAMulSequencePart::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -621,9 +599,7 @@ Task::ReportResult GTest_DNAMulSequencePart::report() {
 
 //-----------------------------------------------------------------------------
 
-void GTest_DNAMulSequenceName::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNAMulSequenceName::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -661,9 +637,7 @@ Task::ReportResult GTest_DNAMulSequenceName::report() {
 
 //-----------------------------------------------------------------------------
 
-void GTest_DNAMulSequenceQuality::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNAMulSequenceQuality::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -717,9 +691,7 @@ Task::ReportResult GTest_DNAMulSequenceQuality::report() {
 
 //-----------------------------------------------------------------------------
 
-void GTest_DNASequencInMulSequence::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNASequencInMulSequence::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -757,9 +729,7 @@ Task::ReportResult GTest_DNASequencInMulSequence::report() {
     return ReportResult_Finished;
 }
 //----------------------------------------------------------
-void GTest_DNAcompareMulSequencesInTwoObjects::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNAcompareMulSequencesInTwoObjects::init(XMLTestFormat *, const QDomElement &el) {
     docContextName = el.attribute(DOC_ATTR);
     if (docContextName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -848,9 +818,7 @@ Task::ReportResult GTest_DNAcompareMulSequencesInTwoObjects::report() {
 }
 
 //----------------------------------------------------------
-void GTest_DNAcompareMulSequencesNamesInTwoObjects::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNAcompareMulSequencesNamesInTwoObjects::init(XMLTestFormat *, const QDomElement &el) {
     docContextName = el.attribute(DOC_ATTR);
     if (docContextName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -934,9 +902,7 @@ Task::ReportResult GTest_DNAcompareMulSequencesNamesInTwoObjects::report() {
     return ReportResult_Finished;
 }
 //----------------------------------------------------------
-void GTest_DNASequenceQualityScores::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNASequenceQualityScores::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -978,9 +944,7 @@ Task::ReportResult GTest_DNASequenceQualityScores::report() {
 
 //----------------------------------------------------------
 
-void GTest_DNASequenceQualityValue::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNASequenceQualityValue::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -1043,9 +1007,7 @@ Task::ReportResult GTest_DNASequenceQualityValue::report() {
 }
 
 //----------------------------------------------------------
-void GTest_CompareDNASequenceQualityInTwoObjects::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CompareDNASequenceQualityInTwoObjects::init(XMLTestFormat *, const QDomElement &el) {
     doc1CtxName = el.attribute("doc1");
     if (doc1CtxName.isEmpty()) {
         failMissingValue("doc1");
@@ -1099,9 +1061,7 @@ Task::ReportResult GTest_CompareDNASequenceQualityInTwoObjects::report() {
 }
 
 //----------------------------------------------------------
-void GTest_DNAcompareMulSequencesAlphabetIdInTwoObjects::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNAcompareMulSequencesAlphabetIdInTwoObjects::init(XMLTestFormat *, const QDomElement &el) {
     docContextName = el.attribute(DOC_ATTR);
     if (docContextName.isEmpty()) {
         failMissingValue(DOC_ATTR);

--- a/src/plugins/CoreTests/src/DNATranslationImplTests.cpp
+++ b/src/plugins/CoreTests/src/DNATranslationImplTests.cpp
@@ -38,9 +38,7 @@ namespace U2 {
 #define END_ATTR "seqend"
 #define OBJ_ATTR "obj"
 //---------------------------------------------------------------------
-void GTest_DNATranslation3to1Test::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DNATranslation3to1Test::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);

--- a/src/plugins/CoreTests/src/DnaAssemblyTests.cpp
+++ b/src/plugins/CoreTests/src/DnaAssemblyTests.cpp
@@ -176,9 +176,7 @@ void GTest_DnaAssemblyToReferenceTask::cleanup() {
 }
 
 //----------------------------------------------------------
-void GTest_AssemblycompareTwoSAMbyLength::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_AssemblycompareTwoSAMbyLength::init(XMLTestFormat *, const QDomElement &el) {
     file1Url = el.attribute(FILE1_ATTR);
     if (file1Url.isEmpty()) {
         failMissingValue(FILE1_ATTR);

--- a/src/plugins/CoreTests/src/DocumentModelTests.cpp
+++ b/src/plugins/CoreTests/src/DocumentModelTests.cpp
@@ -177,9 +177,7 @@ Task::ReportResult GTest_LoadDocument::report() {
 /*******************************
  * GTest_SaveDocument
  *******************************/
-void GTest_SaveDocument::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_SaveDocument::init(XMLTestFormat *, const QDomElement &el) {
     docContextName = el.attribute(DOC_ATTR);
     if (docContextName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -233,9 +231,7 @@ void GTest_SaveDocument::prepare() {
 /*******************************
  * GTest_LoadBrokenDocument
  *******************************/
-void GTest_LoadBrokenDocument::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_LoadBrokenDocument::init(XMLTestFormat *, const QDomElement &el) {
     QString urlAttr = el.attribute("url");
     QString dir = el.attribute("dir");
     IOAdapterId io = el.attribute("io");
@@ -410,9 +406,7 @@ Task::ReportResult GTest_ImportDocument::report() {
 /*******************************
  * GTest_ImportBrokenDocument
  *******************************/
-void GTest_ImportBrokenDocument::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_ImportBrokenDocument::init(XMLTestFormat *, const QDomElement &el) {
     QString urlAttr = el.attribute("url");
     QString outUrlAttr = getTempDir(env) + "/" + el.attribute("outUrl");
     QString dir = el.attribute("dir");
@@ -484,9 +478,7 @@ void GTest_ImportBrokenDocument::cleanup() {
  *GTest_DocumentFormat
  *******************************/
 
-void GTest_DocumentFormat::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DocumentFormat::init(XMLTestFormat *, const QDomElement &el) {
     docUrl = el.attribute("url");
     if (docUrl.isEmpty()) {
         failMissingValue("url");
@@ -518,9 +510,7 @@ Task::ReportResult GTest_DocumentFormat::report() {
 /*******************************
  * GTest_DocumentNumObjects
  *******************************/
-void GTest_DocumentNumObjects::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DocumentNumObjects::init(XMLTestFormat *, const QDomElement &el) {
     docContextName = el.attribute(DOC_ATTR);
     if (docContextName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -555,9 +545,7 @@ Task::ReportResult GTest_DocumentNumObjects::report() {
 /*******************************
  * GTest_DocumentObjectNames
  *******************************/
-void GTest_DocumentObjectNames::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DocumentObjectNames::init(XMLTestFormat *, const QDomElement &el) {
     docContextName = el.attribute(DOC_ATTR);
     if (docContextName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -605,9 +593,7 @@ Task::ReportResult GTest_DocumentObjectNames::report() {
 /*******************************
  * GTest_DocumentObjectTypes
  *******************************/
-void GTest_DocumentObjectTypes::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DocumentObjectTypes::init(XMLTestFormat *, const QDomElement &el) {
     docContextName = el.attribute(DOC_ATTR);
     if (docContextName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -655,9 +641,7 @@ Task::ReportResult GTest_DocumentObjectTypes::report() {
 /*******************************
  * GTest_FindGObjectByName
  *******************************/
-void GTest_FindGObjectByName::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_FindGObjectByName::init(XMLTestFormat *, const QDomElement &el) {
     docContextName = el.attribute(DOC_ATTR);
     if (docContextName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -728,9 +712,7 @@ static const QString COMPARE_FIRST_N_LINES = "first_n_lines";
 static const QString COMPARE_MIXED_LINES = "mixed-lines";
 static const QString COMPARE_FORCE_BUFFER_SIZE = "buffer-size";
 
-void GTest_CompareFiles::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CompareFiles::init(XMLTestFormat *, const QDomElement &el) {
     // Get the attributes values
     QString tmpAttr = el.attribute(TMP_ATTR_ID);
 
@@ -956,9 +938,7 @@ void GTest_CompareFiles::compareMixed() {
  *******************************/
 const QByteArray GTest_Compare_VCF_Files::COMMENT_MARKER = "#";
 
-void GTest_Compare_VCF_Files::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_Compare_VCF_Files::init(XMLTestFormat *, const QDomElement &el) {
     QStringList tmpDocNums = el.attribute(TMP_ATTR_ID).split(TMP_ATTR_SPLITTER, QString::SkipEmptyParts);
 
     doc1Path = el.attribute(DOC1_ATTR_ID);
@@ -1051,9 +1031,7 @@ QString GTest_Compare_VCF_Files::getLine(IOAdapter *io) {
  *******************************/
 const int NUMDER_OF_LINES = 10;
 
-void GTest_Compare_PDF_Files::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_Compare_PDF_Files::init(XMLTestFormat *, const QDomElement &el) {
     QStringList tmpDocNums = el.attribute(TMP_ATTR_ID).split(TMP_ATTR_SPLITTER, QString::SkipEmptyParts);
 
     doc1Path = el.attribute(DOC1_ATTR_ID);

--- a/src/plugins/CoreTests/src/EditAlignmentTests.cpp
+++ b/src/plugins/CoreTests/src/EditAlignmentTests.cpp
@@ -38,8 +38,7 @@ namespace U2 {
 #define REGION_HEIGHT "height"
 #define REGION_WIDTH "width"
 
-void GTest_CreateSubalignimentTask::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_CreateSubalignimentTask::init(XMLTestFormat *, const QDomElement &el) {
     QString buf = el.attribute(DOC_ATTR);
     if (buf.isEmpty()) {
         stateInfo.setError(GTest::tr("value not set %1").arg(DOC_ATTR));
@@ -161,9 +160,7 @@ Task::ReportResult GTest_CreateSubalignimentTask::report() {
 
 //////////////////////////////////////////////////////////////////////////
 
-void GTest_RemoveAlignmentRegion::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_RemoveAlignmentRegion::init(XMLTestFormat *, const QDomElement &el) {
     // Doc name
 
     QString buf = el.attribute(DOC_ATTR);
@@ -288,8 +285,7 @@ Task::ReportResult GTest_RemoveAlignmentRegion::report() {
 
 //////////////////////////////////////////////////////////////////////////
 
-void GTest_AddSequenceToAlignment::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_AddSequenceToAlignment::init(XMLTestFormat *, const QDomElement &el) {
     // Doc before name
 
     QString buf = el.attribute(DOC_ATTR);

--- a/src/plugins/CoreTests/src/EditSequenceTests.cpp
+++ b/src/plugins/CoreTests/src/EditSequenceTests.cpp
@@ -37,8 +37,7 @@ namespace U2 {
 #define EXPECTED_ANNOTATION_STRATEGY_ATTR "annotation_processing"
 #define LENGTH_ATTR "length"
 
-void GTest_AddPartToSequenceTask::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_AddPartToSequenceTask::init(XMLTestFormat *, const QDomElement &el) {
     QString buf;
     buf = el.attribute(DOC_NAME_ATTR);
     if (!buf.isEmpty()) {
@@ -176,8 +175,7 @@ GTest_AddPartToSequenceTask::~GTest_AddPartToSequenceTask() {
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 
-void GTest_RemovePartFromSequenceTask::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_RemovePartFromSequenceTask::init(XMLTestFormat *, const QDomElement &el) {
     QString buf;
     buf = el.attribute(DOC_NAME_ATTR);
     if (!buf.isEmpty()) {
@@ -296,8 +294,7 @@ GTest_RemovePartFromSequenceTask::~GTest_RemovePartFromSequenceTask() {
 
 //////////////////////////////////////////////////////////////////////////
 
-void GTest_ReplacePartOfSequenceTask::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_ReplacePartOfSequenceTask::init(XMLTestFormat *, const QDomElement &el) {
     QString buf;
     buf = el.attribute(DOC_NAME_ATTR);
     if (!buf.isEmpty()) {

--- a/src/plugins/CoreTests/src/FindAlgorithmTests.cpp
+++ b/src/plugins/CoreTests/src/FindAlgorithmTests.cpp
@@ -61,8 +61,7 @@ U2Region stringToRegion(const QString &regionStr) {
     return U2Region(region[0], region[1] - region[0]);
 }
 
-void GTest_FindAlgorithmTest::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_FindAlgorithmTest::init(XMLTestFormat *, const QDomElement &el) {
     QString buf = el.attribute(STRAND_ATTR);
     if (buf.isEmpty()) {
         stateInfo.setError(GTest::tr("value not set %1").arg(STRAND_ATTR));

--- a/src/plugins/CoreTests/src/FindPatternMsaTaskTest.cpp
+++ b/src/plugins/CoreTests/src/FindPatternMsaTaskTest.cpp
@@ -37,9 +37,7 @@ namespace U2 {
 #define EXPECTED_RESULTS_SIZE "resultsSize"
 #define EXPECTED_REGIONS_IN_RESULTS "expectedRegionsInResults"
 
-void GTest_FindPatternMsa::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_FindPatternMsa::init(XMLTestFormat *, const QDomElement &el) {
     settings.findSettings.maxRegExpResultLength = 10000;
     settings.findSettings.maxResult2Find = 100000;
 

--- a/src/plugins/CoreTests/src/GUrlTests.cpp
+++ b/src/plugins/CoreTests/src/GUrlTests.cpp
@@ -166,8 +166,7 @@ Task::ReportResult GTest_CheckTmpFile::report() {
 /************************************************************************/
 /* GTest_CheckStorageFile */
 /************************************************************************/
-void GTest_CheckStorageFile::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_CheckStorageFile::init(XMLTestFormat *, const QDomElement &el) {
     storageUrl = AppContext::getAppFileStorage()->getStorageDir();
     fileName = el.attribute(URL_ATTR);
     exists = bool(el.attribute(EXISTS_ATTR).toInt());
@@ -207,8 +206,7 @@ bool GTest_CheckStorageFile::findRecursive(const QString &currentDirUrl) {
 #define URL_ATTR "url"
 #define LESS_ATTR "lessThen"
 #define MORE_ATTR "moreThen"
-void GTest_CheckCreationTime::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf)
+void GTest_CheckCreationTime::init(XMLTestFormat *, const QDomElement &el) {
     url = el.attribute(URL_ATTR);
     XMLTestUtils::replacePrefix(env, url);
 
@@ -277,8 +275,7 @@ Task::ReportResult GTest_CheckCreationTime::report() {
 /************************************************************************/
 #define FOLDER_ATTR "folder"
 #define EXP_NUM "expected"
-void GTest_CheckFilesNum::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf)
+void GTest_CheckFilesNum::init(XMLTestFormat *, const QDomElement &el) {
     folder = el.attribute(FOLDER_ATTR);
     QString num_string = el.attribute(EXP_NUM);
     if (num_string.isEmpty()) {

--- a/src/plugins/CoreTests/src/LoadRemoteDocumentTests.cpp
+++ b/src/plugins/CoreTests/src/LoadRemoteDocumentTests.cpp
@@ -33,9 +33,7 @@ namespace U2 {
 
 //////////////////////////////////////////////////////////////////////////
 
-void GTest_LoadRemoteDocumentTask::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_LoadRemoteDocumentTask::init(XMLTestFormat *, const QDomElement &el) {
     dbName.clear();
     docId.clear();
     expectedDoc.clear();

--- a/src/plugins/CoreTests/src/PWMatrixTests.cpp
+++ b/src/plugins/CoreTests/src/PWMatrixTests.cpp
@@ -47,9 +47,7 @@ namespace U2 {
 #define EXPECTED "expected-values"
 
 //---------------------------------------------------------------------
-void GTest_PFMtoPWMConvertTest::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_PFMtoPWMConvertTest::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -61,9 +59,7 @@ Task::ReportResult GTest_PFMtoPWMConvertTest::report() {
     return ReportResult_Finished;
 }
 
-void GTest_PFMCreateTest::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_PFMCreateTest::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -212,9 +208,7 @@ Task::ReportResult GTest_PFMCreateTest::report() {
     return ReportResult_Finished;
 }
 
-void GTest_PWMCreateTest::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_PWMCreateTest::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);

--- a/src/plugins/CoreTests/src/PhyTreeObjectTests.cpp
+++ b/src/plugins/CoreTests/src/PhyTreeObjectTests.cpp
@@ -46,9 +46,7 @@ namespace U2 {
 
 #define EPS 0.0001
 
-void GTest_CalculateTreeFromAligment::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CalculateTreeFromAligment::init(XMLTestFormat *, const QDomElement &el) {
     task = nullptr;
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
@@ -119,9 +117,7 @@ Task::ReportResult GTest_CalculateTreeFromAligment::report() {
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-void GTest_CheckPhyNodeHasSibling::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CheckPhyNodeHasSibling::init(XMLTestFormat *, const QDomElement &el) {
     treeContextName = el.attribute(OBJ_ATTR);
     if (treeContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -179,8 +175,7 @@ Task::ReportResult GTest_CheckPhyNodeHasSibling::report() {
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 
-void GTest_CheckPhyNodeBranchDistance::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_CheckPhyNodeBranchDistance::init(XMLTestFormat *, const QDomElement &el) {
     treeContextName = el.attribute(OBJ_ATTR);
     if (treeContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -234,9 +229,7 @@ Task::ReportResult GTest_CheckPhyNodeBranchDistance::report() {
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-void GTest_CompareTreesInTwoObjects::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CompareTreesInTwoObjects::init(XMLTestFormat *, const QDomElement &el) {
     docContextName = el.attribute(DOC_ATTR);
     if (docContextName.isEmpty()) {
         failMissingValue(DOC_ATTR);

--- a/src/plugins/CoreTests/src/RealignSequencesInAlignmentTaskTest.cpp
+++ b/src/plugins/CoreTests/src/RealignSequencesInAlignmentTaskTest.cpp
@@ -33,9 +33,7 @@ namespace U2 {
 #define ROWS_LIST_ATTR "rows"
 #define FORCE_USE_UGENE_ALIGNER_ATTR "useUgeneAligner"
 
-void GTest_Realign::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_Realign::init(XMLTestFormat *, const QDomElement &el) {
     forceUseUgeneAligner = false;
 
     inputObjectName = el.attribute(IN_OBJECT_NAME_ATTR);

--- a/src/plugins/CoreTests/src/SMatrixTests.cpp
+++ b/src/plugins/CoreTests/src/SMatrixTests.cpp
@@ -43,8 +43,7 @@ QList<XMLTestFactory *> SMatrixTests::createTestFactories() {
     return res;
 }
 
-void GTest_SubstMatrix::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_SubstMatrix::init(XMLTestFormat *, const QDomElement &el) {
     QString buf;
     bool isOk;
     buf = el.attribute(FILE_ATTR);

--- a/src/plugins/CoreTests/src/SecStructPredictTests.cpp
+++ b/src/plugins/CoreTests/src/SecStructPredictTests.cpp
@@ -41,8 +41,7 @@ namespace U2 {
 #define OUTPUT_SEQ_ATTR "output-seq"
 #define ALG_NAME_ATTR "algorithm-name"
 
-void GTest_SecStructPredictAlgorithm::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_SecStructPredictAlgorithm::init(XMLTestFormat *, const QDomElement &el) {
     inputSeq = el.attribute(SEQ_ATTR);
     if (inputSeq.isEmpty()) {
         failMissingValue(SEQ_ATTR);
@@ -86,9 +85,7 @@ Task::ReportResult GTest_SecStructPredictAlgorithm::report() {
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-void GTest_SecStructPredictTask::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_SecStructPredictTask::init(XMLTestFormat *, const QDomElement &el) {
     seqName = el.attribute(SEQ_NAME_ATTR);
     if (seqName.isEmpty()) {
         failMissingValue(SEQ_NAME_ATTR);

--- a/src/plugins/CoreTests/src/SequenceWalkerTests.cpp
+++ b/src/plugins/CoreTests/src/SequenceWalkerTests.cpp
@@ -36,9 +36,7 @@ namespace U2 {
 #define REVERSE_ATTR "reverse"
 #define RESULT_ATTR "result"
 
-void GTest_SW_CheckRegion::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_SW_CheckRegion::init(XMLTestFormat *, const QDomElement &el) {
     QString stepStr = el.attribute(CHUNK_ATTR);
     if (stepStr.isEmpty()) {
         failMissingValue(CHUNK_ATTR);

--- a/src/plugins/CoreTests/src/SequenceWalkerTests.h
+++ b/src/plugins/CoreTests/src/SequenceWalkerTests.h
@@ -38,9 +38,7 @@ public:
 
     ReportResult report();
 
-    void onRegion(SequenceWalkerSubtask *t, TaskStateInfo &ti) {
-        Q_UNUSED(t);
-        Q_UNUSED(ti);
+    void onRegion(SequenceWalkerSubtask *, TaskStateInfo &) {
     }
 
 private:

--- a/src/plugins/CoreTests/src/TaskTests.cpp
+++ b/src/plugins/CoreTests/src/TaskTests.cpp
@@ -149,9 +149,7 @@ StateOrderTestTask::~StateOrderTestTask() {
     callback->func(this, StateOrder_Done);
 }
 
-void GTest_TaskCreateTest::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_TaskCreateTest::init(XMLTestFormat *, const QDomElement &el) {
     deleteTask = false;
 
     resultContextName = el.attribute(INDEX_ATTR);
@@ -218,8 +216,7 @@ void GTest_TaskCreateTest::cleanup() {
     XmlTest::cleanup();
 }
 
-void GTest_TaskAddSubtaskTest::init(U2::XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_TaskAddSubtaskTest::init(U2::XMLTestFormat *, const QDomElement &el) {
     taskContextName = el.attribute(OBJ_ATTR);
     if (taskContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -258,9 +255,7 @@ Task::ReportResult GTest_TaskAddSubtaskTest::report() {
     return ReportResult_Finished;
 }
 
-void GTest_TaskCancelTest::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_TaskCancelTest::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -284,8 +279,7 @@ Task::ReportResult GTest_TaskCancelTest::report() {
     return ReportResult_Finished;
 }
 
-void GTest_TaskCheckFlag::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_TaskCheckFlag::init(XMLTestFormat *, const QDomElement &el) {
     taskContextName = el.attribute(OBJ_ATTR);
     if (taskContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -319,9 +313,7 @@ Task::ReportResult GTest_TaskCheckFlag::report() {
     return ReportResult_Finished;
 }
 
-void GTest_TaskCheckState::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_TaskCheckState::init(XMLTestFormat *, const QDomElement &el) {
     checkState = false;
     checkProgress = false;
     checkCancelFlag = false;
@@ -394,8 +386,7 @@ Task::ReportResult GTest_TaskCheckState::report() {
     return ReportResult_Finished;
 }
 
-void GTest_TaskExec::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_TaskExec::init(XMLTestFormat *, const QDomElement &el) {
     taskContextName = el.attribute(OBJ_ATTR);
     if (taskContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);
@@ -416,9 +407,7 @@ Task::ReportResult GTest_TaskExec::report() {
     return ReportResult_Finished;
 }
 
-void GTest_TaskStateOrder::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_TaskStateOrder::init(XMLTestFormat *, const QDomElement &el) {
     serial_flag = true;
     subtask_num = 0;
     cancel_flag = false;
@@ -553,8 +542,7 @@ Task::ReportResult GTest_TaskStateOrder::report() {
     return ReportResult_Finished;
 }
 
-void GTest_Wait::init(U2::XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_Wait::init(U2::XMLTestFormat *, const QDomElement &el) {
     waitOk = false;
     condition = WaitCond_None;
     QString ms_str = el.attribute(DELAY_ATTR);

--- a/src/plugins/CoreTests/src/TextObjectTests.cpp
+++ b/src/plugins/CoreTests/src/TextObjectTests.cpp
@@ -33,9 +33,7 @@ namespace U2 {
 #define MUST_EXIST "must_exist"
 #define NEWLINES "newlines"
 
-void GTest_CheckStringExists::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CheckStringExists::init(XMLTestFormat *, const QDomElement &el) {
     objContextName = el.attribute(OBJ_ATTR);
     if (objContextName.isEmpty()) {
         failMissingValue(OBJ_ATTR);

--- a/src/plugins/annotator/src/AnnotatorTests.cpp
+++ b/src/plugins/annotator/src/AnnotatorTests.cpp
@@ -46,9 +46,7 @@ namespace U2 {
 #define RES_ATTR "result"
 #define CIRCULAR_ATTR "circular"
 
-void GTest_AnnotatorSearch::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_AnnotatorSearch::init(XMLTestFormat *, const QDomElement &el) {
     docName = el.attribute(DOC_ATTR);
     if (docName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -176,9 +174,7 @@ Task::ReportResult GTest_AnnotatorSearch::report() {
 //////////////////////////////////////////////////////////////////////////
 // GTest_PlasmidAutoAnnotation
 
-void GTest_CustomAutoAnnotation::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CustomAutoAnnotation::init(XMLTestFormat *, const QDomElement &el) {
     docName = el.attribute(DOC_ATTR);
     if (docName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -277,9 +273,7 @@ Task::ReportResult GTest_CustomAutoAnnotation::report() {
 #define ANN_NAME_ATTR "ann_name"
 #define EXPECTED_RESULT "exp_result"
 
-void GTest_GeneByGeneApproach::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_GeneByGeneApproach::init(XMLTestFormat *, const QDomElement &el) {
     docName = el.attribute(DOC_ATTR);
     if (docName.isEmpty()) {
         failMissingValue(DOC_ATTR);

--- a/src/plugins/api_tests/src/UnitTestSuite.cpp
+++ b/src/plugins/api_tests/src/UnitTestSuite.cpp
@@ -67,8 +67,7 @@ private:
     QMap<QString, QStringList> tests;
 };
 
-void UnitTestSuite::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void UnitTestSuite::init(XMLTestFormat *, const QDomElement &el) {
     GTestBuilder builder;
 
     passed = 0;

--- a/src/plugins/dna_export/src/DNAExportPluginTests.cpp
+++ b/src/plugins/dna_export/src/DNAExportPluginTests.cpp
@@ -50,9 +50,7 @@ namespace U2 {
 #define UNKNOWN_AMINO_2_GAP "unknown-amino-to-gap"
 #define TRANSLATION_FRAME "translation-frame"
 
-void GTest_ImportPhredQualityScoresTask::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_ImportPhredQualityScoresTask::init(XMLTestFormat *, const QDomElement &el) {
     QString buf = el.attribute(SEQLIST_ATTR);
     if (buf.isEmpty()) {
         failMissingValue(SEQLIST_ATTR);
@@ -100,9 +98,7 @@ void GTest_ImportPhredQualityScoresTask::prepare() {
     addSubTask(importTask);
 }
 
-void GTest_ExportNucleicToAminoAlignmentTask::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_ExportNucleicToAminoAlignmentTask::init(XMLTestFormat *, const QDomElement &el) {
     QString buf;
 
     buf = el.attribute(NUCL_ALIGN_URL_ATTR);

--- a/src/plugins/enzymes/src/EnzymesTests.cpp
+++ b/src/plugins/enzymes/src/EnzymesTests.cpp
@@ -40,8 +40,7 @@
 
 namespace U2 {
 
-void GTest_FindEnzymes::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_FindEnzymes::init(XMLTestFormat *, const QDomElement &el) {
     loadTask = nullptr;
     contextIsAdded = false;
 
@@ -235,8 +234,7 @@ void GTest_FindEnzymes::cleanup() {
 
 //////////////////////////////////////////////////////////////////////////
 
-void GTest_DigestIntoFragments::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_DigestIntoFragments::init(XMLTestFormat *, const QDomElement &el) {
     loadTask = nullptr;
 
     seqObjCtx = el.attribute("sequence");
@@ -246,7 +244,7 @@ void GTest_DigestIntoFragments::init(XMLTestFormat *tf, const QDomElement &el) {
     }
 
     QString isCircularBuf = el.attribute("circular");
-    isCircular = isCircularBuf == "true" ? true : false;
+    isCircular = isCircularBuf == "true";
 
     aObjCtx = el.attribute("annotation-table");
     if (aObjCtx.isEmpty()) {
@@ -327,9 +325,7 @@ QList<Task *> GTest_DigestIntoFragments::onSubTaskFinished(Task *subTask) {
 
 //////////////////////////////////////////////////////////////////////////
 
-void GTest_LigateFragments::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_LigateFragments::init(XMLTestFormat *, const QDomElement &el) {
     ligateTask = nullptr;
     contextAdded = false;
 

--- a/src/plugins/external_tool_support/src/bowtie/bowtie_tests/bowtieTests.cpp
+++ b/src/plugins/external_tool_support/src/bowtie/bowtie_tests/bowtieTests.cpp
@@ -70,8 +70,7 @@ namespace U2 {
 #define BEST_ATTR "best"
 #define ALL_ATTR "all"
 
-void GTest_Bowtie::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_Bowtie::init(XMLTestFormat *, const QDomElement &el) {
     bowtieTask = nullptr;
     indexName = "";
     readsFileName = "";

--- a/src/plugins/external_tool_support/src/bowtie2/bowtie2_tests/Bowtie2Tests.cpp
+++ b/src/plugins/external_tool_support/src/bowtie2/bowtie2_tests/Bowtie2Tests.cpp
@@ -30,9 +30,7 @@ namespace U2 {
 #define FILE3_ATTR "file3"
 #define IS_BAM_ATTR "isbam"
 
-void GTest_Bowtie2::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_Bowtie2::init(XMLTestFormat *, const QDomElement &el) {
     file1Url = el.attribute(FILE1_ATTR);
     if (file1Url.isEmpty()) {
         failMissingValue(FILE1_ATTR);

--- a/src/plugins/external_tool_support/src/bwa/bwa_tests/bwaTests.cpp
+++ b/src/plugins/external_tool_support/src/bwa/bwa_tests/bwaTests.cpp
@@ -74,8 +74,7 @@ namespace U2 {
 #define NON_ITERATIVE_MODE_ATTR "non-iterative-mode"
 #define ALG_NAME_ATTR "alg"
 
-void GTest_Bwa::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_Bwa::init(XMLTestFormat *, const QDomElement &el) {
     bwaTask = nullptr;
     indexName = "";
     readsFileName = "";

--- a/src/plugins/external_tool_support/src/hmmer/HmmerBuildTaskTest.cpp
+++ b/src/plugins/external_tool_support/src/hmmer/HmmerBuildTaskTest.cpp
@@ -233,9 +233,7 @@ static void setEvalueCalibrationOption(HmmerBuildSettings &settings, TaskStateIn
     settings.eft = l[4].toDouble();
 }
 
-void GTest_UHMMER3Build::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_UHMMER3Build::init(XMLTestFormat *, const QDomElement &el) {
     inFile = el.attribute(INPUT_FILE_TAG);
     outFile = el.attribute(OUTPUT_FILE_TAG);
     outputDir = el.attribute(OUTPUT_DIR_TAG);
@@ -319,9 +317,7 @@ const QByteArray DATE_STR = "DATE";
 const QByteArray NAME_STR = "NAME";
 const QByteArray HEADER_STR = "HMMER3/";
 
-void GTest_CompareHmmFiles::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CompareHmmFiles::init(XMLTestFormat *, const QDomElement &el) {
     filename1 = el.attribute(FILE1_NAME_TAG);
     filename2 = el.attribute(FILE2_NAME_TAG);
 

--- a/src/plugins/external_tool_support/src/hmmer/HmmerSearchTaskTest.cpp
+++ b/src/plugins/external_tool_support/src/hmmer/HmmerSearchTaskTest.cpp
@@ -153,9 +153,7 @@ void GTest_UHMM3Search::setSearchTaskSettings(HmmerSearchSettings &settings, con
     setUseBitCutoffsOption(settings.useBitCutoffs, el, GTest_UHMM3Search::USE_BIT_CUTOFFS_OPTION_TAG, si);
 }
 
-void GTest_UHMM3Search::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_UHMM3Search::init(XMLTestFormat *, const QDomElement &el) {
     hmmFilename = el.attribute(HMM_FILENAME_TAG);
 
     searchTask = nullptr;
@@ -344,9 +342,7 @@ static bool compareNumbers(T f1, T f2) {
     return ret;
 }
 
-void GTest_UHMM3SearchCompare::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_UHMM3SearchCompare::init(XMLTestFormat *, const QDomElement &el) {
     trueOutFilename = el.attribute(TRUE_OUT_FILE_TAG);
     actualOutFilename = el.attribute(ACTUAL_OUT_FILE_TAG);
 }

--- a/src/plugins/external_tool_support/src/hmmer/PhmmerSearchTaskTest.cpp
+++ b/src/plugins/external_tool_support/src/hmmer/PhmmerSearchTaskTest.cpp
@@ -57,9 +57,7 @@ static void setDoubleOption(double &to, const QString &str, TaskStateInfo &ti) {
     }
 }
 
-void GTest_UHMM3Phmmer::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_UHMM3Phmmer::init(XMLTestFormat *, const QDomElement &el) {
     phmmerTask = nullptr;
     queryFilename = el.attribute(QUERY_FILENAME_TAG);
     dbFilename = el.attribute(DB_FILENAME_TAG);
@@ -211,9 +209,7 @@ Task::ReportResult GTest_UHMM3Phmmer::report() {
 const QString GTest_UHMM3PhmmerCompare::ACTUAL_OUT_FILE_TAG = "actualOut";
 const QString GTest_UHMM3PhmmerCompare::TRUE_OUT_FILE_TAG = "trueOut";
 
-void GTest_UHMM3PhmmerCompare::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_UHMM3PhmmerCompare::init(XMLTestFormat *, const QDomElement &el) {
     trueOutFilename = el.attribute(TRUE_OUT_FILE_TAG);
     actualOutFilename = el.attribute(ACTUAL_OUT_FILE_TAG);
 }

--- a/src/plugins/external_tool_support/src/mrbayes/MrBayesTests.cpp
+++ b/src/plugins/external_tool_support/src/mrbayes/MrBayesTests.cpp
@@ -38,8 +38,7 @@ QList<XMLTestFactory *> MrBayesToolTests::createTestFactories() {
     return res;
 }
 
-void GTest_MrBayes::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_MrBayes::init(XMLTestFormat *, const QDomElement &el) {
     treeObjFromDoc = nullptr;
     task = nullptr;
     input = nullptr;

--- a/src/plugins/external_tool_support/src/phyml/PhyMLTests.cpp
+++ b/src/plugins/external_tool_support/src/phyml/PhyMLTests.cpp
@@ -45,8 +45,7 @@ QList<XMLTestFactory *> PhyMLToolTests::createTestFactories() {
     return res;
 }
 
-void GTest_PhyML::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_PhyML::init(XMLTestFormat *, const QDomElement &el) {
     treeObjFromDoc = nullptr;
     task = nullptr;
     input = nullptr;

--- a/src/plugins/external_tool_support/src/spades/SpadesTaskTest.cpp
+++ b/src/plugins/external_tool_support/src/spades/SpadesTaskTest.cpp
@@ -57,9 +57,7 @@ const QString GTest_SpadesTaskTest::UNTRUSTED_CONTIGS = "untrusted_contigs";
 const QString GTest_SpadesTaskTest::OUTPUT_DIR = "out";
 const QString GTest_SpadesTaskTest::DESIRED_PARAMETERS = "desired_parameters";
 
-void GTest_SpadesTaskTest::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_SpadesTaskTest::init(XMLTestFormat *, const QDomElement &el) {
     QVariantMap inputDataSettings;
     QString elementStr = el.attribute(SEQUENCING_PLATFORM);
     if (elementStr == "iontorrent") {
@@ -284,9 +282,7 @@ QList<Task *> GTest_SpadesTaskTest::onSubTaskFinished(Task *subTask) {
 const QString GTest_CheckYAMLFile::STRINGS_TO_CHECK = "strings_to_check";
 const QString GTest_CheckYAMLFile::INPUT_DIR = "input_dir";
 
-void GTest_CheckYAMLFile::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CheckYAMLFile::init(XMLTestFormat *, const QDomElement &el) {
     QVariantMap inputDataSettings;
     QString elementStr = el.attribute(STRINGS_TO_CHECK);
     if (elementStr.isEmpty()) {

--- a/src/plugins/orf_marker/src/ORFMarkerTests.cpp
+++ b/src/plugins/orf_marker/src/ORFMarkerTests.cpp
@@ -55,9 +55,7 @@ Translator::Translator(const U2SequenceObject *s, const QString &tid)
     }
 }
 
-void GTest_ORFMarkerTask::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_ORFMarkerTask::init(XMLTestFormat *, const QDomElement &el) {
     seqName = el.attribute(SEQ_ATTR);
     if (seqName.isEmpty()) {
         failMissingValue(SEQ_ATTR);
@@ -75,7 +73,7 @@ void GTest_ORFMarkerTask::init(XMLTestFormat *tf, const QDomElement &el) {
             }
             bool startOk, finishOk;
             int start = bounds.first().toInt(&startOk), finish = bounds.last().toInt(&finishOk);
-            if (startOk && finishOk != true) {
+            if (startOk && !finishOk) {
                 stateInfo.setError(QString("wrong value for %1").arg(EXPECTED_RESULTS_ATTR));
                 return;
             }

--- a/src/plugins/remote_blast/src/RemoteBLASTPluginTests.cpp
+++ b/src/plugins/remote_blast/src/RemoteBLASTPluginTests.cpp
@@ -28,9 +28,7 @@
 
 namespace U2 {
 
-void GTest_RemoteBLAST::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_RemoteBLAST::init(XMLTestFormat *, const QDomElement &el) {
     ao = nullptr;
     task = nullptr;
     sequence = el.attribute(SEQUENCE_ATTR);

--- a/src/plugins/repeat_finder/src/RepeatFinderTests.cpp
+++ b/src/plugins/repeat_finder/src/RepeatFinderTests.cpp
@@ -77,9 +77,7 @@ U2Region GTest_FindSingleSequenceRepeatsTask::parseRegion(const QString &n, cons
     return res;
 }
 
-void GTest_FindSingleSequenceRepeatsTask::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_FindSingleSequenceRepeatsTask::init(XMLTestFormat *, const QDomElement &el) {
     seq = el.attribute(SEQ_ATTR);
     if (seq.isEmpty()) {
         stateInfo.setError(QString("Value not found '%1'").arg(SEQ_ATTR));
@@ -302,9 +300,7 @@ void GTest_FindSingleSequenceRepeatsTask::run() {
 
 //---------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------
-void GTest_FindTandemRepeatsTask::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_FindTandemRepeatsTask::init(XMLTestFormat *, const QDomElement &el) {
     minD = el.attribute(MIND_ATTR, "-1").toInt();
     maxD = el.attribute(MAXD_ATTR, "-1").toInt();
 
@@ -439,9 +435,7 @@ U2Region GTest_FindRealTandemRepeatsTask::parseRegion(const QString &n, const QD
     return res;
 }
 
-void GTest_FindRealTandemRepeatsTask::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_FindRealTandemRepeatsTask::init(XMLTestFormat *, const QDomElement &el) {
     minD = el.attribute(MIND_ATTR, "-1").toInt();
     maxD = el.attribute(MAXD_ATTR, "-1").toInt();
 
@@ -566,9 +560,7 @@ void GTest_FindRealTandemRepeatsTask::run() {
 //---------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------
 
-void GTest_SArrayBasedFindTask::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_SArrayBasedFindTask::init(XMLTestFormat *, const QDomElement &el) {
     QString buf = el.attribute(RESULT_ATTR);
     if (buf.isEmpty()) {
         stateInfo.setError(QString("Value not found: '%1'").arg(RESULT_ATTR));

--- a/src/plugins/smith_waterman/src/SWTaskFactory.cpp
+++ b/src/plugins/smith_waterman/src/SWTaskFactory.cpp
@@ -45,12 +45,6 @@ Task *SWTaskFactory::getTaskInstance(const SmithWatermanSettings &config, const 
     return new SWAlgorithmTask(config, taskName, algType);
 }
 
-bool SWTaskFactory::isValidParameters(const SmithWatermanSettings &sWatermanConfig, SequenceWalkerSubtask *t) const {
-    Q_UNUSED(sWatermanConfig);
-    Q_UNUSED(t);
-    return true;  // not realized
-}
-
 PairwiseAlignmentSmithWatermanTaskFactory::PairwiseAlignmentSmithWatermanTaskFactory(SW_AlgType _algType)
     : AbstractAlignmentTaskFactory(), algType(_algType) {
 }
@@ -67,7 +61,7 @@ AbstractAlignmentTask *PairwiseAlignmentSmithWatermanTaskFactory::getTaskInstanc
     SAFE_POINT(false == settings->inNewWindow || false == settings->resultFileName.isEmpty(),
                "Pairwise alignment: incorrect settings, empty output file name",
                nullptr);
-    if (settings->inNewWindow == true) {
+    if (settings->inNewWindow) {
         settings->reportCallback = new SmithWatermanReportCallbackMAImpl(settings->resultFileName.dirPath() + "/",
                                                                          settings->resultFileName.baseFileName(),
                                                                          settings->firstSequenceRef,

--- a/src/plugins/smith_waterman/src/SWTaskFactory.h
+++ b/src/plugins/smith_waterman/src/SWTaskFactory.h
@@ -44,7 +44,6 @@ public:
     virtual Task *getTaskInstance(const SmithWatermanSettings &config, const QString &taskName) const;
 
 private:
-    bool isValidParameters(const SmithWatermanSettings &sWatermanConfig, SequenceWalkerSubtask *t) const;  // not realized
     SW_AlgType algType;
 };
 

--- a/src/plugins/smith_waterman/src/SmithWatermanTests.cpp
+++ b/src/plugins/smith_waterman/src/SmithWatermanTests.cpp
@@ -295,9 +295,7 @@ Task::ReportResult GTest_SmithWatermnan::report() {
     return ReportResult_Finished;
 }
 
-void GTest_SmithWatermnanPerf::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_SmithWatermnanPerf::init(XMLTestFormat *, const QDomElement &el) {
     searchSeqDocName = el.attribute(FILE_FASTA_CONTAIN_SEQUENCE_ATTR);
     if (searchSeqDocName.isEmpty()) {
         failMissingValue(FILE_FASTA_CONTAIN_SEQUENCE_ATTR);

--- a/src/plugins/weight_matrix/src/PMatrixFormat.cpp
+++ b/src/plugins/weight_matrix/src/PMatrixFormat.cpp
@@ -83,7 +83,6 @@ FormatCheckResult PFMatrixFormat::checkRawData(const QByteArray &rawData, const 
 Document *PFMatrixFormat::loadDocument(IOAdapter *io, const U2DbiRef &dbiRef, const QVariantMap &fs, U2OpStatus &os) {
     DbiOperationsBlock opBlock(dbiRef, os);
     CHECK_OP(os, nullptr);
-    Q_UNUSED(opBlock);
 
     QList<GObject *> objs;
     IOAdapterFactory *iof = AppContext::getIOAdapterRegistry()->getIOAdapterFactoryById(io->getAdapterId());
@@ -211,7 +210,6 @@ FormatCheckResult PWMatrixFormat::checkRawData(const QByteArray &rawData, const 
 Document *PWMatrixFormat::loadDocument(IOAdapter *io, const U2DbiRef &dbiRef, const QVariantMap &fs, U2OpStatus &os) {
     DbiOperationsBlock opBlock(dbiRef, os);
     CHECK_OP(os, nullptr);
-    Q_UNUSED(opBlock);
 
     QList<GObject *> objs;
     IOAdapterFactory *iof = AppContext::getIOAdapterRegistry()->getIOAdapterFactoryById(io->getAdapterId());

--- a/src/plugins_3rdparty/hmm2/src/u_tests/uhmmerTests.cpp
+++ b/src/plugins_3rdparty/hmm2/src/u_tests/uhmmerTests.cpp
@@ -80,9 +80,7 @@ class GObject;
 
 /* TRANSLATOR U2::GTest */
 
-void GTest_uHMMERSearch::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_uHMMERSearch::init(XMLTestFormat *, const QDomElement &el) {
     evalueCutoff = 10;
     number_of_seq = 1;
     domEvalueCutoff = 0.9999999;
@@ -300,9 +298,7 @@ void GTest_uHMMERSearch::cleanup() {
 //**********uHMMER Build*******************************************************
 //*****************************************************************************
 
-void GTest_uHMMERBuild::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_uHMMERBuild::init(XMLTestFormat *, const QDomElement &el) {
     QString inFile = el.attribute(IN_FILE_NAME_ATTR);
     if (inFile.isEmpty()) {
         failMissingValue(IN_FILE_NAME_ATTR);
@@ -378,9 +374,7 @@ void GTest_uHMMERBuild::cleanup() {
     XmlTest::cleanup();
 }
 
-void GTest_hmmCompare::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_hmmCompare::init(XMLTestFormat *, const QDomElement &el) {
     file1Name = el.attribute(IN_FILE1_NAME_ATTR);
     if (file1Name.isEmpty()) {
         failMissingValue(IN_FILE1_NAME_ATTR);
@@ -478,9 +472,7 @@ Task::ReportResult GTest_hmmCompare::report() {
 //**********uHMMER Calibrate***************************************************
 //*****************************************************************************
 
-void GTest_uHMMERCalibrate::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_uHMMERCalibrate::init(XMLTestFormat *, const QDomElement &el) {
     calibrateTask = NULL;
 
     QString hmmFile = el.attribute(HMM_FILE_ATTR);

--- a/src/plugins_3rdparty/phylip/src/PhylipPluginTests.cpp
+++ b/src/plugins_3rdparty/phylip/src/PhylipPluginTests.cpp
@@ -48,8 +48,7 @@ QList<XMLTestFactory *> PhylipPluginTests::createTestFactories() {
     return res;
 }
 
-void GTest_NeighborJoin::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_NeighborJoin::init(XMLTestFormat *, const QDomElement &el) {
     treeObjFromDoc = nullptr;
     task = nullptr;
     input = nullptr;

--- a/src/plugins_3rdparty/primer3/src/Primer3Tests.cpp
+++ b/src/plugins_3rdparty/primer3/src/Primer3Tests.cpp
@@ -125,9 +125,7 @@ PrimerPair readPrimerPair(QDomElement element, QString suffix) {
 }
 }  // namespace
 
-void GTest_Primer3::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_Primer3::init(XMLTestFormat *, const QDomElement &el) {
     settings.setIncludedRegion(U2Region(0, -1));
 
     QString buf;

--- a/src/plugins_3rdparty/sitecon/src/DIPropertiesTests.cpp
+++ b/src/plugins_3rdparty/sitecon/src/DIPropertiesTests.cpp
@@ -30,9 +30,7 @@ namespace U2 {
 #define EXPECTED_AVE_ATTR "exp_ave"
 #define EXPECTED_SDEV_ATTR "exp_sdev"
 
-void GTest_DiPropertySiteconCheckAttribs::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_DiPropertySiteconCheckAttribs::init(XMLTestFormat *, const QDomElement &el) {
     key = el.attribute(DI_KEY_ATTR);
     if (key.isEmpty()) {
         failMissingValue(DI_KEY_ATTR);

--- a/src/plugins_3rdparty/sitecon/src/SiteconAlgorithmTests.cpp
+++ b/src/plugins_3rdparty/sitecon/src/SiteconAlgorithmTests.cpp
@@ -54,9 +54,7 @@ namespace U2 {
 #define STRAND_ATTR "strand"
 #define TRESH_ATTR "treshhold"
 
-void GTest_CalculateACGTContent::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CalculateACGTContent::init(XMLTestFormat *, const QDomElement &el) {
     docName = el.attribute(DOC_ATTR);
     if (docName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -124,9 +122,7 @@ Task::ReportResult GTest_CalculateACGTContent::report() {
     return ReportResult_Finished;
 }
 
-void GTest_CalculateDispersionAndAverage::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CalculateDispersionAndAverage::init(XMLTestFormat *, const QDomElement &el) {
     QStringList propsList = el.attribute(PROPERTIES_INDEXES).split(QRegExp("\\,")),
                 diPosStrList = el.attribute(DINUCLEOTIDE_POSITIONS).split(QRegExp("\\,")),
                 expectedStrList = el.attribute(EXPECTED_RESULTS_ATTR).split(QRegExp("\\,"));
@@ -236,9 +232,7 @@ Task::ReportResult GTest_CalculateDispersionAndAverage::report() {
     return ReportResult_Finished;
 }
 
-void GTest_CalculateFirstTypeError::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CalculateFirstTypeError::init(XMLTestFormat *, const QDomElement &el) {
     docName = el.attribute(DOC_ATTR);
     if (docName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -317,9 +311,7 @@ Task::ReportResult GTest_CalculateFirstTypeError::report() {
     return ReportResult_Finished;
 }
 
-void GTest_CalculateSecondTypeError::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_CalculateSecondTypeError::init(XMLTestFormat *, const QDomElement &el) {
     docName = el.attribute(DOC_ATTR);
     if (docName.isEmpty()) {
         failMissingValue(DOC_ATTR);
@@ -406,9 +398,7 @@ Task::ReportResult GTest_CalculateSecondTypeError::report() {
     return ReportResult_Finished;
 }
 
-void GTest_SiteconSearchTask::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_SiteconSearchTask::init(XMLTestFormat *, const QDomElement &el) {
     seqName = el.attribute(SEQNAME_ATTR);
     if (seqName.isEmpty()) {
         failMissingValue(SEQNAME_ATTR);

--- a/src/plugins_3rdparty/umuscle/src/umuscle_tests/umuscleTests.cpp
+++ b/src/plugins_3rdparty/umuscle/src/umuscle_tests/umuscleTests.cpp
@@ -81,9 +81,7 @@ struct GTestBoolProperty {
     failMissingValue((ATTR));\
     return;}
 
-void GTest_uMuscle::init(XMLTestFormat *tf, const QDomElement& el) {
-    Q_UNUSED(tf);
-
+void GTest_uMuscle::init(XMLTestFormat *, const QDomElement& el) {
     ctxAdded = false;
     ma_result = nullptr;
     refineOnly = false;
@@ -215,9 +213,7 @@ void GTest_uMuscle::cleanup() {
     XmlTest::cleanup();
 }
 
-void GTest_CompareMAlignment::init(XMLTestFormat *tf, const QDomElement& el) {
-    Q_UNUSED(tf);
-
+void GTest_CompareMAlignment::init(XMLTestFormat *, const QDomElement& el) {
     doc1CtxName = el.attribute(DOC1_ATTR);
     if (doc1CtxName.isEmpty()) {
         failMissingValue(DOC1_ATTR);
@@ -427,8 +423,7 @@ Task::ReportResult GTest_uMuscleAddUnalignedSequenceToProfile::report() {
     return ReportResult_Finished;
 }
 
-void GTest_Muscle_Load_Align_QScore::init(XMLTestFormat *tf, const QDomElement& el) {
-    Q_UNUSED(tf);
+void GTest_Muscle_Load_Align_QScore::init(XMLTestFormat *, const QDomElement& el) {
     inFileURL = el.attribute(IN_FILE_NAME_ATTR);
     stateInfo.progress = 0;
     loadTask1 = nullptr;
@@ -837,8 +832,7 @@ Task::ReportResult GTest_Muscle_Load_Align_Compare::report() {
 GTest_Muscle_Load_Align_Compare::~GTest_Muscle_Load_Align_Compare() {
 }
 
-void GTest_uMusclePacketTest::init(U2::XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
+void GTest_uMusclePacketTest::init(U2::XMLTestFormat *, const QDomElement &el) {
     int nThread = qMax(0, getEnv()->getVar("NUM_THREADS").toInt());
     setMaxParallelSubtasks(nThread);
 

--- a/src/ugeneui/src/project_support/ProjectTasksGui.cpp
+++ b/src/ugeneui/src/project_support/ProjectTasksGui.cpp
@@ -147,12 +147,12 @@ void SaveProjectTask::prepare() {
 
         QWidget *mainWindow = AppContext::getMainWindow()->getQMainWindow();
         int code;
-        if (silentSave == true) {
+        if (silentSave) {
             code = QDialogButtonBox::Yes;
         } else {
             code = savedSaveProjectState;
             if (QDialogButtonBox::NoButton == savedSaveProjectState) {
-                // QMessageBox::NoButton is a special invalid button state, represents that no saved choise was made
+                // QMessageBox::NoButton is a special invalid button state, represents that no saved choice was made
                 QObjectScopedPointer<SaveProjectDialogController> saveProjectDialog = new SaveProjectDialogController(mainWindow);
                 code = saveProjectDialog->exec();
                 CHECK_EXT(!saveProjectDialog.isNull(), setError("dialog is NULL"), );
@@ -161,7 +161,7 @@ void SaveProjectTask::prepare() {
                     code = QDialogButtonBox::Cancel;
                 }
 
-                if (QDialogButtonBox::Cancel != code && true == saveProjectDialog->dontAskCheckBox->isChecked()) {
+                if (QDialogButtonBox::Cancel != code && saveProjectDialog->dontAskCheckBox->isChecked()) {
                     AppContext::getAppSettings()->getUserAppsSettings()->setAskToSaveProject(code);
                 }
             }
@@ -462,9 +462,7 @@ QList<XMLTestFactory *> ProjectTests::createTestFactories() {
     return res;
 }
 
-void GTest_ExportProject::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_ExportProject::init(XMLTestFormat *, const QDomElement &el) {
     exportTask = nullptr;
     url = env->getVar("TEMP_DATA_DIR") + el.attribute("url");
 }
@@ -529,9 +527,7 @@ bool GTest_ExportProject::removeDir(const QDir &aDir) {
     }
     return (has_err);
 }
-void GTest_UnloadProject::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_UnloadProject::init(XMLTestFormat *, const QDomElement &el) {
     QString packedList = el.attribute("documents");
     if (packedList.isEmpty()) {
         // document list can be empty!
@@ -550,9 +546,7 @@ void GTest_UnloadProject::prepare() {
     }
 }
 
-void GTest_LoadDocumentFromProject::init(XMLTestFormat *tf, const QDomElement &el) {
-    Q_UNUSED(tf);
-
+void GTest_LoadDocumentFromProject::init(XMLTestFormat *, const QDomElement &el) {
     documentFileName = el.attribute("document");
     contextAdded = false;
 }


### PR DESCRIPTION
The patch is trivial - it removes not-needed Q_UNUSED statements, so such cleanup won't appear in other patches as side effect.

No other code/UI/behavior changes in this patch.