### PR TITLE
Optimize version handling in build files and sources

### DIFF
--- a/src/corelibs/U2Core/src/globals/NetworkConfiguration.cpp
+++ b/src/corelibs/U2Core/src/globals/NetworkConfiguration.cpp
@@ -156,11 +156,7 @@ QSsl::SslProtocol NetworkConfiguration::getSslProtocol() const {
     } else if (sslConfig.currentProtocol == SslConfig::SSLV3) {
         return QSsl::SslV3;
     } else if (sslConfig.currentProtocol == SslConfig::TLSV1) {
-#    if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
         return QSsl::TlsV1_0;
-#    else
-        return QSsl::TlsV1;
-#    endif
     } else {
         return QSsl::SslV3;
     }

--- a/src/corelibs/U2Core/src/globals/global.h
+++ b/src/corelibs/U2Core/src/globals/global.h
@@ -201,14 +201,4 @@ inline bool isOsUnix() {
 #endif
 }
 
-/** Backport of qAsConst for QT < 5.7.0. */
-#if (QT_VERSION < QT_VERSION_CHECK(5, 7, 0))
-template<typename T>
-Q_DECL_CONSTEXPR typename std::add_const<T>::type &qAsConst(T &t) noexcept {
-    return t;
-}
-template<typename T>
-void qAsConst(const T &&) = delete;
-#endif
-
 #endif

--- a/src/corelibs/U2Formats/src/mysql_dbi/util/MysqlAssemblyUtils.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/util/MysqlAssemblyUtils.cpp
@@ -207,21 +207,6 @@ void MysqlAssemblyUtils::unpackData(const QByteArray &packedData, U2AssemblyRead
         os.setError(err);
     }
 }
