### PR TITLE
Fix SAFE_POINTs in pcr GUI tests

### DIFF
--- a/src/plugins/pcr/src/ExtractProductTask.h
+++ b/src/plugins/pcr/src/ExtractProductTask.h
@@ -71,9 +71,9 @@ private:
 private:
     InSilicoPcrProduct product;
     ExtractProductSettings settings;
-    qint64 wholeSequenceLength;
+    qint64 wholeSequenceLength = 0;
 
-    Document *result;
+    Document *result = nullptr;
 };
 
 class ExtractProductWrapperTask : public Task {
@@ -90,7 +90,7 @@ private:
     void prepareUrl(const InSilicoPcrProduct &product, const QString &sequenceName, qint64 sequenceLength);
 
 private:
-    ExtractProductTask *extractTask;
+    ExtractProductTask *extractTask = nullptr;
     ExtractProductSettings settings;
 };
 

--- a/src/plugins/pcr/src/InSilicoPcrTask.cpp
+++ b/src/plugins/pcr/src/InSilicoPcrTask.cpp
@@ -50,9 +50,9 @@ bool InSilicoPcrProduct::isValid() const {
     return ta != Primer::INVALID_TM;
 }
 
-InSilicoPcrTask::InSilicoPcrTask(const InSilicoPcrTaskSettings &settings)
+InSilicoPcrTask::InSilicoPcrTask(const InSilicoPcrTaskSettings &_settings)
     : Task(tr("In Silico PCR"), TaskFlags(TaskFlag_ReportingIsSupported) | TaskFlag_ReportingIsEnabled | TaskFlags_FOSE_COSC),
-      settings(settings), forwardSearch(nullptr), reverseSearch(nullptr), minProductSize(0) {
+      settings(_settings), forwardSearch(nullptr), reverseSearch(nullptr), minProductSize(0) {
     GCOUNTER(cvar, "InSilicoPcrTask");
     minProductSize = qMax(settings.forwardPrimer.length(), settings.reversePrimer.length());
 }

--- a/src/plugins/pcr/src/InSilicoPcrWorkflowTask.cpp
+++ b/src/plugins/pcr/src/InSilicoPcrWorkflowTask.cpp
@@ -23,8 +23,8 @@
 
 namespace U2 {
 
-InSilicoPcrWorkflowTask::InSilicoPcrWorkflowTask(const InSilicoPcrTaskSettings &pcrSettings, const ExtractProductSettings &productSettings)
-    : Task(tr("In silico PCR workflow task"), TaskFlags_NR_FOSE_COSC), productSettings(productSettings) {
+InSilicoPcrWorkflowTask::InSilicoPcrWorkflowTask(const InSilicoPcrTaskSettings &pcrSettings, const ExtractProductSettings &_productSettings)
+    : Task(tr("In silico PCR workflow task"), TaskFlags_NR_FOSE_COSC), productSettings(_productSettings) {
     pcrTask = new InSilicoPcrTask(pcrSettings);
     addSubTask(pcrTask);
     pcrTask->setSubtaskProgressWeight((float)0.7);
@@ -32,12 +32,12 @@ InSilicoPcrWorkflowTask::InSilicoPcrWorkflowTask(const InSilicoPcrTaskSettings &
 
 QList<Task *> InSilicoPcrWorkflowTask::onSubTaskFinished(Task *subTask) {
     QList<Task *> result;
-    CHECK(nullptr != subTask, result);
+    CHECK(subTask != nullptr, result);
     CHECK(!subTask->getStateInfo().isCoR(), result);
 
-    if (pcrTask == subTask) {
+    if (subTask == pcrTask) {
         foreach (const InSilicoPcrProduct &product, pcrTask->getResults()) {
-            ExtractProductTask *productTask = new ExtractProductTask(product, productSettings);
+            auto productTask = new ExtractProductTask(product, productSettings);
             productTask->setSubtaskProgressWeight(0.3 / pcrTask->getResults().size());
             result << productTask;
             productTasks << productTask;


### PR DESCRIPTION
These SAFE_POINTs were found by the https://github.com/ugeneunipro/ugene/pull/566 and blocks it from being submitted

The real fix is inside  "ExtractProductTask::run()" method. Everything else is no-op cleanup I did during debugging the issue.

The problem was with outputUrl that is never set when the task is run from WD
