### PR TITLE
Move addAlignMenu from MaEditor to MsaEditor

### DIFF
--- a/src/corelibs/U2View/src/ov_msa/MSAEditor.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditor.cpp
@@ -328,6 +328,12 @@ void MSAEditor::addSortMenu(QMenu *m) {
     }
 }
 
+void MSAEditor::addAlignMenu(QMenu *m) {
+    QMenu *em = m->addMenu(tr("Align"));
+    em->setIcon(QIcon(":core/images/align.png"));
+    em->menuAction()->setObjectName(MSAE_MENU_ALIGN);
+}
+
 void MSAEditor::addExportMenu(QMenu *m) {
     MaEditor::addExportMenu(m);
     QMenu *em = GUIUtils::findSubMenu(m, MSAE_MENU_EXPORT);

--- a/src/corelibs/U2View/src/ov_msa/MSAEditor.h
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditor.h
@@ -187,6 +187,7 @@ protected:
     void addCopyPasteMenu(QMenu *m) override;
     void addEditMenu(QMenu *m) override;
     void addSortMenu(QMenu *m);
+    void addAlignMenu(QMenu *m);
     void addExportMenu(QMenu *m) override;
     void addAppearanceMenu(QMenu *m);
     void addColorsMenu(QMenu *m);

--- a/src/corelibs/U2View/src/ov_msa/MaEditor.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditor.cpp
@@ -419,12 +419,6 @@ void MaEditor::addLoadMenu(QMenu *m) {
     lsm->menuAction()->setObjectName(MSAE_MENU_LOAD);
 }
 
-void MaEditor::addAlignMenu(QMenu *m) {
-    QMenu *em = m->addMenu(tr("Align"));
-    em->setIcon(QIcon(":core/images/align.png"));
-    em->menuAction()->setObjectName(MSAE_MENU_ALIGN);
-}
-
 void MaEditor::setFont(const QFont &f) {
     int pSize = f.pointSize();
     font = f;

--- a/src/corelibs/U2View/src/ov_msa/MaEditor.h
+++ b/src/corelibs/U2View/src/ov_msa/MaEditor.h
@@ -249,7 +249,6 @@ protected:
     virtual void addEditMenu(QMenu *m) = 0;
     virtual void addExportMenu(QMenu *m);
     void addLoadMenu(QMenu *m);
-    void addAlignMenu(QMenu *m);  // SANGER_TODO: should the align menu exist in MCA?
 
     void setFont(const QFont &f);
 


### PR DESCRIPTION
This is a trivial patch in the context of the big UGENE-7499 feature

Separation of this patch from the big one helps to reduce the size/side effects of the main patch.