### PR TITLE
Make getDocument method wait until the result is available

### DIFF
--- a/src/plugins/GUITestBase/src/GTUtilsDocument.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsDocument.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "GTUtilsDocument.h"
+#include <api/GTUtils.h>
 #include <base_dialogs/MessageBoxFiller.h>
 #include <drivers/GTKeyboardDriver.h>
 #include <drivers/GTMouseDriver.h>
@@ -46,29 +47,33 @@ const QString GTUtilsDocument::DocumentUnloaded = "Unloaded";
 #define GT_CLASS_NAME "GTUtilsDocument"
 
 #define GT_METHOD_NAME "getDocument"
-Document *GTUtilsDocument::getDocument(HI::GUITestOpStatus &os, const QString &documentName) {
-    Project *p = AppContext::getProject();
-    GT_CHECK_RESULT(p != nullptr, "Project does not exist", nullptr);
-
-    QList<Document *> docs = p->getDocuments();
-    foreach (Document *d, docs) {
-        if (d && (d->getName() == documentName)) {
-            return d;
+Document *GTUtilsDocument::getDocument(HI::GUITestOpStatus &os, const QString &documentName, const GTGlobals::FindOptions &options) {
+    for (int time = 0; time < GT_OP_WAIT_MILLIS; time += GT_OP_CHECK_MILLIS) {
+        Project *project = AppContext::getProject();
+        GT_CHECK_RESULT(project != nullptr || !options.failIfNotFound, "Project does not exist", nullptr);
+        if (project == nullptr && !options.failIfNotFound) {
+            return nullptr;
+        }
+        if (project == nullptr) {
+            continue;
+        }
+        QList<Document *> documents = project->getDocuments();
+        for (Document *document : qAsConst(documents)) {
+            if (GTUtils::matchText(os, documentName, document->getName(), options.matchPolicy)) {
+                return document;
+            }
+        }
+        if (!options.failIfNotFound) {
+            return nullptr;
         }
     }
-
-    return nullptr;
+    GT_FAIL("Document is not found: " + documentName, nullptr);
 }
 #undef GT_METHOD_NAME
 
 #define GT_METHOD_NAME "checkDocument"
 void GTUtilsDocument::checkDocument(HI::GUITestOpStatus &os, const QString &documentName, const GObjectViewFactoryId &id) {
-    Document *document = nullptr;
-    for (int time = 0; time < GT_OP_WAIT_MILLIS && document == nullptr; time += GT_OP_CHECK_MILLIS) {
-        GTGlobals::sleep(time > 0 ? GT_OP_CHECK_MILLIS : 0);
-        document = getDocument(os, documentName);
-    }
-    GT_CHECK(document != nullptr, "There is no document with name " + documentName);
+    Document *document = getDocument(os, documentName);
     if (id.isEmpty()) {
         return;
     }

--- a/src/plugins/GUITestBase/src/GTUtilsDocument.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsDocument.cpp
@@ -48,13 +48,11 @@ const QString GTUtilsDocument::DocumentUnloaded = "Unloaded";
 
 #define GT_METHOD_NAME "getDocument"
 Document *GTUtilsDocument::getDocument(HI::GUITestOpStatus &os, const QString &documentName, const GTGlobals::FindOptions &options) {
+    Project *project = nullptr;
     for (int time = 0; time < GT_OP_WAIT_MILLIS; time += GT_OP_CHECK_MILLIS) {
-        Project *project = AppContext::getProject();
-        GT_CHECK_RESULT(project != nullptr || !options.failIfNotFound, "Project does not exist", nullptr);
-        if (project == nullptr && !options.failIfNotFound) {
-            return nullptr;
-        }
-        if (project == nullptr) {
+        GTGlobals::sleep(time > 0 ? GT_OP_CHECK_MILLIS : 0);
+        project = AppContext::getProject();
+        if (project == nullptr) {  // Wait up to 'GT_OP_WAIT_MILLIS' before failing.
             continue;
         }
         QList<Document *> documents = project->getDocuments();
@@ -66,6 +64,9 @@ Document *GTUtilsDocument::getDocument(HI::GUITestOpStatus &os, const QString &d
         if (!options.failIfNotFound) {
             return nullptr;
         }
+    }
+    if (project == nullptr) {
+        GT_FAIL("There is no project to check if document is present or not: " + documentName, nullptr);
     }
     GT_FAIL("Document is not found: " + documentName, nullptr);
 }

--- a/src/plugins/GUITestBase/src/GTUtilsDocument.h
+++ b/src/plugins/GUITestBase/src/GTUtilsDocument.h
@@ -41,7 +41,11 @@ public:
 
     static void removeDocument(HI::GUITestOpStatus &os, const QString &documentName, GTGlobals::UseMethod method = GTGlobals::UseKey);
 
-    static Document *getDocument(HI::GUITestOpStatus &os, const QString &documentName);
+    /**
+     * Finds document with the given name in the project.
+     * Waits until document is found or fails unless options.failIfNotFound is false.
+     */
+    static Document *getDocument(HI::GUITestOpStatus &os, const QString &documentName, const GTGlobals::FindOptions &options = {});
 
     static bool isDocumentLoaded(HI::GUITestOpStatus &os, const QString &documentName);
 

--- a/src/plugins/GUITestBase/src/api/GTUtils.cpp
+++ b/src/plugins/GUITestBase/src/api/GTUtils.cpp
@@ -55,7 +55,7 @@ void GTUtils::checkServiceIsEnabled(HI::GUITestOpStatus &os, const QString &serv
 bool GTUtils::matchText(HI::GUITestOpStatus &os, const QString &textInTest, const QString &textInUi, const Qt::MatchFlags &matchFlags) {
     Qt::CaseSensitivity caseSensitivity = matchFlags.testFlag(Qt::MatchCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive;
     if (matchFlags.testFlag(Qt::MatchExactly)) {
-        return QString::compare(textInUi, textInTest, caseSensitivity);
+        return QString::compare(textInTest, textInUi, caseSensitivity) == 0;
     } else if (matchFlags.testFlag(Qt::MatchContains)) {
         return textInUi.contains(textInTest, caseSensitivity);
     } else if (matchFlags.testFlag(Qt::MatchStartsWith)) {

--- a/src/plugins/GUITestBase/src/api/GTUtils.cpp
+++ b/src/plugins/GUITestBase/src/api/GTUtils.cpp
@@ -51,6 +51,22 @@ void GTUtils::checkServiceIsEnabled(HI::GUITestOpStatus &os, const QString &serv
 }
 #undef GT_METHOD_NAME
 
+#define GT_METHOD_NAME "matchText"
+bool GTUtils::matchText(HI::GUITestOpStatus &os, const QString &textInTest, const QString &textInUi, const Qt::MatchFlags &matchFlags) {
+    Qt::CaseSensitivity caseSensitivity = matchFlags.testFlag(Qt::MatchCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive;
+    if (matchFlags.testFlag(Qt::MatchExactly)) {
+        return QString::compare(textInUi, textInTest, caseSensitivity);
+    } else if (matchFlags.testFlag(Qt::MatchContains)) {
+        return textInUi.contains(textInTest, caseSensitivity);
+    } else if (matchFlags.testFlag(Qt::MatchStartsWith)) {
+        return textInUi.startsWith(textInTest, caseSensitivity);
+    } else if (matchFlags.testFlag(Qt::MatchEndsWith)) {
+        return textInUi.endsWith(textInTest, caseSensitivity);
+    }
+    GT_FAIL("Unsupported match method: " + QString::number(matchFlags), false);
+}
+#undef GT_METHOD_NAME
+
 #undef GT_CLASS_NAME
 
 }  // namespace U2

--- a/src/plugins/GUITestBase/src/api/GTUtils.h
+++ b/src/plugins/GUITestBase/src/api/GTUtils.h
@@ -41,6 +41,13 @@ public:
     static void checkExportServiceIsEnabled(HI::GUITestOpStatus &os) {
         checkServiceIsEnabled(os, "DNA export service");
     }
+
+    /**
+     * Match text from test with an actual text from UI according to the flag. Returns true if texts are matched.
+     * For all 'contains'-line matchers 'textInUi' is checked to contain 'textInTest'.
+     * If some match flag from the flags is not supported an error is set to 'os'.
+     */
+    static bool matchText(HI::GUITestOpStatus &os, const QString &textInTest, const QString &textInUi, const Qt::MatchFlags &matchFlags);
 };
 
 }  // namespace U2

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/project/sequence_exporting/GTTestsProjectSequenceExporting.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/project/sequence_exporting/GTTestsProjectSequenceExporting.cpp
@@ -81,7 +81,6 @@ GUI_TEST_CLASS_DEFINITION(test_0001) {
     //     1) Project view with document "1.gb" and "2.gb" is opened, both documents are unloaded
     Document *doc1 = GTUtilsDocument::getDocument(os, "1.gb");
     Document *doc2 = GTUtilsDocument::getDocument(os, "2.gb");
-    CHECK_SET_ERR(doc1 != nullptr && doc2 != nullptr, "there are no documents 1.gb and 2.gb");
 
     CHECK_SET_ERR(!doc1->isLoaded(), "1.gb is loaded");
     CHECK_SET_ERR(!doc2->isLoaded(), "2.gb is loaded");

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_1001_2000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_1001_2000.cpp
@@ -737,7 +737,6 @@ GUI_TEST_CLASS_DEFINITION(test_1038) {
 
     // get the list of sequences in file and read names in assembly
     Document *seqDoc = GTUtilsDocument::getDocument(os, "test_1038_seq");
-    CHECK_SET_ERR(seqDoc != nullptr, "Document is NULL");
     QList<GObject *> seqList = seqDoc->findGObjectByType(GObjectTypes::SEQUENCE, UOF_LoadedAndUnloaded);
     CHECK_SET_ERR(!seqList.isEmpty(), "The list of sequences is empty");
     QList<QByteArray> seqNames;

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_3001_4000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_3001_4000.cpp
@@ -2435,7 +2435,6 @@ GUI_TEST_CLASS_DEFINITION(test_3398_1) {
     //    Expected state: an unloaded document appears, there are no objects within.
     GTUtilsTaskTreeView::waitTaskFinished(os);
     Document *doc = GTUtilsDocument::getDocument(os, "data_in_the_name_line.fa");
-    CHECK_SET_ERR(nullptr != doc, "Document is NULL");
     CHECK_SET_ERR(!doc->isLoaded(), "Document is unexpectedly loaded");
 
     //    3. Call context menu on the document.
@@ -2455,7 +2454,6 @@ GUI_TEST_CLASS_DEFINITION(test_3398_2) {
     //    Expected state: an unloaded document appears, there are no objects within.
     GTUtilsTaskTreeView::waitTaskFinished(os);
     Document *doc = GTUtilsDocument::getDocument(os, "data_in_the_name_line.fa");
-    CHECK_SET_ERR(nullptr != doc, "Document is NULL");
     CHECK_SET_ERR(!doc->isLoaded(), "Document is unexpectedly loaded");
 
     //    3. Call context menu on the document.
@@ -2475,7 +2473,6 @@ GUI_TEST_CLASS_DEFINITION(test_3398_3) {
     //    Expected state: an unloaded document appears, there are no objects within.
     GTUtilsTaskTreeView::waitTaskFinished(os);
     Document *doc = GTUtilsDocument::getDocument(os, "data_in_the_name_line.fa");
-    CHECK_SET_ERR(nullptr != doc, "Document is NULL");
     CHECK_SET_ERR(!doc->isLoaded(), "Document is unexpectedly loaded");
 
     //    3. Call context menu on the document.
@@ -2495,7 +2492,6 @@ GUI_TEST_CLASS_DEFINITION(test_3398_4) {
     //    Expected state: an unloaded document appears, there are no objects within.
     GTUtilsTaskTreeView::waitTaskFinished(os);
     Document *doc = GTUtilsDocument::getDocument(os, "data_in_the_name_line.fa");
-    CHECK_SET_ERR(nullptr != doc, "Document is NULL");
     CHECK_SET_ERR(!doc->isLoaded(), "Document is unexpectedly loaded");
 
     //    3. Call context menu on the document.

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_4001_5000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_4001_5000.cpp
@@ -2890,7 +2890,6 @@ GUI_TEST_CLASS_DEFINITION(test_4356) {
     GTWidget::click(os, GTWidget::findWidget(os, "build_dotplot_action_widget"));
 
     Document *doc = GTUtilsDocument::getDocument(os, "murine.gb");
-    CHECK_SET_ERR(nullptr != doc, "Document is NULL");
     CHECK_SET_ERR(doc->isLoaded(), "Document is unexpectedly unloaded");
 }
 


### PR DESCRIPTION
"getDocument" with no wait condition was a reason of flaky tests on Windows.

Now it implements the same logic as all other selector methods: it waits up to N (30) seconds until the result is found before failing (if options.failIfNotFound = true)