### PR TITLE
Remove build_pass iteration from qmake build

### DIFF
--- a/src/libs_3rdparty/QSpec/QSpec.pri
+++ b/src/libs_3rdparty/QSpec/QSpec.pri
@@ -12,14 +12,14 @@ DEFINES += QT_DLL
 
 DESTDIR = ../../$$out_dir()
 
-CONFIG(debug) {
+CONFIG(debug, debug|release) {
     DEFINES += _DEBUG
     CONFIG +=console
     MOC_DIR=_tmp/moc/debug
     OBJECTS_DIR=_tmp/obj/debug
 }
 
-CONFIG(release) {
+CONFIG(release, debug|release) {
     DEFINES+=NDEBUG
     MOC_DIR=_tmp/moc/release
     OBJECTS_DIR=_tmp/obj/release

--- a/src/libs_3rdparty/QSpec/QSpec.pri
+++ b/src/libs_3rdparty/QSpec/QSpec.pri
@@ -12,14 +12,14 @@ DEFINES += QT_DLL
 
 DESTDIR = ../../$$out_dir()
 
-CONFIG(debug, debug|release) {
+CONFIG(debug) {
     DEFINES += _DEBUG
     CONFIG +=console
     MOC_DIR=_tmp/moc/debug
     OBJECTS_DIR=_tmp/obj/debug
 }
 
-CONFIG(release, debug|release) {
+CONFIG(release) {
     DEFINES+=NDEBUG
     MOC_DIR=_tmp/moc/release
     OBJECTS_DIR=_tmp/obj/release

--- a/src/libs_3rdparty/QSpec/QSpec.pri
+++ b/src/libs_3rdparty/QSpec/QSpec.pri
@@ -12,22 +12,18 @@ DEFINES += QT_DLL
 
 DESTDIR = ../../$$out_dir()
 
-!debug_and_release|build_pass {
-
-    CONFIG(debug, debug|release) {
-        DEFINES += _DEBUG
-        CONFIG +=console
-        MOC_DIR=_tmp/moc/debug
-        OBJECTS_DIR=_tmp/obj/debug
-    }
-
-    CONFIG(release, debug|release) {
-        DEFINES+=NDEBUG
-        MOC_DIR=_tmp/moc/release
-        OBJECTS_DIR=_tmp/obj/release
-    }
+CONFIG(debug, debug|release) {
+    DEFINES += _DEBUG
+    CONFIG +=console
+    MOC_DIR=_tmp/moc/debug
+    OBJECTS_DIR=_tmp/obj/debug
 }
 
+CONFIG(release, debug|release) {
+    DEFINES+=NDEBUG
+    MOC_DIR=_tmp/moc/release
+    OBJECTS_DIR=_tmp/obj/release
+}
 
 unix {
     !macx {

--- a/src/libs_3rdparty/breakpad/breakpad.pri
+++ b/src/libs_3rdparty/breakpad/breakpad.pri
@@ -8,13 +8,13 @@ DESTDIR = ../../$$out_dir()
 QMAKE_PROJECT_NAME = breakpad
 QT -= gui
 
-CONFIG(debug) {
+CONFIG(debug, debug|release) {
     DEFINES += _DEBUG
     CONFIG += console
     OBJECTS_DIR = _tmp/obj/debug
 }
 
-CONFIG(release) {
+CONFIG(release, debug|release) {
     DEFINES += NDEBUG
     OBJECTS_DIR = _tmp/obj/release
 }

--- a/src/libs_3rdparty/breakpad/breakpad.pri
+++ b/src/libs_3rdparty/breakpad/breakpad.pri
@@ -8,13 +8,13 @@ DESTDIR = ../../$$out_dir()
 QMAKE_PROJECT_NAME = breakpad
 QT -= gui
 
-CONFIG(debug, debug|release) {
+CONFIG(debug) {
     DEFINES += _DEBUG
     CONFIG += console
     OBJECTS_DIR = _tmp/obj/debug
 }
 
-CONFIG(release, debug|release) {
+CONFIG(release) {
     DEFINES += NDEBUG
     OBJECTS_DIR = _tmp/obj/release
 }

--- a/src/libs_3rdparty/breakpad/breakpad.pri
+++ b/src/libs_3rdparty/breakpad/breakpad.pri
@@ -8,17 +8,15 @@ DESTDIR = ../../$$out_dir()
 QMAKE_PROJECT_NAME = breakpad
 QT -= gui
 
-!debug_and_release|build_pass {
-    CONFIG(debug, debug|release) {
-        DEFINES += _DEBUG
-        CONFIG += console
-        OBJECTS_DIR = _tmp/obj/debug
-    }
+CONFIG(debug, debug|release) {
+    DEFINES += _DEBUG
+    CONFIG += console
+    OBJECTS_DIR = _tmp/obj/debug
+}
 
-    CONFIG(release, debug|release) {
-        DEFINES += NDEBUG
-        OBJECTS_DIR = _tmp/obj/release
-    }
+CONFIG(release, debug|release) {
+    DEFINES += NDEBUG
+    OBJECTS_DIR = _tmp/obj/release
 }
 
 unix {

--- a/src/libs_3rdparty/qscore/qscore.pri
+++ b/src/libs_3rdparty/qscore/qscore.pri
@@ -11,22 +11,18 @@ DESTDIR = ../../$$out_dir()
 TARGET = qscore$$D
 QMAKE_PROJECT_NAME = qscore
 
-!debug_and_release|build_pass {
-
-    CONFIG(debug, debug|release) {
-        DEFINES+=_DEBUG
-        CONFIG +=console
-        MOC_DIR=_tmp/moc/debug
-        OBJECTS_DIR=_tmp/obj/debug
-    }
-
-    CONFIG(release, debug|release) {
-        DEFINES+=NDEBUG
-        MOC_DIR=_tmp/moc/release
-        OBJECTS_DIR=_tmp/obj/release
-    }
+CONFIG(debug, debug|release) {
+    DEFINES+=_DEBUG
+    CONFIG +=console
+    MOC_DIR=_tmp/moc/debug
+    OBJECTS_DIR=_tmp/obj/debug
 }
 
+CONFIG(release, debug|release) {
+    DEFINES+=NDEBUG
+    MOC_DIR=_tmp/moc/release
+    OBJECTS_DIR=_tmp/obj/release
+}
 
 UI_DIR=_tmp/ui
 RCC_DIR=_tmp/rcc

--- a/src/libs_3rdparty/qscore/qscore.pri
+++ b/src/libs_3rdparty/qscore/qscore.pri
@@ -11,14 +11,14 @@ DESTDIR = ../../$$out_dir()
 TARGET = qscore$$D
 QMAKE_PROJECT_NAME = qscore
 
-CONFIG(debug) {
+CONFIG(debug, debug|release) {
     DEFINES+=_DEBUG
     CONFIG +=console
     MOC_DIR=_tmp/moc/debug
     OBJECTS_DIR=_tmp/obj/debug
 }
 
-CONFIG(release) {
+CONFIG(release, debug|release) {
     DEFINES+=NDEBUG
     MOC_DIR=_tmp/moc/release
     OBJECTS_DIR=_tmp/obj/release

--- a/src/libs_3rdparty/qscore/qscore.pri
+++ b/src/libs_3rdparty/qscore/qscore.pri
@@ -11,14 +11,14 @@ DESTDIR = ../../$$out_dir()
 TARGET = qscore$$D
 QMAKE_PROJECT_NAME = qscore
 
-CONFIG(debug, debug|release) {
+CONFIG(debug) {
     DEFINES+=_DEBUG
     CONFIG +=console
     MOC_DIR=_tmp/moc/debug
     OBJECTS_DIR=_tmp/obj/debug
 }
 
-CONFIG(release, debug|release) {
+CONFIG(release) {
     DEFINES+=NDEBUG
     MOC_DIR=_tmp/moc/release
     OBJECTS_DIR=_tmp/obj/release

--- a/src/libs_3rdparty/samtools/samtools.pri
+++ b/src/libs_3rdparty/samtools/samtools.pri
@@ -18,20 +18,17 @@ macx {
     LIBS += -lcurses
 }
 
-!debug_and_release|build_pass {
+CONFIG(debug, debug|release) {
+    DEFINES+=_DEBUG
+    CONFIG +=console
+    MOC_DIR=_tmp/moc/debug
+    OBJECTS_DIR=_tmp/obj/debug
+}
 
-    CONFIG(debug, debug|release) {
-        DEFINES+=_DEBUG
-        CONFIG +=console
-        MOC_DIR=_tmp/moc/debug
-        OBJECTS_DIR=_tmp/obj/debug
-    }
-
-    CONFIG(release, debug|release) {
-        DEFINES+=NDEBUG
-        MOC_DIR=_tmp/moc/release
-        OBJECTS_DIR=_tmp/obj/release
-    }
+CONFIG(release, debug|release) {
+    DEFINES+=NDEBUG
+    MOC_DIR=_tmp/moc/release
+    OBJECTS_DIR=_tmp/obj/release
 }
 
 

--- a/src/libs_3rdparty/samtools/samtools.pri
+++ b/src/libs_3rdparty/samtools/samtools.pri
@@ -18,14 +18,14 @@ macx {
     LIBS += -lcurses
 }
 
-CONFIG(debug, debug|release) {
+CONFIG(debug) {
     DEFINES+=_DEBUG
     CONFIG +=console
     MOC_DIR=_tmp/moc/debug
     OBJECTS_DIR=_tmp/obj/debug
 }
 
-CONFIG(release, debug|release) {
+CONFIG(release) {
     DEFINES+=NDEBUG
     MOC_DIR=_tmp/moc/release
     OBJECTS_DIR=_tmp/obj/release

--- a/src/libs_3rdparty/samtools/samtools.pri
+++ b/src/libs_3rdparty/samtools/samtools.pri
@@ -18,14 +18,14 @@ macx {
     LIBS += -lcurses
 }
 
-CONFIG(debug) {
+CONFIG(debug, debug|release) {
     DEFINES+=_DEBUG
     CONFIG +=console
     MOC_DIR=_tmp/moc/debug
     OBJECTS_DIR=_tmp/obj/debug
 }
 
-CONFIG(release) {
+CONFIG(release, debug|release) {
     DEFINES+=NDEBUG
     MOC_DIR=_tmp/moc/release
     OBJECTS_DIR=_tmp/obj/release

--- a/src/libs_3rdparty/sqlite3/sqlite3.pri
+++ b/src/libs_3rdparty/sqlite3/sqlite3.pri
@@ -16,13 +16,13 @@ LIBS += -L../../$$out_dir()
 DESTDIR = ../../$$out_dir()
 TARGET = ugenedb$$D
 
-CONFIG(debug, debug|release) {
+CONFIG(debug) {
     DEFINES+=_DEBUG
     CONFIG +=console
     OBJECTS_DIR=_tmp/obj/debug
 }
 
-CONFIG(release, debug|release) {
+CONFIG(release) {
     DEFINES+=NDEBUG
     OBJECTS_DIR=_tmp/obj/release
 }

--- a/src/libs_3rdparty/sqlite3/sqlite3.pri
+++ b/src/libs_3rdparty/sqlite3/sqlite3.pri
@@ -16,13 +16,13 @@ LIBS += -L../../$$out_dir()
 DESTDIR = ../../$$out_dir()
 TARGET = ugenedb$$D
 
-CONFIG(debug) {
+CONFIG(debug, debug|release) {
     DEFINES+=_DEBUG
     CONFIG +=console
     OBJECTS_DIR=_tmp/obj/debug
 }
 
-CONFIG(release) {
+CONFIG(release, debug|release) {
     DEFINES+=NDEBUG
     OBJECTS_DIR=_tmp/obj/release
 }

--- a/src/libs_3rdparty/sqlite3/sqlite3.pri
+++ b/src/libs_3rdparty/sqlite3/sqlite3.pri
@@ -16,20 +16,16 @@ LIBS += -L../../$$out_dir()
 DESTDIR = ../../$$out_dir()
 TARGET = ugenedb$$D
 
-!debug_and_release|build_pass {
-
-    CONFIG(debug, debug|release) {
-        DEFINES+=_DEBUG
-        CONFIG +=console
-        OBJECTS_DIR=_tmp/obj/debug
-    }
-
-    CONFIG(release, debug|release) {
-        DEFINES+=NDEBUG
-        OBJECTS_DIR=_tmp/obj/release
-    }
+CONFIG(debug, debug|release) {
+    DEFINES+=_DEBUG
+    CONFIG +=console
+    OBJECTS_DIR=_tmp/obj/debug
 }
 
+CONFIG(release, debug|release) {
+    DEFINES+=NDEBUG
+    OBJECTS_DIR=_tmp/obj/release
+}
 
 win32 {
     DEF_FILE=$$PWD/src/sqlite3.def

--- a/src/libs_3rdparty/zlib/zlib.pri
+++ b/src/libs_3rdparty/zlib/zlib.pri
@@ -8,14 +8,14 @@ INCLUDEPATH += src ../../include
 TARGET = zlib$$D
 DESTDIR = ../../$$out_dir()
 
-CONFIG(debug) {
+CONFIG(debug, debug|release) {
     DEFINES+=_DEBUG
     CONFIG +=console
     OBJECTS_DIR=_tmp/obj/debug
     MOC_DIR=_tmp/moc/debug
 }
 
-CONFIG(release) {
+CONFIG(release, debug|release) {
     DEFINES+=NDEBUG
     OBJECTS_DIR=_tmp/obj/release
     MOC_DIR=_tmp/moc/release

--- a/src/libs_3rdparty/zlib/zlib.pri
+++ b/src/libs_3rdparty/zlib/zlib.pri
@@ -8,14 +8,14 @@ INCLUDEPATH += src ../../include
 TARGET = zlib$$D
 DESTDIR = ../../$$out_dir()
 
-CONFIG(debug, debug|release) {
+CONFIG(debug) {
     DEFINES+=_DEBUG
     CONFIG +=console
     OBJECTS_DIR=_tmp/obj/debug
     MOC_DIR=_tmp/moc/debug
 }
 
-CONFIG(release, debug|release) {
+CONFIG(release) {
     DEFINES+=NDEBUG
     OBJECTS_DIR=_tmp/obj/release
     MOC_DIR=_tmp/moc/release

--- a/src/libs_3rdparty/zlib/zlib.pri
+++ b/src/libs_3rdparty/zlib/zlib.pri
@@ -8,20 +8,17 @@ INCLUDEPATH += src ../../include
 TARGET = zlib$$D
 DESTDIR = ../../$$out_dir()
 
-!debug_and_release|build_pass {
+CONFIG(debug, debug|release) {
+    DEFINES+=_DEBUG
+    CONFIG +=console
+    OBJECTS_DIR=_tmp/obj/debug
+    MOC_DIR=_tmp/moc/debug
+}
 
-    CONFIG(debug, debug|release) {
-        DEFINES+=_DEBUG
-        CONFIG +=console
-        OBJECTS_DIR=_tmp/obj/debug
-        MOC_DIR=_tmp/moc/debug
-    }
-
-    CONFIG(release, debug|release) {
-        DEFINES+=NDEBUG
-        OBJECTS_DIR=_tmp/obj/release
-        MOC_DIR=_tmp/moc/release
-    }
+CONFIG(release, debug|release) {
+    DEFINES+=NDEBUG
+    OBJECTS_DIR=_tmp/obj/release
+    MOC_DIR=_tmp/moc/release
 }
 
 UI_DIR=_tmp/ui

--- a/src/plugins/smith_waterman/smith_waterman.pri
+++ b/src/plugins/smith_waterman/smith_waterman.pri
@@ -18,11 +18,11 @@ use_cuda() {
     INCLUDEPATH += $$UGENE_CUDA_INC_DIR
 
     win32 {
-        CONFIG(debug) {
+        CONFIG(debug, debug|release) {
             SW2_NVCC_LIBS_TYPE_FLAG = -MDd
         }
 
-        CONFIG(release) {
+        CONFIG(release, debug|release) {
             SW2_NVCC_LIBS_TYPE_FLAG = -MD
         }
         XCOMPILER_OPT = "-Xcompiler -Zi,$${SW2_NVCC_LIBS_TYPE_FLAG}"

--- a/src/plugins/smith_waterman/smith_waterman.pri
+++ b/src/plugins/smith_waterman/smith_waterman.pri
@@ -18,11 +18,11 @@ use_cuda() {
     INCLUDEPATH += $$UGENE_CUDA_INC_DIR
 
     win32 {
-        CONFIG(debug, debug|release) {
+        CONFIG(debug) {
             SW2_NVCC_LIBS_TYPE_FLAG = -MDd
         }
 
-        CONFIG(release, debug|release) {
+        CONFIG(release) {
             SW2_NVCC_LIBS_TYPE_FLAG = -MD
         }
         XCOMPILER_OPT = "-Xcompiler -Zi,$${SW2_NVCC_LIBS_TYPE_FLAG}"

--- a/src/plugins_checker/plugins_checker.pri
+++ b/src/plugins_checker/plugins_checker.pri
@@ -21,13 +21,13 @@ DESTDIR = ../$$out_dir()
 TARGET = plugins_checker$$D
 QMAKE_PROJECT_NAME = plugins_checker
 
-CONFIG(debug) {
+CONFIG(debug, debug|release) {
     DEFINES+=_DEBUG
     MOC_DIR=_tmp/moc/debug
     OBJECTS_DIR=_tmp/obj/debug
 }
 
-CONFIG(release) {
+CONFIG(release, debug|release) {
     DEFINES+=NDEBUG
     MOC_DIR=_tmp/moc/release
     OBJECTS_DIR=_tmp/obj/release

--- a/src/plugins_checker/plugins_checker.pri
+++ b/src/plugins_checker/plugins_checker.pri
@@ -21,13 +21,13 @@ DESTDIR = ../$$out_dir()
 TARGET = plugins_checker$$D
 QMAKE_PROJECT_NAME = plugins_checker
 
-CONFIG(debug, debug|release) {
+CONFIG(debug) {
     DEFINES+=_DEBUG
     MOC_DIR=_tmp/moc/debug
     OBJECTS_DIR=_tmp/obj/debug
 }
 
-CONFIG(release, debug|release) {
+CONFIG(release) {
     DEFINES+=NDEBUG
     MOC_DIR=_tmp/moc/release
     OBJECTS_DIR=_tmp/obj/release

--- a/src/plugins_checker/plugins_checker.pri
+++ b/src/plugins_checker/plugins_checker.pri
@@ -21,19 +21,16 @@ DESTDIR = ../$$out_dir()
 TARGET = plugins_checker$$D
 QMAKE_PROJECT_NAME = plugins_checker
 
-!debug_and_release|build_pass {
+CONFIG(debug, debug|release) {
+    DEFINES+=_DEBUG
+    MOC_DIR=_tmp/moc/debug
+    OBJECTS_DIR=_tmp/obj/debug
+}
 
-    CONFIG(debug, debug|release) {
-        DEFINES+=_DEBUG
-        MOC_DIR=_tmp/moc/debug
-        OBJECTS_DIR=_tmp/obj/debug
-    }
-
-    CONFIG(release, debug|release) {
-        DEFINES+=NDEBUG
-        MOC_DIR=_tmp/moc/release
-        OBJECTS_DIR=_tmp/obj/release
-    }
+CONFIG(release, debug|release) {
+    DEFINES+=NDEBUG
+    MOC_DIR=_tmp/moc/release
+    OBJECTS_DIR=_tmp/obj/release
 }
 
 UI_DIR=_tmp/ui

--- a/src/ugene_globals.pri
+++ b/src/ugene_globals.pri
@@ -2,6 +2,9 @@ include (ugene_version.pri)
 
 UGENE_GLOBALS_DEFINED=1
 
+# Generate only 2 separate Makefiles: Debug & Release. Do not generate a common one that builds both targets.
+CONFIG -= debug_and_release debug_and_release_target
+
 DEFINES+=UGENE_VERSION=$${UGENE_VERSION}
 # Separate minor/major version tokens are used in .rc resource.
 win32:DEFINES+=UGENE_VER_MAJOR=$${UGENE_VER_MAJOR}
@@ -12,6 +15,7 @@ win32:DEFINES+=UGENE_VER_MINOR=$${UGENE_VER_MINOR}
 # and do not use any deprecated API.
 DEFINES+=QT_DISABLE_DEPRECATED_BEFORE=0x050700
 
+CONFIG -= c++11 # Remove the default provided by the current (Qt 5.12) qmake spec.
 CONFIG += c++14
 
 # Do not use library suffix names for files and ELF-dependency sections on Linux.
@@ -187,24 +191,20 @@ defineReplace(add_sqlite_lib) {
 
 # Returns active UGENE output dir name for core libs and executables used by build process: _debug or _release.
 defineReplace(out_dir) {
-    !debug_and_release|build_pass {
-        CONFIG(debug, debug|release) {
-            RES = _debug
-        } else {
-            RES = _release
-        }
+    CONFIG(debug, debug|release) {
+        RES = _debug
+    } else {
+        RES = _release
     }
     return ($$RES)
 }
 
 # Returns active UGENE output dir name for core libs and executables used by build process: _debug or _release.
 defineTest(is_debug_build) {
-    !debug_and_release|build_pass {
-        CONFIG(debug, debug|release) {
-            RES = true
-        } else {
-            RES = false
-        }
+    CONFIG(debug, debug|release) {
+        RES = true
+    } else {
+        RES = false
     }
     return ($$RES)
 }

--- a/src/ugene_globals.pri
+++ b/src/ugene_globals.pri
@@ -15,7 +15,6 @@ win32:DEFINES+=UGENE_VER_MINOR=$${UGENE_VER_MINOR}
 # and do not use any deprecated API.
 DEFINES+=QT_DISABLE_DEPRECATED_BEFORE=0x050700
 
-CONFIG -= c++11 # Remove the default provided by the current (Qt 5.12) qmake spec.
 CONFIG += c++14
 
 # Do not use library suffix names for files and ELF-dependency sections on Linux.

--- a/src/ugene_globals.pri
+++ b/src/ugene_globals.pri
@@ -191,7 +191,7 @@ defineReplace(add_sqlite_lib) {
 
 # Returns active UGENE output dir name for core libs and executables used by build process: _debug or _release.
 defineReplace(out_dir) {
-    CONFIG(debug) {
+    CONFIG(debug, debug|release) {
         RES = _debug
     } else {
         RES = _release
@@ -201,7 +201,7 @@ defineReplace(out_dir) {
 
 # Returns active UGENE output dir name for core libs and executables used by build process: _debug or _release.
 defineTest(is_debug_build) {
-    CONFIG(debug) {
+    CONFIG(debug, debug|release) {
         RES = true
     } else {
         RES = false

--- a/src/ugene_globals.pri
+++ b/src/ugene_globals.pri
@@ -191,7 +191,7 @@ defineReplace(add_sqlite_lib) {
 
 # Returns active UGENE output dir name for core libs and executables used by build process: _debug or _release.
 defineReplace(out_dir) {
-    CONFIG(debug, debug|release) {
+    CONFIG(debug) {
         RES = _debug
     } else {
         RES = _release
@@ -201,7 +201,7 @@ defineReplace(out_dir) {
 
 # Returns active UGENE output dir name for core libs and executables used by build process: _debug or _release.
 defineTest(is_debug_build) {
-    CONFIG(debug, debug|release) {
+    CONFIG(debug) {
         RES = true
     } else {
         RES = false

--- a/src/ugene_lib_common.pri
+++ b/src/ugene_lib_common.pri
@@ -19,18 +19,17 @@ MODULE_ID=$$join(MODULE_ID, "", "", $$D)
 TARGET = $${MODULE_ID}
 CONFDIR=$$out_dir()
 
-!debug_and_release|build_pass {
-    CONFIG(debug, debug|release) {
-        DEFINES+=_DEBUG
-        CONFIG +=console
-        MOC_DIR=_tmp/moc/debug
-        OBJECTS_DIR=_tmp/obj/debug
-    }
-    CONFIG(release, debug|release) {
-        DEFINES+=NDEBUG
-        MOC_DIR=_tmp/moc/release
-        OBJECTS_DIR=_tmp/obj/release
-    }    
+CONFIG(debug, debug|release) {
+    DEFINES+=_DEBUG
+    CONFIG +=console
+    MOC_DIR=_tmp/moc/debug
+    OBJECTS_DIR=_tmp/obj/debug
+}
+
+CONFIG(release, debug|release) {
+    DEFINES+=NDEBUG
+    MOC_DIR=_tmp/moc/release
+    OBJECTS_DIR=_tmp/obj/release
 }
 
 UI_DIR=_tmp/ui

--- a/src/ugene_lib_common.pri
+++ b/src/ugene_lib_common.pri
@@ -19,14 +19,14 @@ MODULE_ID=$$join(MODULE_ID, "", "", $$D)
 TARGET = $${MODULE_ID}
 CONFDIR=$$out_dir()
 
-CONFIG(debug) {
+CONFIG(debug, debug|release) {
     DEFINES+=_DEBUG
     CONFIG +=console
     MOC_DIR=_tmp/moc/debug
     OBJECTS_DIR=_tmp/obj/debug
 }
 
-CONFIG(release) {
+CONFIG(release, debug|release) {
     DEFINES+=NDEBUG
     MOC_DIR=_tmp/moc/release
     OBJECTS_DIR=_tmp/obj/release

--- a/src/ugene_lib_common.pri
+++ b/src/ugene_lib_common.pri
@@ -19,14 +19,14 @@ MODULE_ID=$$join(MODULE_ID, "", "", $$D)
 TARGET = $${MODULE_ID}
 CONFDIR=$$out_dir()
 
-CONFIG(debug, debug|release) {
+CONFIG(debug) {
     DEFINES+=_DEBUG
     CONFIG +=console
     MOC_DIR=_tmp/moc/debug
     OBJECTS_DIR=_tmp/obj/debug
 }
 
-CONFIG(release, debug|release) {
+CONFIG(release) {
     DEFINES+=NDEBUG
     MOC_DIR=_tmp/moc/release
     OBJECTS_DIR=_tmp/obj/release

--- a/src/ugene_plugin_common.pri
+++ b/src/ugene_plugin_common.pri
@@ -12,11 +12,9 @@ LIBS += -lU2Core$$D -lU2Algorithm$$D -lU2Formats$$D -lU2Gui$$D -lU2View$$D -lU2T
 DESTDIR=../../$$out_dir()/plugins
 PLUGIN_ID=$$join(PLUGIN_ID, "", "", $$D)
 
-!debug_and_release|build_pass {
-    # Plugin output dir must exist before *.plugin/*.license files generation
-    mkpath($$OUT_PWD)
-    include (./ugene_plugin_descriptor.pri)
-}
+# Plugin output dir must exist before *.plugin/*.license files generation
+mkpath($$OUT_PWD)
+include (./ugene_plugin_descriptor.pri)
 
 DEFINES += PLUGIN_ID=\\\"$${PLUGIN_ID}\\\"
 

--- a/src/ugene_plugin_descriptor.pri
+++ b/src/ugene_plugin_descriptor.pri
@@ -100,10 +100,8 @@ write("    <library>$${PLUGIN_LIBRARY}</library>", >>)
 write("    <platform name=$${QQ}$${PLATFORM_NAME}$${QQ} arch=$${QQ}$${PLATFORM_ARCH}$${QQ}/>", >>)
 
 
-!debug_and_release|build_pass {
-    CONFIG(debug, debug|release) {
-        write("    <debug-build>true</debug-build>", >>)
-    }
+CONFIG(debug, debug|release) {
+    write("    <debug-build>true</debug-build>", >>)
 }
 
 write("</ugene-plugin>",  >>)

--- a/src/ugene_plugin_descriptor.pri
+++ b/src/ugene_plugin_descriptor.pri
@@ -100,7 +100,7 @@ write("    <library>$${PLUGIN_LIBRARY}</library>", >>)
 write("    <platform name=$${QQ}$${PLATFORM_NAME}$${QQ} arch=$${QQ}$${PLATFORM_ARCH}$${QQ}/>", >>)
 
 
-CONFIG(debug, debug|release) {
+CONFIG(debug) {
     write("    <debug-build>true</debug-build>", >>)
 }
 

--- a/src/ugene_plugin_descriptor.pri
+++ b/src/ugene_plugin_descriptor.pri
@@ -100,7 +100,7 @@ write("    <library>$${PLUGIN_LIBRARY}</library>", >>)
 write("    <platform name=$${QQ}$${PLATFORM_NAME}$${QQ} arch=$${QQ}$${PLATFORM_ARCH}$${QQ}/>", >>)
 
 
-CONFIG(debug) {
+CONFIG(debug, debug|release) {
     write("    <debug-build>true</debug-build>", >>)
 }
 

--- a/src/ugenecl/ugenecl.pri
+++ b/src/ugenecl/ugenecl.pri
@@ -21,13 +21,13 @@ DESTDIR = ../$$out_dir()
 TARGET = ugenecl$$D
 QMAKE_PROJECT_NAME = ugenecl
 
-CONFIG(debug, debug|release) {
+CONFIG(debug) {
     DEFINES+=_DEBUG
     MOC_DIR=_tmp/moc/debug
     OBJECTS_DIR=_tmp/obj/debug
 }
 
-CONFIG(release, debug|release) {
+CONFIG(release) {
     DEFINES+=NDEBUG
     MOC_DIR=_tmp/moc/release
     OBJECTS_DIR=_tmp/obj/release

--- a/src/ugenecl/ugenecl.pri
+++ b/src/ugenecl/ugenecl.pri
@@ -21,20 +21,16 @@ DESTDIR = ../$$out_dir()
 TARGET = ugenecl$$D
 QMAKE_PROJECT_NAME = ugenecl
 
-!debug_and_release|build_pass {
+CONFIG(debug, debug|release) {
+    DEFINES+=_DEBUG
+    MOC_DIR=_tmp/moc/debug
+    OBJECTS_DIR=_tmp/obj/debug
+}
 
-    CONFIG(debug, debug|release) {
-        DEFINES+=_DEBUG
-        MOC_DIR=_tmp/moc/debug
-        OBJECTS_DIR=_tmp/obj/debug
-    }
-
-    CONFIG(release, debug|release) {
-        DEFINES+=NDEBUG
-        MOC_DIR=_tmp/moc/release
-        OBJECTS_DIR=_tmp/obj/release
-    }
-
+CONFIG(release, debug|release) {
+    DEFINES+=NDEBUG
+    MOC_DIR=_tmp/moc/release
+    OBJECTS_DIR=_tmp/obj/release
 }
 
 UI_DIR=_tmp/ui

--- a/src/ugenecl/ugenecl.pri
+++ b/src/ugenecl/ugenecl.pri
@@ -21,13 +21,13 @@ DESTDIR = ../$$out_dir()
 TARGET = ugenecl$$D
 QMAKE_PROJECT_NAME = ugenecl
 
-CONFIG(debug) {
+CONFIG(debug, debug|release) {
     DEFINES+=_DEBUG
     MOC_DIR=_tmp/moc/debug
     OBJECTS_DIR=_tmp/obj/debug
 }
 
-CONFIG(release) {
+CONFIG(release, debug|release) {
     DEFINES+=NDEBUG
     MOC_DIR=_tmp/moc/release
     OBJECTS_DIR=_tmp/obj/release

--- a/src/ugeneui/ugeneui.pri
+++ b/src/ugeneui/ugeneui.pri
@@ -31,14 +31,14 @@ DESTDIR = ../$$out_dir()
 TARGET = ugeneui$$D
 QMAKE_PROJECT_NAME = ugeneui
 
-CONFIG(debug, debug|release) {
+CONFIG(debug) {
     DEFINES+=_DEBUG
     CONFIG +=console
     MOC_DIR=_tmp/moc/debug
     OBJECTS_DIR=_tmp/obj/debug
 }
 
-CONFIG(release, debug|release) {
+CONFIG(release) {
     DEFINES+=NDEBUG
     MOC_DIR=_tmp/moc/release
     OBJECTS_DIR=_tmp/obj/release

--- a/src/ugeneui/ugeneui.pri
+++ b/src/ugeneui/ugeneui.pri
@@ -31,24 +31,20 @@ DESTDIR = ../$$out_dir()
 TARGET = ugeneui$$D
 QMAKE_PROJECT_NAME = ugeneui
 
-!debug_and_release|build_pass {
+CONFIG(debug, debug|release) {
+    DEFINES+=_DEBUG
+    CONFIG +=console
+    MOC_DIR=_tmp/moc/debug
+    OBJECTS_DIR=_tmp/obj/debug
+}
 
-    CONFIG(debug, debug|release) {
-        DEFINES+=_DEBUG
-        CONFIG +=console
-        MOC_DIR=_tmp/moc/debug
-        OBJECTS_DIR=_tmp/obj/debug
-    }
+CONFIG(release, debug|release) {
+    DEFINES+=NDEBUG
+    MOC_DIR=_tmp/moc/release
+    OBJECTS_DIR=_tmp/obj/release
 
-    CONFIG(release, debug|release) {
-        DEFINES+=NDEBUG
-        MOC_DIR=_tmp/moc/release
-        OBJECTS_DIR=_tmp/obj/release
-
-        FORCE_CONSOLE = $$(UGENE_BUILD_WITH_CONSOLE)
-        !isEmpty( FORCE_CONSOLE ) : CONFIG +=console
-    }
-
+    FORCE_CONSOLE = $$(UGENE_BUILD_WITH_CONSOLE)
+    !isEmpty( FORCE_CONSOLE ) : CONFIG +=console
 }
 
 UI_DIR=_tmp/ui

--- a/src/ugeneui/ugeneui.pri
+++ b/src/ugeneui/ugeneui.pri
@@ -31,14 +31,14 @@ DESTDIR = ../$$out_dir()
 TARGET = ugeneui$$D
 QMAKE_PROJECT_NAME = ugeneui
 
-CONFIG(debug) {
+CONFIG(debug, debug|release) {
     DEFINES+=_DEBUG
     CONFIG +=console
     MOC_DIR=_tmp/moc/debug
     OBJECTS_DIR=_tmp/obj/debug
 }
 
-CONFIG(release) {
+CONFIG(release, debug|release) {
     DEFINES+=NDEBUG
     MOC_DIR=_tmp/moc/release
     OBJECTS_DIR=_tmp/obj/release


### PR DESCRIPTION
The main idea is to have 2 passes only: Debug or Release instead of 3.

The third pass we have today (Debug_And_Release) configuration is 'undefined' in many places as you can see from the diffs: a lot of values are not set correctly for that pass.

I checked the build on Linux only now and need to re-check on other platforms.
