### PR TITLE
Remove all warnings supression form GCC build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,10 +40,11 @@ set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -D_DEBUG")
 if (CMAKE_COMPILER_IS_GNUCXX)
     string(CONCAT GCC_WARNING_FLAGS
             " -Wall"
+            " -Werror=deprecated-copy" # Requires GCC 9.1+
             " -Werror=maybe-uninitialized"
             " -Werror=parentheses"
-            " -Werror=shadow=local" # Requires GCC 7+
             " -Werror=return-type"
+            " -Werror=shadow=local" # Requires GCC 7.1+
             " -Werror=uninitialized"
             " -Werror=unused-parameter"
             " -Werror=unused-variable"

--- a/src/corelibs/U2Core/src/datatype/AnnotationData.cpp
+++ b/src/corelibs/U2Core/src/datatype/AnnotationData.cpp
@@ -59,15 +59,6 @@ const QVector<U2Region> &AnnotationData::getRegions() const {
     return location->regions;
 }
 
-AnnotationData &AnnotationData::operator=(const AnnotationData &a) {
-    type = a.type;
-    name = a.name;
-    location = a.location;
-    qualifiers = a.qualifiers;
-    caseAnnotation = a.caseAnnotation;
-    return *this;
-}
-
 bool AnnotationData::operator==(const AnnotationData &other) const {
     if (this->type != other.type) {
         return false;

--- a/src/corelibs/U2Core/src/datatype/AnnotationData.h
+++ b/src/corelibs/U2Core/src/datatype/AnnotationData.h
@@ -37,7 +37,7 @@ class U2CORE_EXPORT AnnotationData : public QSharedData {
 public:
     AnnotationData();
 
-    AnnotationData &operator=(const AnnotationData &a);
+    AnnotationData(const AnnotationData &) = default;
 
     bool operator==(const AnnotationData &other) const;
     bool operator!=(const AnnotationData &other) const;

--- a/src/corelibs/U2Core/src/datatype/BioStruct3D.cpp
+++ b/src/corelibs/U2Core/src/datatype/BioStruct3D.cpp
@@ -47,15 +47,6 @@ BioStruct3D::BioStruct3D()
     transform.loadIdentity();
 }
 
-BioStruct3D::BioStruct3D(const BioStruct3D &other)
-    : moleculeMap(other.moleculeMap), modelMap(other.modelMap),
-      secondaryStructures(other.secondaryStructures),
-      interMolecularBonds(other.interMolecularBonds),
-      descr(other.descr), pdbId(other.pdbId),
-      radius(other.radius), rotationCenter(other.rotationCenter),
-      transform(other.transform) {
-}
-
 void BioStruct3D::calcCenterAndMaxDistance() {
     Vector3D siteSum;
     Vector3D center;

--- a/src/corelibs/U2Core/src/datatype/BioStruct3D.h
+++ b/src/corelibs/U2Core/src/datatype/BioStruct3D.h
@@ -203,7 +203,7 @@ public:
 public:
     BioStruct3D();
     /** This is not deep copy constructor */
-    BioStruct3D(const BioStruct3D &other);
+    BioStruct3D(const BioStruct3D &other) = default;
 
     QMap<int, SharedMolecule> moleculeMap;
     QMap<int, AtomCoordSet> modelMap;

--- a/src/corelibs/U2Core/src/datatype/Matrix44.cpp
+++ b/src/corelibs/U2Core/src/datatype/Matrix44.cpp
@@ -37,19 +37,6 @@ Matrix44::Matrix44(const float *data)
     }
 }
 
-Matrix44::Matrix44(const Matrix44 &other)
-    : m(other.m) {
-}
-
-Matrix44 &Matrix44::operator=(const Matrix44 &other) {
-    m = other.m;
-    return *this;
-}
-
-void Matrix44::loadZero() {
-    m.fill(0.0);
-}
-
 void Matrix44::loadIdentity() {
     m.fill(0.0);
     for (int i = 0; i < 4; ++i) {

--- a/src/corelibs/U2Core/src/datatype/Matrix44.h
+++ b/src/corelibs/U2Core/src/datatype/Matrix44.h
@@ -32,11 +32,8 @@ class U2CORE_EXPORT Matrix44 {
 public:
     Matrix44();
     Matrix44(const float *data);
-    Matrix44(const Matrix44 &other);
+    Matrix44(const Matrix44 &) = default;
 
-    Matrix44 &operator=(const Matrix44 &other);
-
-    void loadZero();
     void loadIdentity();
 
     void transpose();

--- a/src/corelibs/U2Core/src/datatype/PFMatrix.cpp
+++ b/src/corelibs/U2Core/src/datatype/PFMatrix.cpp
@@ -67,7 +67,7 @@ QMap<QString, QString> JasparInfo::getProperties() const {
     return properties;
 }
 
-PFMatrix::PFMatrix(const MultipleSequenceAlignment &align, PFMatrixType _type)
+PFMatrix::PFMatrix(const MultipleSequenceAlignment &align, const PFMatrixType& _type)
     : type(_type) {
     assert(align->hasEqualLength());
     const int sequenceLength = align->getMsaRows().first()->getUngappedLength();
@@ -97,7 +97,7 @@ PFMatrix::PFMatrix(const MultipleSequenceAlignment &align, PFMatrixType _type)
     }
 }
 
-PFMatrix::PFMatrix(const QList<DNASequence *> &seq, PFMatrixType _type)
+PFMatrix::PFMatrix(const QList<DNASequence *> &seq, const PFMatrixType& _type)
     : type(_type) {
     assert(seq.length() > 0);
 

--- a/src/corelibs/U2Core/src/datatype/PFMatrix.h
+++ b/src/corelibs/U2Core/src/datatype/PFMatrix.h
@@ -70,13 +70,12 @@ public:
     PFMatrix(const QVarLengthArray<int> &data, const PFMatrixType type);
 
     // create matrix from alignment (without gaps)
-    PFMatrix(const MultipleSequenceAlignment &data, const PFMatrixType type);
+    PFMatrix(const MultipleSequenceAlignment &data, const PFMatrixType& type);
 
     // create matrix from set of sequences with equal length
-    PFMatrix(const QList<DNASequence *> &data, const PFMatrixType type);
+    PFMatrix(const QList<DNASequence *> &data, const PFMatrixType& type);
 
-    PFMatrix(const PFMatrix &m)
-        : data(m.data), length(m.length), type(m.type), info(m.info) {};
+    PFMatrix(const PFMatrix &m) = default;
 
     // get internal index of position in 1-dimensional array
     int index(int row, int column) const;

--- a/src/corelibs/U2Core/src/datatype/U2Location.h
+++ b/src/corelibs/U2Core/src/datatype/U2Location.h
@@ -133,6 +133,7 @@ public:
     U2Location(U2LocationData *l)
         : d(l) {
     }
+    U2Location(const U2Location &) = default;
 
     U2LocationData &operator*() {
         return *d;

--- a/src/corelibs/U2Core/src/datatype/U2Type.cpp
+++ b/src/corelibs/U2Core/src/datatype/U2Type.cpp
@@ -31,20 +31,8 @@ U2Entity::U2Entity(const U2DataId &id)
     : id(id) {
 }
 
-U2Entity::U2Entity(const U2Entity &other)
-    : id(other.id) {
-}
-
-U2Entity::~U2Entity() {
-}
-
 bool U2Entity::hasValidId() const {
     return !id.isEmpty();
-}
-
-U2Entity U2Entity::operator=(const U2Entity &other) {
-    id = other.id;
-    return *this;
 }
 
 bool U2Entity::operator==(const U2Entity &other) const {

--- a/src/corelibs/U2Core/src/datatype/U2Type.h
+++ b/src/corelibs/U2Core/src/datatype/U2Type.h
@@ -170,13 +170,11 @@ public:
 class U2CORE_EXPORT U2Entity {
 public:
     U2Entity(const U2DataId &id = U2DataId());
-    U2Entity(const U2Entity &other);
+    U2Entity(const U2Entity &) = default;
 
-    virtual ~U2Entity();
+    virtual ~U2Entity() = default;
 
     bool hasValidId() const;
-
-    U2Entity operator=(const U2Entity &other);
 
     bool operator==(const U2Entity &other) const;
     bool operator!=(const U2Entity &other) const;

--- a/src/corelibs/U2Core/src/datatype/Vector3D.cpp
+++ b/src/corelibs/U2Core/src/datatype/Vector3D.cpp
@@ -33,19 +33,6 @@ Vector3D::Vector3D(double xi, double yi, double zi) {
     z = zi;
 }
 
-Vector3D::Vector3D(const Vector3D &v) {
-    x = v.x;
-    y = v.y;
-    z = v.z;
-}
-
-Vector3D &Vector3D::operator=(const Vector3D &v) {
-    x = v.x;
-    y = v.y;
-    z = v.z;
-    return *this;
-}
-
 void Vector3D::set(double xs, double ys, double zs) {
     x = xs;
     y = ys;

--- a/src/corelibs/U2Core/src/datatype/Vector3D.h
+++ b/src/corelibs/U2Core/src/datatype/Vector3D.h
@@ -35,8 +35,8 @@ public:
     double x, y, z;
 
     explicit Vector3D(double xi = 0.0, double yi = 0.0, double zi = 0.0);
-    Vector3D(const Vector3D &v);
-    Vector3D &operator=(const Vector3D &v);
+    Vector3D(const Vector3D &) = default;
+
     bool operator==(const Vector3D &other) const;
     bool operator!=(const Vector3D &other) const;
     double &operator[](unsigned int i);

--- a/src/corelibs/U2Core/src/globals/GUrl.cpp
+++ b/src/corelibs/U2Core/src/globals/GUrl.cpp
@@ -125,17 +125,12 @@ GUrl::GUrl(const QString &_urlString) {
 }
 
 // constructs url specified by string. The type provided as param
-GUrl::GUrl(const QString &_urlString, const GUrlType _type) {
+GUrl::GUrl(const QString &_urlString, const GUrlType& _type) {
     urlString = _urlString;
     type = _type;
     if (type == GUrl_File) {
         urlString = makeFilePathCanonical(urlString);
     }
-}
-
-GUrl::GUrl(const GUrl &anotherUrl) {
-    urlString = anotherUrl.getURLString();
-    type = anotherUrl.getType();
 }
 
 bool GUrl::operator==(const GUrl &url) const {

--- a/src/corelibs/U2Core/src/globals/GUrl.h
+++ b/src/corelibs/U2Core/src/globals/GUrl.h
@@ -63,9 +63,9 @@ public:
     GUrl(const QString &urlString);
 
     // constructs url specified by string. The type provided as param
-    GUrl(const QString &urlString, const GUrlType type);
+    GUrl(const QString &urlString, const GUrlType& type);
 
-    GUrl(const GUrl &anotherUrl);
+    GUrl(const GUrl &url) = default;
 
     bool operator==(const GUrl &url) const;
 

--- a/src/corelibs/U2Core/src/globals/disable-warnings.h
+++ b/src/corelibs/U2Core/src/globals/disable-warnings.h
@@ -34,10 +34,11 @@
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wpragmas"  // Ignore all unknown (for example when an old GCC is used) pragmas below.
 // All warnings in the list below should be sorted by name.
-// Warnings that require gcc compiler > 5.4 should be enabled with a gcc version check.
+// Warnings that require GCC compiler > 5.4 should be enabled in qmake file with a GCC version check.
 #    pragma GCC diagnostic ignored "-Wbool-compare"
 #    pragma GCC diagnostic ignored "-Wclass-memaccess"
 #    pragma GCC diagnostic ignored "-Wdeprecated"
+#    pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #    pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #    pragma GCC diagnostic ignored "-Wimplicit-int-float-conversion"
 #    pragma GCC diagnostic ignored "-Wmaybe-uninitialized"

--- a/src/corelibs/U2Core/src/util/U1AnnotationUtils.cpp
+++ b/src/corelibs/U2Core/src/util/U1AnnotationUtils.cpp
@@ -53,10 +53,6 @@ AnnotatedRegion::AnnotatedRegion(Annotation *annotation, int regionIdx)
     : annotation(annotation), regionIdx(regionIdx) {
 }
 
-AnnotatedRegion::AnnotatedRegion(const AnnotatedRegion &annRegion)
-    : annotation(annRegion.annotation), regionIdx(annRegion.regionIdx) {
-}
-
 QList<QVector<U2Region>> U1AnnotationUtils::fixLocationsForReplacedRegion(const U2Region &region2Remove, qint64 region2InsertLength, const QVector<U2Region> &original, AnnotationStrategyForResize s) {
     QList<QVector<U2Region>> res;
     const qint64 dLen = region2InsertLength - region2Remove.length;

--- a/src/corelibs/U2Core/src/util/U1AnnotationUtils.h
+++ b/src/corelibs/U2Core/src/util/U1AnnotationUtils.h
@@ -43,7 +43,7 @@ class U2CORE_EXPORT AnnotatedRegion {
 public:
     AnnotatedRegion();
     AnnotatedRegion(Annotation *annotation, int regionIdx);
-    AnnotatedRegion(const AnnotatedRegion &annRegion);
+    AnnotatedRegion(const AnnotatedRegion &annRegion) = default;
 
 public:
     Annotation *annotation;

--- a/src/corelibs/U2View/src/ov_sequence/annot_highlight/AnnotHighlightWidget.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/annot_highlight/AnnotHighlightWidget.cpp
@@ -225,7 +225,7 @@ bool AnnotHighlightWidget::findFirstAnnotatedRegionAfterPos(AnnotatedRegion &ann
 
     QList<AnnotatedRegion> regionsAtTheSamePosition = getAllAnnotatedRegionsByStartPos(pos);
     if (!regionsAtTheSamePosition.isEmpty()) {
-        annRegion = regionsAtTheSamePosition[isForward ? 0 : (regionsAtTheSamePosition.size() - 1)];
+        annRegion = regionsAtTheSamePosition[isForward ? 0 : regionsAtTheSamePosition.size() - 1];
         return true;
     }
 

--- a/src/plugins/biostruct3d_view/src/GraphicUtils.cpp
+++ b/src/plugins/biostruct3d_view/src/GraphicUtils.cpp
@@ -55,12 +55,6 @@ Color4f::Color4f(const QColor &qc) {
     color[3] = qc.alphaF();
 }
 
-Color4f::Color4f(const Color4f &c) {
-    for (int i = 0; i < 4; ++i) {
-        color[i] = c.color[i];
-    }
-}
-
 float Color4f::operator[](unsigned int i) const {
     assert(i < 4);
     return color[i];

--- a/src/plugins/biostruct3d_view/src/GraphicUtils.h
+++ b/src/plugins/biostruct3d_view/src/GraphicUtils.h
@@ -52,7 +52,7 @@ private:
 public:
     Color4f();
     Color4f(float r, float g, float b, float a = 1.0);
-    Color4f(const Color4f &c);
+    Color4f(const Color4f &c) = default;
     Color4f(const QColor &qc);
 
     float operator[](unsigned int i) const;

--- a/src/plugins/biostruct3d_view/src/deprecated/GraphicUtils.cpp
+++ b/src/plugins/biostruct3d_view/src/deprecated/GraphicUtils.cpp
@@ -57,12 +57,6 @@ Color4f::Color4f(const QColor &qc) {
     color[3] = qc.alphaF();
 }
 
-Color4f::Color4f(const Color4f &c) {
-    for (int i = 0; i < 4; ++i) {
-        color[i] = c.color[i];
-    }
-}
-
 float Color4f::operator[](unsigned int i) const {
     assert(i < 4);
     return color[i];

--- a/src/plugins/biostruct3d_view/src/deprecated/GraphicUtils.h
+++ b/src/plugins/biostruct3d_view/src/deprecated/GraphicUtils.h
@@ -51,7 +51,7 @@ private:
 public:
     Color4f();
     Color4f(float r, float g, float b, float a = 1.0);
-    Color4f(const Color4f &c);
+    Color4f(const Color4f &c) = default;
     Color4f(const QColor &qc);
 
     float operator[](unsigned int i) const;

--- a/src/plugins/dbi_bam/src/LoadBamInfoTask.h
+++ b/src/plugins/dbi_bam/src/LoadBamInfoTask.h
@@ -36,9 +36,7 @@ public:
     BAMInfo()
         : _hasIndex(false), unmappedSelected(false) {
     }
-    BAMInfo(const BAMInfo &src)
-        : header(src.header), selected(src.selected), index(src.index), _hasIndex(src._hasIndex), unmappedSelected(src.unmappedSelected) {
-    }
+    BAMInfo(const BAMInfo &src) = default;
 
     inline QList<bool> &getSelected() {
         return selected;
@@ -58,7 +56,7 @@ public:
     inline const Header &getHeader() {
         return header;
     }
-    inline bool isUnmappedSelected() {
+    inline bool isUnmappedSelected() const {
         return unmappedSelected;
     }
     void setIndex(Index &index) {


### PR DESCRIPTION
Two warning suppression (-Wno-deprecated-copy, -Wno-deprecated-declarations) were removed and all related issues in UGENE code were fixed.

I also made "warnings-as-errors" mode configurable. Now it is optional and by default UGENE build does not use "warnings-as-errors" mode. 

When we use this mode by default there is a chance that a new GCC compiler will find a new warning in our own or even in untested (by us) QT code that will finally cause UGENE build to fail. 

Now this is not possible: warnings-as-errors will be enabled only in our local Teamcity build.

In CMake build warnings-as-errors are enabled by default as it was before: this is an unofficial development tool, so I see no problem here.