### PR TITLE
UGENE-7463. [Wd] Crash or freeze in "Extract consensus from assemblies".

### DIFF
--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_7001_8000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_7001_8000.cpp
@@ -1434,7 +1434,8 @@ GUI_TEST_CLASS_DEFINITION(test_7463) {
 
     GTUtilsNotifications::waitForNotification(os);
     GTUtilsDialog::waitAllFinished(os);
-    GTTabWidget::closeTab(os, GTUtilsDashboard::getTabWidget(os), "Extract consensus from assembly 2");
+    auto tab = GTTabWidget::getTabBar(os, GTUtilsDashboard::getTabWidget(os));
+    GTWidget::click(os, tab->tabButton(tab->currentIndex(), QTabBar::RightSide));
 }
 
 GUI_TEST_CLASS_DEFINITION(test_7469) {


### PR DESCRIPTION
Fixed GUI test.