### PR TITLE
Fix SAFE_POINTs in Cufflinks GUI tests

### DIFF
--- a/src/plugins/external_tool_support/src/cufflinks/CuffmergeSupportTask.cpp
+++ b/src/plugins/external_tool_support/src/cufflinks/CuffmergeSupportTask.cpp
@@ -50,8 +50,8 @@ CuffmergeSupportTask::CuffmergeSupportTask(const CuffmergeSettings &_settings)
       fileNum(0),
       mergeTask(nullptr),
       loadResultTask(nullptr) {
-    SAFE_POINT_EXT(nullptr != settings.storage, setError(tr("Workflow data storage is NULL")), );
-    SAFE_POINT_EXT(!settings.annotationTables.isEmpty(), setError(tr("There are no annotations to process")), );
+    SAFE_POINT_EXT(settings.storage != nullptr, setError(tr("Workflow data storage is NULL")), );
+    CHECK_EXT(!settings.annotationTables.isEmpty(), setError(tr("There are no annotations to process")), );
 }
 
 CuffmergeSupportTask::~CuffmergeSupportTask() {

--- a/src/plugins/external_tool_support/src/cufflinks/CuffmergeWorker.h
+++ b/src/plugins/external_tool_support/src/cufflinks/CuffmergeWorker.h
@@ -60,7 +60,6 @@ protected:
     QList<SharedDbiDataHandler> annTableHandlers;
 
 private:
-    CuffmergeSettings scanParameters() const;
     Task *createCuffmergeTask();
     void takeAnnotations();
 };


### PR DESCRIPTION
These SAFE_POINTs were found by the https://github.com/ugeneunipro/ugene/pull/566 and blocks it from being submitted

cuffmergeTask fails if provided with no annotations. Now we do not run it when there are no valid inputs.