### PR TITLE
Use monospaced font in the document text preview widget

### DIFF
--- a/src/ugeneui/src/project_support/DocumentFormatSelectorDialog.ui
+++ b/src/ugeneui/src/project_support/DocumentFormatSelectorDialog.ui
@@ -48,11 +48,23 @@
        <height>200</height>
       </size>
      </property>
+     <property name="styleSheet">
+      <string notr="true">font-family: monospace;</string>
+     </property>
+     <property name="undoRedoEnabled">
+      <bool>false</bool>
+     </property>
      <property name="lineWrapMode">
       <enum>QPlainTextEdit::NoWrap</enum>
      </property>
      <property name="readOnly">
       <bool>true</bool>
+     </property>
+     <property name="plainText">
+      <string notr="true"/>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
This fix is needed because some document formats depends on inner text alignment (like Phylip)
In this case when we show a preview to user we need to keep columns of characters alignment.