### PR TITLE
Fix debug mode issues in GUI tests

### DIFF
--- a/src/corelibs/U2Formats/src/TextDocumentFormat.cpp
+++ b/src/corelibs/U2Formats/src/TextDocumentFormat.cpp
@@ -98,7 +98,7 @@ Document *TextDocumentFormat::loadDocument(IOAdapter *io, const U2DbiRef &dbiRef
     CHECK_OP(os, nullptr);
     IOAdapterReader reader(io);  // TODO: store codec in the result document hints.
     Document *document = loadTextDocument(reader, dbiRef, hints, os);
-    SAFE_POINT(document != nullptr || os.hasError(), "Either document must not be null or there must be an error!", document);
+    SAFE_POINT(document != nullptr || os.hasError() || os.isCanceled(), "Either document must not be null or there must be an error/cancel flag!", document);
     return document;
 }
 


### PR DESCRIPTION
This is a trivial fix. It can't be reproduced in Release mode but I often run tests locally in debug mode.

+ I think it worth making SAFE_POINTs fail even in the release mode when run in GUI tests environment, but this is out of scope of the current PR