### PR TITLE
Fix SAFE_POINTs in DotPlot GUI tests

### DIFF
--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_1_1000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_1_1000.cpp
@@ -472,21 +472,18 @@ GUI_TEST_CLASS_DEFINITION(test_0567) {
         Test_0567(HI::GUITestOpStatus &os)
             : Filler(os, "DotPlotDialog") {
         }
-        virtual void run() {
+        void run() override {
             QWidget *dialog = GTWidget::getActiveModalWidget(os);
-            CHECK_SET_ERR(dialog, "activeModalWidget is NULL");
 
             GTUtilsDialog::waitForDialog(os, new SequenceReadingModeSelectorDialogFiller(os));
             GTUtilsDialog::waitForDialog(os, new GTFileDialogUtils(os, testDir + "_common_data/scenarios/dp_view/dpm1.fa"));
-            GTWidget::click(os, dialog->findChild<QPushButton *>("loadSequenceButton"));
-            GTGlobals::sleep();
+            GTWidget::click(os, GTWidget::findPushButton(os, "loadSequenceButton", dialog));
 
             GTUtilsDialog::waitForDialog(os, new SequenceReadingModeSelectorDialogFiller(os));
             GTUtilsDialog::waitForDialog(os, new GTFileDialogUtils(os, testDir + "_common_data/scenarios/dp_view/dpm2.fa"));
-            GTWidget::click(os, dialog->findChild<QPushButton *>("loadSequenceButton"));
-            GTGlobals::sleep();
+            GTWidget::click(os, GTWidget::findPushButton(os, "loadSequenceButton", dialog));
 
-            QDialogButtonBox *box = qobject_cast<QDialogButtonBox *>(GTWidget::findWidget(os, "buttonBox", dialog));
+            auto box = GTWidget::findExactWidget<QDialogButtonBox*>(os, "buttonBox", dialog);
             QPushButton *button = box->button(QDialogButtonBox::Cancel);
             CHECK_SET_ERR(button != nullptr, "cancel button is NULL");
             GTWidget::click(os, button);
@@ -495,11 +492,11 @@ GUI_TEST_CLASS_DEFINITION(test_0567) {
 
     GTFileDialog::openFile(os, dataDir + "samples/FASTA/human_T1.fa");
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    GTGlobals::sleep();
 
     GTUtilsDialog::waitForDialog(os, new Test_0567(os));
     GTWidget::click(os, GTWidget::findWidget(os, "build_dotplot_action_widget"));
-    GTGlobals::sleep(1000);
+
+    GTUtilsDialog::waitAllFinished(os);
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0574) {

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_2001_3000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_2001_3000.cpp
@@ -4029,30 +4029,28 @@ GUI_TEST_CLASS_DEFINITION(test_2656) {
 
     class DotplotLoadSequenceFiller : public Filler {
     public:
-        DotplotLoadSequenceFiller(HI::GUITestOpStatus &os, const QString seqPath, const QString seqName)
-            : Filler(os, "DotPlotDialog"), seqPath(seqPath), seqName(seqName) {
+        DotplotLoadSequenceFiller(HI::GUITestOpStatus &os, const QString &_seqPath, const QString &_seqName)
+            : Filler(os, "DotPlotDialog"), seqPath(_seqPath), seqName(_seqName) {
         }
-        virtual void run() {
-            QWidget *dialog = GTWidget::getActiveModalWidget(os);
-            QPushButton *loadSeq = qobject_cast<QPushButton *>(GTWidget::findWidget(os, "loadSequenceButton", dialog));
-            CHECK_SET_ERR(loadSeq != nullptr, "Load sequence button no found");
-            GTUtilsDialog::waitForDialog(os, new GTFileDialogUtils(os, seqPath, seqName));
-            GTWidget::click(os, loadSeq);
 
-            QDialogButtonBox *box = qobject_cast<QDialogButtonBox *>(GTWidget::findWidget(os, "buttonBox", dialog));
+        void run() override {
+            QWidget *dialog = GTWidget::getActiveModalWidget(os);
+            GTUtilsDialog::waitForDialog(os, new GTFileDialogUtils(os, seqPath, seqName));
+            GTWidget::click(os, GTWidget::findPushButton(os, "loadSequenceButton", dialog));
+
+            auto box = GTWidget::findExactWidget<QDialogButtonBox *>(os, "buttonBox", dialog);
             QPushButton *button = box->button(QDialogButtonBox::Cancel);
             CHECK_SET_ERR(button != nullptr, "Cancel button is NULL");
             GTWidget::click(os, button);
         }
 
-    private:
         QString seqPath;
         QString seqName;
     };
 
     GTUtilsDialog::waitForDialog(os, new DotplotLoadSequenceFiller(os, testDir + "_common_data/fasta", "empty_2.fa"));
     GTWidget::click(os, GTWidget::findWidget(os, "build_dotplot_action_widget"));
-    GTThread::waitForMainThread();
+    GTUtilsDialog::waitAllFinished(os);
 
     CHECK_SET_ERR(l.hasErrors(), "Expected to have errors in the log, but no errors found");
 }

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_4001_5000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_4001_5000.cpp
@@ -2866,12 +2866,13 @@ GUI_TEST_CLASS_DEFINITION(test_4356) {
         Test_4356(HI::GUITestOpStatus &os)
             : Filler(os, "DotPlotDialog") {
         }
-        virtual void run() {
+
+        void run() override {
             QWidget *dialog = GTWidget::getActiveModalWidget(os);
             GTUtilsDialog::waitForDialog(os, new GTFileDialogUtils(os, dataDir + "samples/Genbank", "murine.gb"));
-            GTWidget::click(os, dialog->findChild<QPushButton *>("loadSequenceButton"));
+            GTWidget::click(os, GTWidget::findPushButton(os, "loadSequenceButton", dialog));
 
-            QDialogButtonBox *box = qobject_cast<QDialogButtonBox *>(GTWidget::findWidget(os, "buttonBox", dialog));
+            auto box = GTWidget::findExactWidget<QDialogButtonBox *>(os, "buttonBox", dialog);
             QPushButton *button = box->button(QDialogButtonBox::Ok);
             CHECK_SET_ERR(button != nullptr, "Ok button is NULL");
             GTWidget::click(os, button);


### PR DESCRIPTION
These SAFE_POINTs were found by the https://github.com/ugeneunipro/ugene/pull/566 and blocks it from being submitted

The fix is inside DotPlotDialog::sl_sequenceSelectorIndexChanged: SAFE_POINT was replaced with CHECK because it is a valid state.

Tests were not changed but modernized (removed sleeps/null-checks)
