### PR TITLE
Cleanup unused SaveDoc_Overwrite flag

### DIFF
--- a/src/corelibs/U2Algorithm/src/smith_waterman/SmithWatermanReportCallback.cpp
+++ b/src/corelibs/U2Algorithm/src/smith_waterman/SmithWatermanReportCallback.cpp
@@ -234,7 +234,7 @@ QString SmithWatermanReportCallbackMAImpl::planFor_SequenceView_Search(const QLi
         alignmentDoc->addObject(docObject);
         currentProject->addDocument(alignmentDoc);
 
-        SaveDocFlags flags = SaveDoc_Overwrite;
+        SaveDocFlags flags;
         Task *saveMADocument = nullptr;
 
         if (countOfLoadedDocs < SmithWatermanReportCallbackMAImpl::countOfSimultLoadedMADocs) {
@@ -318,17 +318,14 @@ QString SmithWatermanReportCallbackMAImpl::planFor_MSA_Alignment_InNewWindow(
     CHECK_OP(stateInfo, tr("Failed to create an alignment."));
     alignmentDoc->addObject(docObject);
 
-    SaveDocFlags flags = SaveDoc_Overwrite;
-    flags |= SaveDoc_OpenAfter;
-    Task *saveMADocument = nullptr;
-
+    SaveDocFlags flags = SaveDoc_OpenAfter;
     if (countOfLoadedDocs < SmithWatermanReportCallbackMAImpl::countOfSimultLoadedMADocs) {
         ++countOfLoadedDocs;
     } else {
         flags |= SaveDoc_UnloadAfter;
     }
 
-    saveMADocument = new SaveDocumentTask(alignmentDoc, flags);
+    auto saveMADocument = new SaveDocumentTask(alignmentDoc, flags);
     taskScheduler->registerTopLevelTask(saveMADocument);
     return QString();
 }

--- a/src/corelibs/U2Core/src/tasks/SaveDocumentTask.cpp
+++ b/src/corelibs/U2Core/src/tasks/SaveDocumentTask.cpp
@@ -250,7 +250,7 @@ SaveMultipleDocuments::SaveMultipleDocuments(const QList<Document *> &docs, bool
                 url = chooseAnotherUrl(doc);
                 if (!url.isEmpty()) {
                     if (saveAndOpenFlag == SavedNewDoc_Open) {
-                        addSubTask(new SaveDocumentTask(doc, doc->getIOAdapterFactory(), url, SaveDocFlags(SaveDoc_Overwrite) | SaveDoc_DestroyAfter | SaveDoc_OpenAfter));
+                        addSubTask(new SaveDocumentTask(doc, doc->getIOAdapterFactory(), url, SaveDocFlags(SaveDoc_DestroyAfter | SaveDoc_OpenAfter)));
                     } else {
                         addSubTask(new SaveDocumentTask(doc, doc->getIOAdapterFactory(), url));
                     }

--- a/src/corelibs/U2Core/src/tasks/SaveDocumentTask.h
+++ b/src/corelibs/U2Core/src/tasks/SaveDocumentTask.h
@@ -36,7 +36,7 @@ class IOAdapterFactory;
 class DocumentFormat;
 
 enum SaveDocFlag {
-    SaveDoc_Overwrite = 1 << 0,
+    SaveDoc_Overwrite = 1 << 0,  // Deprecated. Not used by the 'SaveDocumentTask', but still is used by a non-related code.
     SaveDoc_Append = 1 << 1,
     SaveDoc_Roll = 1 << 2,
     SaveDoc_DestroyAfter = 1 << 3,
@@ -50,7 +50,7 @@ Q_DECLARE_FLAGS(SaveDocFlags, SaveDocFlag)
 class U2CORE_EXPORT SaveDocumentTask : public Task {
     Q_OBJECT
 public:
-    SaveDocumentTask(Document *doc, IOAdapterFactory *iof = nullptr, const GUrl &url = GUrl(), SaveDocFlags flags = SaveDoc_Overwrite);
+    SaveDocumentTask(Document *doc, IOAdapterFactory *iof = nullptr, const GUrl &url = GUrl(), SaveDocFlags flags = 0);
     SaveDocumentTask(Document *doc, SaveDocFlags flags, const QSet<QString> &excludeFileNames = QSet<QString>());
 
     void prepare() override;

--- a/src/corelibs/U2Script/src/CommonDbi.cpp
+++ b/src/corelibs/U2Script/src/CommonDbi.cpp
@@ -151,7 +151,7 @@ U2SCRIPT_EXPORT void saveObjectsToFile(UgeneDbHandle *objects, int objectCount, 
             doc->addObject(object);
         }
     }
-    Task *saveDoc = new SaveDocumentTask(doc, SaveDoc_Overwrite);
+    Task *saveDoc = new SaveDocumentTask(doc);
     AppContext::getTaskScheduler()->registerTopLevelTask(saveDoc);
 }
 

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyReadsArea.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyReadsArea.cpp
@@ -914,7 +914,7 @@ void AssemblyReadsArea::exportReads(const QList<U2AssemblyRead> &reads) {
         Document *doc = df->createNewLoadedDocument(iof, model.filepath, os);
         CHECK_OP(os, )
 
-        SaveDocFlags saveFlags(SaveDoc_Overwrite);
+        SaveDocFlags saveFlags;
         if (model.addToProject) {
             saveFlags |= SaveDoc_OpenAfter;
         }

--- a/src/corelibs/U2View/src/ov_assembly/ExportConsensusTask.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/ExportConsensusTask.cpp
@@ -93,8 +93,7 @@ void ExportConsensusTask::prepare() {
     CHECK_OP(stateInfo, );
 
     if (settings.saveToFile) {
-        SaveDocFlags saveFlags = SaveDoc_Overwrite;
-        addSubTask(new SaveDocumentTask(resultDocument, saveFlags));
+        addSubTask(new SaveDocumentTask(resultDocument));
 
         Project *p = AppContext::getProject();
         if (p != nullptr && p->findDocumentByURL(resultDocument->getURL()) != nullptr) {

--- a/src/corelibs/U2View/src/ov_assembly/ExportConsensusVariationsTask.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/ExportConsensusVariationsTask.cpp
@@ -87,8 +87,7 @@ void ExportConsensusVariationsTask::prepare() {
     U2EntityRef trackRef(resultDocument->getDbiRef(), track.id);
     varTrackObject = new VariantTrackObject(settings.seqObjName, trackRef);
 
-    SaveDocFlags saveFlags = SaveDoc_Overwrite;
-    addSubTask(new SaveDocumentTask(resultDocument, saveFlags));
+    addSubTask(new SaveDocumentTask(resultDocument));
 
     Project *p = AppContext::getProject();
     if (p != nullptr && p->findDocumentByURL(resultDocument->getURL()) != nullptr) {

--- a/src/corelibs/U2View/src/ov_msa/MaEditorTasks.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorTasks.cpp
@@ -281,7 +281,6 @@ QList<Task *> ExportMaConsensusTask::onSubTaskFinished(Task *subTask) {
     Document *consensusDocument = createDocument();
     CHECK_OP(stateInfo, taskList);
     auto saveTask = new SaveDocumentTask(consensusDocument, consensusDocument->getIOAdapterFactory(), consensusDocument->getURL());
-    saveTask->addFlag(SaveDoc_Overwrite);
     taskList << saveTask;
 
     Project *proj = AppContext::getProject();

--- a/src/plugins/CoreTests/src/DocumentModelTests.cpp
+++ b/src/plugins/CoreTests/src/DocumentModelTests.cpp
@@ -215,7 +215,7 @@ void GTest_SaveDocument::prepare() {
         return;
     }
 
-    SaveDocFlags saveTaskFlags = SaveDoc_Overwrite;
+    SaveDocFlags saveTaskFlags;
     if (!formatId.isEmpty() && formatId != doc->getDocumentFormatId()) {
         DocumentFormat *format = AppContext::getDocumentFormatRegistry()->getFormatById(formatId);
         CHECK_EXT(nullptr != format, stateInfo.setError(QString("Document format not found: %1").arg(formatId)), );

--- a/src/plugins/dna_export/src/DNASequenceGenerator.cpp
+++ b/src/plugins/dna_export/src/DNASequenceGenerator.cpp
@@ -282,7 +282,7 @@ QList<Task *> DNASequenceGeneratorTask::onGenerateTaskFinished() {
                        resultTasks);
             addSequencesToMsaDoc(doc);
         }
-        saveTask = new SaveDocumentTask(doc, SaveDoc_Overwrite);
+        saveTask = new SaveDocumentTask(doc);
         resultTasks << saveTask;
     } else {  // TODO: avoid high memory consumption here
         const DNAAlphabet *alp = cfg.getAlphabet();

--- a/src/plugins/external_tool_support/src/blast_plus/align_worker_subtasks/PrepareReferenceSequenceTask.cpp
+++ b/src/plugins/external_tool_support/src/blast_plus/align_worker_subtasks/PrepareReferenceSequenceTask.cpp
@@ -101,7 +101,7 @@ QList<Task *> PrepareReferenceSequenceTask::onSubTaskFinished(Task *subTask) {
 
         preparedReferenceUrl = GUrlUtils::rollFileName(doc->getURL().getURLString(), "_");    // we roll the URL here because there was a strange problem when UGENE couldn't overwrite the file (UTI-242)
         Document *fastaDoc = doc->getSimpleCopy(fastaFormat, ioAdapterFactory, preparedReferenceUrl);
-        SaveDocumentTask *saveTask = new SaveDocumentTask(fastaDoc, SaveDoc_Overwrite | SaveDoc_DestroyButDontUnload);
+        SaveDocumentTask *saveTask = new SaveDocumentTask(fastaDoc, SaveDoc_DestroyButDontUnload);
         newSubTasks << saveTask;
     }
 

--- a/src/plugins/external_tool_support/src/utils/ExportTasks.cpp
+++ b/src/plugins/external_tool_support/src/utils/ExportTasks.cpp
@@ -166,7 +166,7 @@ QList<Task *> SaveSequenceTask::onSubTaskFinished(Task *subTask) {
         document->setDocumentOwnsDbiResources(true);
         document->addObject(cloneTask->takeResult());
 
-        SaveDocumentTask *saveTask = new SaveDocumentTask(document, nullptr, GUrl(), SaveDocFlags(SaveDoc_Overwrite) | SaveDoc_DestroyAfter);
+        SaveDocumentTask *saveTask = new SaveDocumentTask(document, nullptr, GUrl(), SaveDoc_DestroyAfter);
         saveTask->setSubtaskProgressWeight(50);
         result << saveTask;
     }

--- a/src/plugins/pcr/src/ExtractProductTask.cpp
+++ b/src/plugins/pcr/src/ExtractProductTask.cpp
@@ -291,7 +291,6 @@ QList<Task *> ExtractProductWrapperTask::onSubTaskFinished(Task *subTask) {
     SaveDocFlags flags;
     flags |= SaveDoc_OpenAfter;
     flags |= SaveDoc_DestroyAfter;
-    flags |= SaveDoc_Overwrite;
     QFile::remove(settings.outputFile);
     result << new SaveDocumentTask(extractTask->takeResult(), flags);
     return result;

--- a/src/plugins/pcr/src/export/ExportPrimersToLocalFileTask.cpp
+++ b/src/plugins/pcr/src/export/ExportPrimersToLocalFileTask.cpp
@@ -62,7 +62,7 @@ QList<Task *> ExportPrimersToLocalFileTask::onSubTaskFinished(Task *subTask) {
     addObjects(document, convertTask);
     CHECK_OP(stateInfo, result);
 
-    result << new SaveDocumentTask(document, SaveDocFlags(SaveDoc_Overwrite | SaveDoc_DestroyAfter));
+    result << new SaveDocumentTask(document, SaveDoc_DestroyAfter);
     return result;
 }
 

--- a/src/plugins_3rdparty/kalign/src/PairwiseAlignmentHirschbergTask.cpp
+++ b/src/plugins_3rdparty/kalign/src/PairwiseAlignmentHirschbergTask.cpp
@@ -131,8 +131,7 @@ QList<Task *> PairwiseAlignmentHirschbergTask::onSubTaskFinished(Task *subTask) 
 
             alignmentDoc->addObject(docObject);
 
-            SaveDocFlags flags = SaveDoc_Overwrite;
-            flags |= SaveDoc_OpenAfter;
+            SaveDocFlags flags = SaveDoc_OpenAfter;
             res << new SaveDocumentTask(alignmentDoc, flags);
         } else {  // in current window
             U2OpStatus2Log os;


### PR DESCRIPTION
This flag (SaveDoc_Overwrite) is not used as designed at all because save-with-overwrite is also the default behavior of the SaveDocumentTask.

This patch removes it from all users of the SaveDocumentTask. Once this patch is submitted and we see no issues/regression I will remove it completely from other places in the code in a separate PR (WD workers use this flag for their own independent use-case)