### PR TITLE
Improve symbol artifact names generated by the release scripts

### DIFF
--- a/etc/script/linux/release.sh
+++ b/etc/script/linux/release.sh
@@ -97,6 +97,6 @@ mv "${APP_BUNDLE_DIR}" "${RELEASE_UNPACKED_DIR_NAME}"
 tar cfz "${RELEASE_BASE_FILE_NAME}.tar.gz" "${RELEASE_UNPACKED_DIR_NAME}"
 
 echo Compressing symbols...
-tar cfz "${SYMBOLS_DIR_NAME}-r${TEAMCITY_RELEASE_BUILD_COUNTER}.tar.gz" "${SYMBOLS_DIR_NAME}"
+tar cfz "${SYMBOLS_DIR_NAME}-r${TEAMCITY_RELEASE_BUILD_COUNTER}-linux-x86-64.tar.gz" "${SYMBOLS_DIR_NAME}"
 
 echo "##teamcity[blockClosed name='Build archive']"

--- a/etc/script/linux/release.sh
+++ b/etc/script/linux/release.sh
@@ -97,6 +97,6 @@ mv "${APP_BUNDLE_DIR}" "${RELEASE_UNPACKED_DIR_NAME}"
 tar cfz "${RELEASE_BASE_FILE_NAME}.tar.gz" "${RELEASE_UNPACKED_DIR_NAME}"
 
 echo Compressing symbols...
-tar cfz "${SYMBOLS_DIR_NAME}.tar.gz" "${SYMBOLS_DIR_NAME}"
+tar cfz "${SYMBOLS_DIR_NAME}-r${TEAMCITY_RELEASE_BUILD_COUNTER}.tar.gz" "${SYMBOLS_DIR_NAME}"
 
 echo "##teamcity[blockClosed name='Build archive']"

--- a/etc/script/mac/release.sh
+++ b/etc/script/mac/release.sh
@@ -110,7 +110,7 @@ find "${APP_DIR}" | sed 's/.*\/tools\/.*$//g' | grep -e ugeneui -e ugenecl -e li
 done
 
 echo Compressing symbols...
-tar cfz "${SYMBOLS_DIR_NAME}.tar.gz" "${SYMBOLS_DIR_NAME}"
+tar cfz "${SYMBOLS_DIR_NAME}-r${TEAMCITY_RELEASE_BUILD_COUNTER}-mac-${ARCHITECTURE_FILE_SUFFIX}.tar.gz" "${SYMBOLS_DIR_NAME}"
 
 echo "##teamcity[blockClosed name='Dump symbols']"
 

--- a/etc/script/windows/release.sh
+++ b/etc/script/windows/release.sh
@@ -68,7 +68,7 @@ echo "##teamcity[blockClosed name='Validate bundle content']"
 echo "##teamcity[blockOpened name='Dump symbols']"
 
 function dump_symbols() {
-  echo "Dumping symbols for $1"
+  echo "Dumping symbols for ${1}"
   BASE_NAME=$(basename "${1}")
   SYMBOL_FILE="${SYMBOLS_DIR}/${BASE_NAME}.sym"
 
@@ -76,7 +76,7 @@ function dump_symbols() {
 
   FILE_HEAD=$(head -n 1 "${SYMBOL_FILE}")
   FILE_HASH=$(echo "${FILE_HEAD}" | awk '{ print $4 }')
-  FILE_NAME=$(echo "${FILE_HEAD}" | awk '{ print $5 }' | tr -d "\r")
+  FILE_NAME=$(echo "${FILE_HEAD}" | awk '{ print $5 }' | tr -d "\r" | tr -d ".pdb")
 
   DEST_PATH="${SYMBOLS_DIR}/${FILE_NAME}/${FILE_HASH}"
   mkdir -p "${DEST_PATH}"


### PR DESCRIPTION
Windows: Strip '.pdb' file suffix from the result symbol file names.
Linux & Mac: include release build number into file name.