-#if (QT_VERSION < 0x050400)  // Qt 5.4
-namespace {
-int removeAll(QVector<U2CigarOp> *vector, const U2CigarOp &t) {
-    const QVector<U2CigarOp>::const_iterator ce = vector->cend(), cit = std::find(vector->cbegin(), ce, t);
-    if (cit == ce)
-        return 0;
-    // next operation detaches, so ce, cit may become invalidated:
-    const int firstFoundIdx = std::distance(vector->cbegin(), cit);
-    const QVector<U2CigarOp>::iterator e = vector->end(), it = std::remove(vector->begin() + firstFoundIdx, e, t);
-    const int result = std::distance(it, e);
-    vector->erase(it, e);
-    return result;
-}
-}  // namespace
-#endif
 
 void MysqlAssemblyUtils::calculateCoverage(U2SqlQuery &q, const U2Region &r, U2AssemblyCoverageStat &coverage, U2OpStatus &os) {
     int csize = coverage.size();
@@ -249,15 +234,9 @@ void MysqlAssemblyUtils::calculateCoverage(U2SqlQuery &q, const U2Region &r, U2A
         foreach (const U2CigarToken &cigar, read->cigar) {
             cigarVector += QVector<U2CigarOp>(cigar.count, cigar.op);
         }
-#if (QT_VERSION < 0x050400)  // Qt 5.4
-        removeAll(&cigarVector, U2CigarOp_I);
-        removeAll(&cigarVector, U2CigarOp_S);
-        removeAll(&cigarVector, U2CigarOp_P);
-#else
         cigarVector.removeAll(U2CigarOp_I);
         cigarVector.removeAll(U2CigarOp_S);
         cigarVector.removeAll(U2CigarOp_P);
-#endif
         if (r.startPos > startPos) {
             cigarVector = cigarVector.mid(r.startPos - startPos);  // cut unneeded cigar string
         }
@@ -287,15 +266,9 @@ void MysqlAssemblyUtils::addToCoverage(U2AssemblyCoverageImportInfo &ii, const U
     foreach (const U2CigarToken &cigar, read->cigar) {
         cigarVector += QVector<U2CigarOp>(cigar.count, cigar.op);
     }
-#if (QT_VERSION < 0x050400)  // Qt 5.4
-    removeAll(&cigarVector, U2CigarOp_I);
-    removeAll(&cigarVector, U2CigarOp_S);
-    removeAll(&cigarVector, U2CigarOp_P);
-#else
     cigarVector.removeAll(U2CigarOp_I);
     cigarVector.removeAll(U2CigarOp_S);
     cigarVector.removeAll(U2CigarOp_P);
-#endif
 
     int startPos = (int)(read->leftmostPos / ii.coverageBasesPerPoint);
     int endPos = (int)((read->leftmostPos + read->effectiveLen - 1) / ii.coverageBasesPerPoint);

--- a/src/corelibs/U2Formats/src/sqlite_dbi/SQLiteAssemblyDbi.cpp
+++ b/src/corelibs/U2Formats/src/sqlite_dbi/SQLiteAssemblyDbi.cpp
@@ -369,11 +369,7 @@ QByteArray SQLiteAssemblyUtils::packData(SQLiteAssemblyDataMethod method, const 
             nBytes += 1 + aux.length();
         }
     }
-#if QT_VERSION >= QT_VERSION_CHECK(4, 7, 0)
     QByteArray res(nBytes, Qt::Uninitialized);
-#else
-    QByteArray res(nBytes, char(0));
-#endif
     char *data = res.data();
     int pos = 0;
 
@@ -533,21 +529,7 @@ void SQLiteAssemblyUtils::unpackData(const QByteArray &packedData, U2AssemblyRea
         os.setError(err);
     }
 }
-#if (QT_VERSION < 0x050400)  // Qt 5.4
-namespace {
-int removeAll(QVector<U2CigarOp> *vector, const U2CigarOp &t) {
-    const QVector<U2CigarOp>::const_iterator ce = vector->cend(), cit = std::find(vector->cbegin(), ce, t);
-    if (cit == ce)
-        return 0;
-    // next operation detaches, so ce, cit may become invalidated:
-    const int firstFoundIdx = std::distance(vector->cbegin(), cit);
-    const QVector<U2CigarOp>::iterator e = vector->end(), it = std::remove(vector->begin() + firstFoundIdx, e, t);
-    const int result = std::distance(it, e);
-    vector->erase(it, e);
-    return result;
-}
-}  // namespace
-#endif
+
 void SQLiteAssemblyUtils::calculateCoverage(SQLiteReadQuery &q, const U2Region &r, U2AssemblyCoverageStat &coverage, U2OpStatus &os) {
     int csize = coverage.size();
     SAFE_POINT(csize > 0, "illegal coverage vector size!", );
@@ -574,15 +556,9 @@ void SQLiteAssemblyUtils::calculateCoverage(SQLiteReadQuery &q, const U2Region &
         foreach (const U2CigarToken &cigar, read->cigar) {
             cigarVector += QVector<U2CigarOp>(cigar.count, cigar.op);
         }
-#if (QT_VERSION < 0x050400)  // Qt 5.4
-        removeAll(&cigarVector, U2CigarOp_I);
-        removeAll(&cigarVector, U2CigarOp_S);
-        removeAll(&cigarVector, U2CigarOp_P);
-#else
         cigarVector.removeAll(U2CigarOp_I);
         cigarVector.removeAll(U2CigarOp_S);
         cigarVector.removeAll(U2CigarOp_P);
-#endif
 
         if (r.startPos > startPos) {
             cigarVector = cigarVector.mid(r.startPos - startPos);  // cut unneeded cigar string
@@ -612,15 +588,9 @@ void SQLiteAssemblyUtils::addToCoverage(U2AssemblyCoverageImportInfo &ii, const 
     foreach (const U2CigarToken &cigar, read->cigar) {
         cigarVector += QVector<U2CigarOp>(cigar.count, cigar.op);
     }
-#if (QT_VERSION < 0x050400)  // Qt 5.4
-    removeAll(&cigarVector, U2CigarOp_I);
-    removeAll(&cigarVector, U2CigarOp_S);
-    removeAll(&cigarVector, U2CigarOp_P);
-#else
     cigarVector.removeAll(U2CigarOp_I);
     cigarVector.removeAll(U2CigarOp_S);
     cigarVector.removeAll(U2CigarOp_P);
-#endif
 
     int startPos = (int)(read->leftmostPos / ii.coverageBasesPerPoint);
     int endPos = (int)((read->leftmostPos + read->effectiveLen) / ii.coverageBasesPerPoint) - 1;

--- a/src/corelibs/U2View/src/ov_assembly/ZoomableAssemblyOverview.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/ZoomableAssemblyOverview.cpp
@@ -285,11 +285,7 @@ void ZoomableAssemblyOverview::drawCoordLabels(QPainter &p) {
 
     // Prepare font
     QFont font = p.font();
-#if QT_VERSION >= QT_VERSION_CHECK(4, 7, 0)
     font.setStyleHint(QFont::SansSerif, (QFont::StyleStrategy)(QFont::PreferAntialias | QFont::ForceIntegerMetrics));
-#else
-    font.setStyleHint(QFont::SansSerif, QFont::PreferAntialias);
-#endif
     p.setFont(font);
     QFontMetrics fontMetrics(font, this);
 

--- a/src/libs_3rdparty/QSpec/QSpec.pro
+++ b/src/libs_3rdparty/QSpec/QSpec.pro
@@ -1,15 +1,5 @@
 include (QSpec.pri)
 
-# Check the Qt version. If QT_VERSION is not set, it is probably Qt 3.
-isEmpty(QT_VERSION) {
-    error("QT_VERSION not defined. QScore does not work with Qt 3.")
-}
-
-!minQtVersion(5, 12, 0) {
-    message("Cannot build QScore with Qt version $${QT_VERSION}")
-    error("Use at least Qt 5.12.0.")
-}
-
 # Input
 HEADERS += \
             src/GTGlobals.h \

--- a/src/libs_3rdparty/QSpec/src/GTGlobals.cpp
+++ b/src/libs_3rdparty/QSpec/src/GTGlobals.cpp
@@ -19,20 +19,14 @@
  * MA 02110-1301, USA.
  */
 
+#include "GTGlobals.h"
+
 #include <QtCore/QEventLoop>
+#include <QtGui/QScreen>
 #include <QtTest/QSpontaneKeyEvent>
 #include <QtTest>
-#if (QT_VERSION < 0x050000)  // Qt 5
-#    include <QtGui/QApplication>
-#    include <QtGui/QDesktopWidget>
-#    include <QtGui/QPixmap>
-#else
-#    include <QtGui/QScreen>
-#    include <QtWidgets/QApplication>
-#    include <QtWidgets/QDesktopWidget>
-#endif
-
-#include "GTGlobals.h"
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QDesktopWidget>
 
 #ifdef Q_OS_WIN
 #    include <windows.h>

--- a/src/libs_3rdparty/QSpec/src/utils/GTMouseUtils.h
+++ b/src/libs_3rdparty/QSpec/src/utils/GTMouseUtils.h
@@ -22,12 +22,9 @@
 #ifndef HI_GUI_GTMOUSE_H_
 #define HI_GUI_GTMOUSE_H_
 
+#include <QtWidgets/QWidget>
+
 #include "GTGlobals.h"
-#if (QT_VERSION < 0x050000)  // Qt 5
-#    include <QtGui/QWidget>
-#else
-#    include <QtWidgets/QWidget>
-#endif
 
 namespace HI {
 

--- a/src/plugins/query_designer/src/QueryViewItems.cpp
+++ b/src/plugins/query_designer/src/QueryViewItems.cpp
@@ -62,9 +62,7 @@ QDElement::QDElement(QDSchemeUnit *_unit)
     : highlighted(false), unit(_unit), font(QFont()), bound(0, 0, 3 * ANNOTATION_MIN_SIZE, ANNOTATION_MIN_SIZE),
       dragging(false), extendedHeight(ANNOTATION_MIN_SIZE), itemResizeFlags(0) {
     setFlag(QGraphicsItem::ItemIsSelectable, true);
-#if (QT_VERSION >= QT_VERSION_CHECK(4, 6, 0))
     setFlag(QGraphicsItem::ItemSendsGeometryChanges, true);
-#endif
     setAcceptHoverEvents(true);
     setZValue(1);
 
@@ -806,9 +804,7 @@ bool QDElementDescription::sceneEvent(QEvent *event) {
 
 Footnote::Footnote(QDElement *_from, QDElement *_to, QDDistanceType _distType, QDConstraint *parent, const QFont &_font)
     : from(_from), to(_to), distType(_distType), constraint(parent), font(_font), draging(false) {
-#if (QT_VERSION >= QT_VERSION_CHECK(4, 6, 0))
     setFlag(QGraphicsItem::ItemSendsGeometryChanges, true);
-#endif
     connect(constraint->getParameters(), SIGNAL(si_modified()), SLOT(sl_update()));
     init();
 }

--- a/src/plugins/workflow_designer/src/ItemViewStyle.cpp
+++ b/src/plugins/workflow_designer/src/ItemViewStyle.cpp
@@ -523,9 +523,7 @@ void ExtendedProcStyle::linkHovered(const QString &url) {
 HintItem::HintItem(const QString &text, QGraphicsItem *parent)
     : QGraphicsTextItem(text, parent), dragging(false) {
     setFlag(QGraphicsItem::ItemIsSelectable);
-#if (QT_VERSION >= QT_VERSION_CHECK(4, 6, 0))
     setFlag(QGraphicsItem::ItemSendsGeometryChanges, true);
-#endif
     document()->setDefaultTextOption(QTextOption(Qt::AlignCenter));
     setTextWidth(qMin(3 * R, document()->idealWidth()));
     QRectF tb = boundingRect();

--- a/src/plugins/workflow_designer/src/WorkflowViewItems.cpp
+++ b/src/plugins/workflow_designer/src/WorkflowViewItems.cpp
@@ -56,9 +56,7 @@ WorkflowProcessItem::WorkflowProcessItem(Actor *prc)
     setToolTip(process->getProto()->getDocumentation());
     setFlag(QGraphicsItem::ItemIsSelectable, true);
     setFlag(QGraphicsItem::ItemIsMovable, true);
-#if (QT_VERSION >= QT_VERSION_CHECK(4, 6, 0))
     setFlag(QGraphicsItem::ItemSendsGeometryChanges, true);
-#endif
     setAcceptHoverEvents(true);
 
     styles[ItemStyles::SIMPLE] = new SimpleProcStyle(this);

--- a/src/ugene_globals.pri
+++ b/src/ugene_globals.pri
@@ -217,34 +217,3 @@ D=
 is_debug_build() {
     D=d
 }
-
-#Variable enabling exclude list for ugene non-free modules
-defineTest( without_non_free ) {
-    contains( UGENE_WITHOUT_NON_FREE, 1 ) : return (true)
-    return (false)
-}
-
-#Check minimal Qt version
-# Taken from Qt Creator project files
-defineTest(minQtVersion) {
-    maj = $$1
-    min = $$2
-    patch = $$3
-    isEqual(QT_MAJOR_VERSION, $$maj) {
-        isEqual(QT_MINOR_VERSION, $$min) {
-            isEqual(QT_PATCH_VERSION, $$patch) {
-                return(true)
-            }
-            greaterThan(QT_PATCH_VERSION, $$patch) {
-                return(true)
-            }
-        }
-        greaterThan(QT_MINOR_VERSION, $$min) {
-            return(true)
-        }
-    }
-    greaterThan(QT_MAJOR_VERSION, $$maj) {
-        return(true)
-    }
-    return(false)
-}

--- a/src/ugeneui/src/main_window/MainWindowImpl.cpp
+++ b/src/ugeneui/src/main_window/MainWindowImpl.cpp
@@ -511,16 +511,6 @@ void FixedMdiArea::setViewMode(QMdiArea::ViewMode mode) {
     }
 }
 
-void FixedMdiArea::closeSubWindow(int idx) {
-    Q_UNUSED(idx);
-    // We use Qt greater than 4.8.0
-    // this workaround can be removed
-    // do it accurately
-#if QT_VERSION < 0x040800  // In Qt version 4.8.0 was added default behavior for closing tab.
-    subWindowList().at(idx)->close();
-#endif
-}
-
 // Workaround for QTBUG-17428: Superfluous RestoreAction for tabbed QMdiSubWindows
 void FixedMdiArea::sysContextMenuAction(QAction *action) {
     if (viewMode() == QMdiArea::TabbedView && activeSubWindow()) {

--- a/src/ugeneui/src/main_window/MainWindowImpl.h
+++ b/src/ugeneui/src/main_window/MainWindowImpl.h
@@ -61,7 +61,6 @@ public slots:
 private slots:
     // Workaround for QTBUG-17428
     void sysContextMenuAction(QAction *);
-    void closeSubWindow(int);
 };
 
 class MainWindowImpl : public MainWindow {

--- a/ugene.pri
+++ b/ugene.pri
@@ -1,14 +1,5 @@
 include( src/ugene_globals.pri )
 
-isEmpty(QT_VERSION) {
-    error("QT_VERSION is not defined.")
-}
-
-!minQtVersion(5, 12, 0) {
-    message("Cannot build Unipro UGENE with Qt version $${QT_VERSION}")
-    error("Use at least Qt 5.12.0.")
-}
-
 TEMPLATE = subdirs
 
 CONFIG += ordered debug_and_release
@@ -18,6 +9,8 @@ use_opencl() {
 }
 
 message("Qt version is $${QT_VERSION}")
+!versionAtLeast(QT_VERSION, 5.12.0):error("UGENE requires Qt version between 5.12.0 and 5.15.x")
+!versionAtMost(QT_VERSION, 5.15.99):error("UGENE requires Qt version between 5.12.0 and 5.15.x")
 
 # create target build & plugin folders (to copy licenses/descriptors to)
 mkpath($$OUT_PWD/src/_debug/plugins)

--- a/ugene.pro
+++ b/ugene.pro
@@ -80,10 +80,6 @@ use_opencl() {
     SUBDIRS += src/plugins/opencl_support
 }
 
-without_non_free() {
-    SUBDIRS -= src/plugins_3rdparty/psipred
-}
-
 #foreach 'language'
 for( i, UGENE_TRANSL_IDX ) {
     UGENE_TRANSLATIONS =


### PR DESCRIPTION
This patch removes all "ifdefs"  target to unsupported/untested QT versions, like Qt4, Qt5<5.4, etc..