### PR TITLE
Translations for PCR Primer Design for DNA assembly

### DIFF
--- a/src/plugins/GUITestBase/src/tests/common_scenarios/pcr_primer_design_for_dna_assembly/GTTestsPcrPrimerDesignForDnaAssembly.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/pcr_primer_design_for_dna_assembly/GTTestsPcrPrimerDesignForDnaAssembly.cpp
@@ -491,7 +491,7 @@ GUI_TEST_CLASS_DEFINITION(test_0005) {
     // Open the PCR Primer Design tab.
     // Set common_data/pcr_primer_design/backbone_bad.fa as "Open the backbone sequence".
     // Click "Insert to backbone bearings" -> "5' insert to 3' backbone".
-    // Set "Insert to backbone bearings" -> "5' backbone length" = 12.
+    // Set "Insert to backbone bearings" -> "3' backbone length" = 12.
     // Click "Start".
     //     Expected: the "The unwanted structures have been found in the following backbone sequence candidate" dialog
     //               has appeared.

--- a/src/plugins/pcr_primer_design_for_dna_assembly/src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp
+++ b/src/plugins/pcr_primer_design_for_dna_assembly/src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp
@@ -74,9 +74,8 @@ const QString PCRPrimerDesignForDNAAssemblyOPWidget::SELECT_AREAS_FOR_PRIMING_SH
 const QString PCRPrimerDesignForDNAAssemblyOPWidget::OPEN_BACKBONE_SEQUENCE_SHOW_HIDE_ID = "open-backbone-sequence-show-hide-id";
 const QString PCRPrimerDesignForDNAAssemblyOPWidget::GENERATE_SEQUENCE_SHOW_HIDE_ID = "generate-sequence-show-hide-id";
 const QString PCRPrimerDesignForDNAAssemblyOPWidget::OTHER_SEQUENCES_IN_PCR_REACTION_SHOW_HIDE_ID = "other-sequences-in-pcr-reaction-show-hide-id";
-QString PCRPrimerDesignForDNAAssemblyOPWidget::PCR_TABLE_OBJECT_NAME() {
-    return PCRPrimerDesignForDNAAssemblyOPWidget::tr("PCR Primer Design for DNA assembly");
-}
+const QString PCRPrimerDesignForDNAAssemblyOPWidget::PCR_TABLE_OBJECT_NAME =
+    QApplication::translate("PCRPrimerDesignForDNAAssemblyOPWidget", "PCR Primer Design for DNA assembly");
 
 PCRPrimerDesignForDNAAssemblyOPWidget::PCRPrimerDesignForDNAAssemblyOPWidget(AnnotatedDNAView* _annDnaView)
     : QWidget(nullptr),
@@ -456,7 +455,7 @@ void PCRPrimerDesignForDNAAssemblyOPWidget::createResultAnnotations() {
     U2OpStatusImpl os;
     const U2DbiRef localDbiRef = AppContext::getDbiRegistry()->getSessionTmpDbiRef(os);
     SAFE_POINT_OP(os, );
-    auto resultsTableObject = new AnnotationTableObject(PCR_TABLE_OBJECT_NAME(), localDbiRef);
+    auto resultsTableObject = new AnnotationTableObject(PCR_TABLE_OBJECT_NAME, localDbiRef);
     QSet<QString> excludeList;
     for (Document *d : qAsConst(AppContext::getProject()->getDocuments())) {
         excludeList.insert(d->getURLString());

--- a/src/plugins/pcr_primer_design_for_dna_assembly/src/PCRPrimerDesignForDNAAssemblyOPWidget.h
+++ b/src/plugins/pcr_primer_design_for_dna_assembly/src/PCRPrimerDesignForDNAAssemblyOPWidget.h
@@ -161,7 +161,7 @@ private:
     static const QString OPEN_BACKBONE_SEQUENCE_SHOW_HIDE_ID;
     static const QString GENERATE_SEQUENCE_SHOW_HIDE_ID;
     static const QString OTHER_SEQUENCES_IN_PCR_REACTION_SHOW_HIDE_ID;
-    static QString PCR_TABLE_OBJECT_NAME();
+    static const QString PCR_TABLE_OBJECT_NAME;
 };
 
 

--- a/src/plugins/pcr_primer_design_for_dna_assembly/src/UnwantedStructuresInBackboneDialog.ui
+++ b/src/plugins/pcr_primer_design_for_dna_assembly/src/UnwantedStructuresInBackboneDialog.ui
@@ -56,7 +56,7 @@ p, li { white-space: pre-wrap; }
    <item>
     <widget class="QLabel" name="questionLabel">
      <property name="text">
-      <string>There no sequences in the file left. Use this sequence as the backbone?</string>
+      <string>There are no sequences in the file left. Use this sequence as the backbone?</string>
      </property>
     </widget>
    </item>

--- a/src/plugins/pcr_primer_design_for_dna_assembly/src/options_panel/ResultTable.cpp
+++ b/src/plugins/pcr_primer_design_for_dna_assembly/src/options_panel/ResultTable.cpp
@@ -54,7 +54,9 @@ void ResultTable::setCurrentProducts(const QList<U2Region> &_currentProducts, An
     for (const U2Region &region : qAsConst(_currentProducts)) {
         if (!region.isEmpty()) {
             setItem(row, 0, new QTableWidgetItem(PCRPrimerDesignForDNAAssemblyTask::FRAGMENT_INDEX_TO_NAME.at(index)));
-            setItem(row, 1, new QTableWidgetItem(tr("%1-%2").arg(QString::number(region.startPos + 1)).arg(QString::number(region.endPos()))));
+            setItem(row, 1, new QTableWidgetItem(QString("%1-%2")
+                                                     .arg(QString::number(region.startPos + 1))
+                                                     .arg(QString::number(region.endPos()))));
             row++;
         }
         index++;

--- a/src/plugins/pcr_primer_design_for_dna_assembly/src/tasks/FindPresenceOfUnwantedParametersTask.cpp
+++ b/src/plugins/pcr_primer_design_for_dna_assembly/src/tasks/FindPresenceOfUnwantedParametersTask.cpp
@@ -29,7 +29,7 @@ namespace U2 {
 
 FindPresenceOfUnwantedParametersTask::FindPresenceOfUnwantedParametersTask(const QByteArray& _sequence,
                                             const PCRPrimerDesignForDNAAssemblyTaskSettings& _settings)
-    : Task("Find Presence of Unwanted Parameters Task", TaskFlags_FOSCOE),
+    : Task(tr("Find Presence of Unwanted Parameters Task"), TaskFlags_FOSCOE),
       sequence(_sequence),
       settings(_settings) {}
 
@@ -37,10 +37,10 @@ void FindPresenceOfUnwantedParametersTask::run() {
     SAFE_POINT(settings.bachbone5Length >= 0 && settings.bachbone3Length >= 0,
                "Backbone length must be greater than 0", )
     if (sequence.length() < settings.bachbone5Length) {
-        stateInfo.addWarning("Sequence length is less than 5' backbone length, the entire sequence is used");
+        stateInfo.addWarning(tr("Sequence length is less than 5' backbone length, the entire sequence is used"));
     }
     if (sequence.length() < settings.bachbone3Length) {
-        stateInfo.addWarning("Sequence length is less than 3' backbone length, the entire sequence is used");
+        stateInfo.addWarning(tr("Sequence length is less than 3' backbone length, the entire sequence is used"));
     }
     QByteArray forward = sequence.left(settings.bachbone5Length);
     QByteArray reverse = sequence.right(settings.bachbone3Length);

--- a/src/plugins/pcr_primer_design_for_dna_assembly/src/tasks/FindUnwantedIslandsTask.cpp
+++ b/src/plugins/pcr_primer_design_for_dna_assembly/src/tasks/FindUnwantedIslandsTask.cpp
@@ -31,7 +31,7 @@
 namespace U2 {
 
 FindUnwantedIslandsTask::FindUnwantedIslandsTask(const U2Region& _searchArea, int _possibleOverlap, const QByteArray& _sequence, bool _isComplement)
-    : Task("Find Unwanted Islands Task", TaskFlags_FOSCOE),
+    : Task(tr("Find Unwanted Islands Task"), TaskFlags_FOSCOE),
       searchArea(_searchArea),
       possibleOverlap(_possibleOverlap),
       sequence(_sequence),
@@ -40,8 +40,10 @@ FindUnwantedIslandsTask::FindUnwantedIslandsTask(const U2Region& _searchArea, in
 void FindUnwantedIslandsTask::run() {
     taskLog.details(tr("Searching of unwanted islands and areas between them "
                        "in the region \"%1\" (+ %2 nucleotides to the %3, deep into the amplified fragment) has been started")
-                       .arg(regionToString(searchArea)).arg(possibleOverlap).arg(isComplement ? "left" : "right"));
-    taskLog.details(tr("The following unwanted parametes are used. Free Gibbs energy: %1 kj/mol, "
+                        .arg(regionToString(searchArea))
+                        .arg(possibleOverlap)
+                        .arg(isComplement ? tr("left") : tr("right")));
+    taskLog.details(tr("The following unwanted parameters are used. Free Gibbs energy: %1 kj/mol, "
                        "melting temperature: %2 C, maximum dimer length: %3 nt")
                        .arg(UNWANTED_DELTA_G).arg(UNWANTED_MELTING_TEMPERATURE).arg(UNWANTED_MAX_LENGTH));
     /**

--- a/src/plugins/pcr_primer_design_for_dna_assembly/src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp
+++ b/src/plugins/pcr_primer_design_for_dna_assembly/src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp
@@ -237,7 +237,7 @@ QList<Task*> PCRPrimerDesignForDNAAssemblyTask::onSubTaskFinished(Task* subTask)
             return { checkBackboneSequence };
         } else {
             backboneSequence = QByteArray();
-            taskLog.error(tr("The file \"%1\" doesn't contain the backbone sequence, which matchs the parameters. "
+            taskLog.error(tr("The file \"%1\" doesn't contain the backbone sequence, which matches the parameters. "
                 "Skip the backbone sequence parameter.").arg(settings.backboneSequenceUrl));
         }
     } else if (subTask == loadOtherSequencesInPcr) {

--- a/src/plugins/pcr_primer_design_for_dna_assembly/src/tasks/PCRPrimerDesignForDNAAssemblyTaskTest.cpp
+++ b/src/plugins/pcr_primer_design_for_dna_assembly/src/tasks/PCRPrimerDesignForDNAAssemblyTaskTest.cpp
@@ -87,10 +87,10 @@ void GTest_PCRPrimerDesignForDNAAssemblyTaskTest::init(XMLTestFormat *, const QD
 
 void GTest_PCRPrimerDesignForDNAAssemblyTaskTest::prepare() {
     Document *loadedDocument = getContext<Document>(this, docName);
-    CHECK_EXT(loadedDocument != nullptr, stateInfo.setError(GTest::tr("context not found %1").arg(docName)), );
+    CHECK_EXT(loadedDocument != nullptr, stateInfo.setError(QString("context not found %1").arg(docName)), );
     
     U2SequenceObject *dnaso = (U2SequenceObject *)loadedDocument->findGObjectByName(seqName);
-    CHECK_EXT(dnaso != nullptr, stateInfo.setError(GTest::tr("Sequence %1 not found").arg(seqName)), );
+    CHECK_EXT(dnaso != nullptr, stateInfo.setError(QString("Sequence %1 not found").arg(seqName)), );
 
     CHECK_OP(stateInfo, );
 

--- a/src/plugins/pcr_primer_design_for_dna_assembly/src/utils/PCRPrimerDesignTaskReportUtils.cpp
+++ b/src/plugins/pcr_primer_design_for_dna_assembly/src/utils/PCRPrimerDesignTaskReportUtils.cpp
@@ -26,14 +26,11 @@
 #include "../PCRPrimerDesignForDNAAssemblyPlugin.h"
 #include "../tasks/PCRPrimerDesignForDNAAssemblyTask.h"
 
-// Short alias for translate string method.
-static QString tr(const char s[]) {
-    return U2::PCRPrimerDesignForDNAAssemblyPlugin::tr(s);
-}
+namespace U2 {
 
 // Returns error message in html.
 static QString errMsg() {
-    return tr("<p>Error, see log.</p>");
+    return PCRPrimerDesignForDNAAssemblyPlugin::tr("<p>Error, see log.</p>");
 }
 
 // Returns primerName as html header. Wraps primerName in <h2> tag. primerName must not be empty.
@@ -48,27 +45,25 @@ static QString primerToHtml(const QString &primer) {
 
 // Functions below return row and column headers.
 static QString forwardUserPrimerStr() {
-    return tr("Forward user primer");
+    return PCRPrimerDesignForDNAAssemblyPlugin::tr("Forward user primer");
 }
 static QString reverseUserPrimerStr() {
-    return tr("Reverse user primer");
+    return PCRPrimerDesignForDNAAssemblyPlugin::tr("Reverse user primer");
 }
 static QString sequenceStr() {
-    return tr("File sequence");
+    return PCRPrimerDesignForDNAAssemblyPlugin::tr("Sequence");
 }
 static QString revComplSeqStr() {
-    return tr("Reverse complementary file sequence");
+    return PCRPrimerDesignForDNAAssemblyPlugin::tr("Reverse complementary sequence");
 }
 static QString otherSequencesStr() {
-    return tr("Other sequences in PCR reaction");
+    return PCRPrimerDesignForDNAAssemblyPlugin::tr("Other sequences in PCR reaction");
 }
 
 // Returns "name1 and name2". name1 and name2 must not be empty.
 static QString concatenateNames(const QString &name1, const QString &name2) {
-    return name1 + tr(" and ") + name2;
+    return name1 + PCRPrimerDesignForDNAAssemblyPlugin::tr(" and ") + name2;
 }
-
-namespace U2 {
 
 // Are user primers set?
 static bool hasUserPrimers(const PCRPrimerDesignForDNAAssemblyTaskSettings &settings) {
@@ -88,8 +83,10 @@ static QString checkPrimerAndGetInfo(const U2Region region, const QString &prime
     if (!region.isEmpty()) {
         ans += primerHeader(primerName);
         SAFE_POINT(region.startPos > 0 && region.startPos < sequence.length() && region.length > 0,
-                   tr("Invalid region %1 for sequence length %2 (%3 primer)").arg(region.toString())
-                       .arg(sequence.length()).arg(primerName),
+                   QString("Invalid region %1 for sequence length %2 (%3 primer)")
+                       .arg(region.toString())
+                       .arg(sequence.length())
+                       .arg(primerName),
                    ans += errMsg())
 
         QString res = "<p>%1%2</p>";
@@ -111,12 +108,12 @@ static QString primersInfo(const PCRPrimerDesignForDNAAssemblyTask &task,
                            const QByteArray &sequence,
                            const QByteArray &revComplSeq,
                            const PCRPrimerDesignTaskReportUtils::UserPrimersReports &reports) {
-    SAFE_POINT(!sequence.isEmpty(), tr("Empty sequence"), errMsg())
+    SAFE_POINT(!sequence.isEmpty(), "Empty sequence", errMsg())
 
     const QStringList &primersNames = PCRPrimerDesignForDNAAssemblyTask::FRAGMENT_INDEX_TO_NAME;
     QList<U2Region> regions = task.getResults();
     SAFE_POINT(regions.size() == primersNames.size(),
-               tr("The number of resulting primers (%1) isn't equal to the number of primer names (%2)")
+               QString("The number of resulting primers (%1) isn't equal to the number of primer names (%2)")
                    .arg(regions.size())
                    .arg(primersNames.size()),
                errMsg())
@@ -124,16 +121,17 @@ static QString primersInfo(const PCRPrimerDesignForDNAAssemblyTask &task,
     bool primersNotFound = std::all_of(regions.begin(), regions.end(), [](U2Region r) { return r.isEmpty(); });
     bool areUserPrimersBad = !hasUserPrimers(task.getSettings()) || reports.hasUnwantedConnections();
     if (primersNotFound && areUserPrimersBad) {
-        return tr("<p>There are no primers that meet the specified parameters.</p>");
+        return PCRPrimerDesignForDNAAssemblyPlugin::tr("<p>There are no primers that meet the specified parameters."
+                                                       "</p>");
     }
 
     QString ans;
     // Desciption.
-    ans += tr("<h3>Details:</h3>"
-              "<p>"
-              "<u>Underlined</u>&#8211;backbone sequence&#59;<br>"
-              "<b>Bold</b>&#8211;primer sequence."
-              "</p>");
+    ans += PCRPrimerDesignForDNAAssemblyPlugin::tr("<h3>Details:</h3>"
+                                                   "<p>"
+                                                   "<u>Underlined</u>&#8211;backbone sequence&#59;<br>"
+                                                   "<b>Bold</b>&#8211;primer sequence."
+                                                   "</p>");
 
     QString backbone = task.getBackboneSequence().isEmpty() ? task.getBackboneSequence() : "<u>" +
         task.getBackboneSequence() + "</u>";
@@ -186,10 +184,10 @@ QString PCRPrimerDesignTaskReportUtils::userPrimersUnwantedConnectionsInfo(
     const PCRPrimerDesignTaskReportUtils::UserPrimersReports &reports) {
     QString ans;
     if (hasUserPrimers(settings) && reports.hasUnwantedConnections()) {
-        ans += tr("<h2>Unwanted connections of user primers</h2>");
+        ans += PCRPrimerDesignForDNAAssemblyPlugin::tr("<h2>Unwanted connections of user primers</h2>");
 
         if (reports.hasSelfdimers()) {
-            QString selfdimerStr = tr("Selfdimers");
+            QString selfdimerStr = PCRPrimerDesignForDNAAssemblyPlugin::tr("Self-dimers");
             PCRPrimerDesignTaskReportUtils::UserPrimersTable table(selfdimerStr, {selfdimerStr});
             table.addForwardRow({!reports.forward.selfdimer.isEmpty()});
             table.addReverseRow({!reports.reverse.selfdimer.isEmpty()});
@@ -204,8 +202,11 @@ QString PCRPrimerDesignTaskReportUtils::userPrimersUnwantedConnectionsInfo(
                 return {!reports.heterodimer.isEmpty(), !r.fileSeq.isEmpty(), !r.fileRevComplSeq.isEmpty(),
                         !r.other.isEmpty()};
             };
-            UserPrimersTable table(tr("Heterodimers"), {tr("Another user primer"), sequenceStr(), revComplSeqStr(),
-                                                        otherSequencesStr()});
+            UserPrimersTable table(PCRPrimerDesignForDNAAssemblyPlugin::tr("Hetero-dimers"),
+                                   {PCRPrimerDesignForDNAAssemblyPlugin::tr("Another user primer"),
+                                    sequenceStr(),
+                                    revComplSeqStr(),
+                                    otherSequencesStr()});
             table.addForwardRow(getRow(reports.forward));
             table.addReverseRow(getRow(reports.reverse));
 
@@ -240,7 +241,9 @@ bool PCRPrimerDesignTaskReportUtils::UserPrimersReports::hasUnwantedConnections(
 QString PCRPrimerDesignTaskReportUtils::UserPrimersTable::getRow(const QList<bool> &row) const {
     QString ans;
     for (bool cell : qAsConst(row)) {
-        ans += "<td align='center'>" + (cell ? tr("Yes") : tr("No")) + "</td>";
+        ans += "<td align='center'>" +
+               (cell ? PCRPrimerDesignForDNAAssemblyPlugin::tr("Yes") : PCRPrimerDesignForDNAAssemblyPlugin::tr("No")) +
+               "</td>";
     }
     return ans;
 }

--- a/src/plugins/pcr_primer_design_for_dna_assembly/transl/russian.ts
+++ b/src/plugins/pcr_primer_design_for_dna_assembly/transl/russian.ts
@@ -342,7 +342,7 @@
     <message>
         <location filename="../src/PCRPrimerDesignForDNAAssemblyPlugin.cpp" line="44"/>
         <source>PCR Primer Design for DNA assembly.</source>
-        <translation>Дизайн праймеров для ПЦР для сборки ДНК,.</translation>
+        <translation>Дизайн праймеров для ПЦР для сборки ДНК.</translation>
     </message>
     <message>
         <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="33"/>

--- a/src/plugins/pcr_primer_design_for_dna_assembly/transl/russian.ts
+++ b/src/plugins/pcr_primer_design_for_dna_assembly/transl/russian.ts
@@ -31,7 +31,7 @@
     <message>
         <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.ui" line="227"/>
         <source>Sequence</source>
-        <translation type="unfinished"></translation>
+        <translation>Последовательность</translation>
     </message>
     <message>
         <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.ui" line="235"/>
@@ -113,7 +113,7 @@
     <message>
         <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.ui" line="566"/>
         <source>Max complementary motifs length</source>
-        <translation>Максимальная длина комплементарных мотивов</translation>
+        <translation>Макс. длина комплементарных мотивов</translation>
     </message>
     <message>
         <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.ui" line="827"/>
@@ -172,165 +172,10 @@
         <source>Info: choose a nucleic sequence for running PCR Primer Design</source>
         <translation>Инфо: выберите нуклеотидную последовательность для запуска &quot;Дизайна Праймеров для ПЦР&quot;</translation>
     </message>
-</context>
-<context>
-    <name>QObject</name>
     <message>
-        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="77"/>
+        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="78"/>
         <source>PCR Primer Design for DNA assembly</source>
         <translation>Дизайн праймеров для ПЦР для сборки ДНК</translation>
-    </message>
-    <message>
-        <source>A Forward</source>
-        <translation type="vanished">А Прямой</translation>
-    </message>
-    <message>
-        <source>A Reverse</source>
-        <translation type="vanished">А Обратный</translation>
-    </message>
-    <message>
-        <source>B1 Forward</source>
-        <translation type="vanished">В1 Прямой</translation>
-    </message>
-    <message>
-        <source>B1 Reverse</source>
-        <translation type="vanished">B1 Обратный</translation>
-    </message>
-    <message>
-        <source>B2 Forward</source>
-        <translation type="vanished">В2 Прямой</translation>
-    </message>
-    <message>
-        <source>B2 Reverse</source>
-        <translation type="vanished">В2 Обратный</translation>
-    </message>
-    <message>
-        <source>B3 Forward</source>
-        <translation type="vanished">В3 Прямой</translation>
-    </message>
-    <message>
-        <source>B3 Reverse</source>
-        <translation type="vanished">В3 Обратный</translation>
-    </message>
-    <message>
-        <location filename="../src/UnwantedStructuresInBackboneDialog.cpp" line="39"/>
-        <source>are no sequences</source>
-        <translation>0</translation>
-    </message>
-    <message>
-        <location filename="../src/UnwantedStructuresInBackboneDialog.cpp" line="42"/>
-        <source>is 1 sequence</source>
-        <translation>1</translation>
-    </message>
-    <message>
-        <location filename="../src/UnwantedStructuresInBackboneDialog.cpp" line="45"/>
-        <source>are %1 sequences</source>
-        <translation>%1</translation>
-    </message>
-    <message>
-        <location filename="../src/UnwantedStructuresInBackboneDialog.cpp" line="47"/>
-        <source>There %1 in the file left. Use this sequence as the backbone?</source>
-        <translation>Последовательностей осталось: %1. Использовать текущую в качестве остова?</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/UnwantedConnectionsUtils.cpp" line="45"/>
-        <source>&lt;b&gt;Self-dimer:&lt;/b&gt;&lt;br&gt;</source>
-        <translation>&lt;b&gt;Гомодимер:&lt;/b&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/UnwantedConnectionsUtils.cpp" line="67"/>
-        <source>&lt;b&gt;Hetero-dimer:&lt;/b&gt;&lt;br&gt;</source>
-        <translation>&lt;b&gt;Гетеродимер:&lt;/b&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="30"/>
-        <source>&lt;p&gt;Error, see log.&lt;/p&gt;</source>
-        <translation>&lt;b&gt;Ошибка, смотрите лог:&lt;/b&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="45"/>
-        <source>Forward user primer</source>
-        <translation>Прямой праймер пользователя</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="48"/>
-        <source>Reverse user primer</source>
-        <translation>Обратный праймер пользователя</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="51"/>
-        <source>File sequence</source>
-        <translation>Файл последовательности</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="54"/>
-        <source>Reverse complementary file sequence</source>
-        <translation>Обратно комплементарный файл последовательности</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="57"/>
-        <source>Other sequences in PCR reaction</source>
-        <translation>Другие последовательностив реакции ПЦР</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="62"/>
-        <source> and </source>
-        <translation> и </translation>
-    </message>
-    <message>
-        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="85"/>
-        <source>Invalid region %1 for sequence length %2 (%3 primer)</source>
-        <translation>Не валидный регион %1 для последовательности длиной %2 (праймер %3)</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="108"/>
-        <source>Empty sequence</source>
-        <translation>Пустая последовательность</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="113"/>
-        <source>The number of resulting primers (%1) isn&apos;t equal to the number of primer names (%2)</source>
-        <translation>Количество полученных в результате праймеров (%1) не равно количеству имен праймеров (%2)</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="121"/>
-        <source>&lt;p&gt;There are no primers that meet the specified parameters.&lt;/p&gt;</source>
-        <translation>&lt;p&gt;Нет праймеров, подходящих под заданные параметры.&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="126"/>
-        <source>&lt;h3&gt;Details:&lt;/h3&gt;&lt;p&gt;&lt;u&gt;Underlined&lt;/u&gt;&amp;#8211;backbone sequence&amp;#59;&lt;br&gt;&lt;b&gt;Bold&lt;/b&gt;&amp;#8211;primer sequence.&lt;/p&gt;</source>
-        <translation>&lt;h3&gt;Детали:&lt;/h3&gt;&lt;p&gt;&lt;u&gt;Подчеркнутый шрифт&lt;/u&gt;&amp;#8211;последовательность остова&amp;#59;&lt;br&gt;&lt;b&gt;Жирный шрифт &lt;/b&gt;&amp;#8211;последовательность праймера.&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="183"/>
-        <source>&lt;h2&gt;Unwanted connections of user primers&lt;/h2&gt;</source>
-        <translation>&lt;h2&gt;Нежелательные соединения пользовательских праймеров&lt;/h2&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="186"/>
-        <source>Selfdimers</source>
-        <translation>Гомодимер</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="201"/>
-        <source>Heterodimers</source>
-        <translation>Гетеродимер</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="201"/>
-        <source>Another user primer</source>
-        <translation>Другой праймер пользователя</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="237"/>
-        <source>Yes</source>
-        <translation>Да</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="237"/>
-        <source>No</source>
-        <translation>Нет</translation>
     </message>
 </context>
 <context>
@@ -352,6 +197,21 @@
 <context>
     <name>U2::FindPresenceOfUnwantedParametersTask</name>
     <message>
+        <location filename="../src/tasks/FindPresenceOfUnwantedParametersTask.cpp" line="32"/>
+        <source>Find Presence of Unwanted Parameters Task</source>
+        <translation>Задача Найти Наличие Нежелательных Параметров</translation>
+    </message>
+    <message>
+        <location filename="../src/tasks/FindPresenceOfUnwantedParametersTask.cpp" line="40"/>
+        <source>Sequence length is less than 5&apos; backbone length, the entire sequence is used</source>
+        <translation>Длина последовательности меньше длины 5&apos; остова, используется вся последовательность</translation>
+    </message>
+    <message>
+        <location filename="../src/tasks/FindPresenceOfUnwantedParametersTask.cpp" line="43"/>
+        <source>Sequence length is less than 3&apos; backbone length, the entire sequence is used</source>
+        <translation>Длина последовательности меньше длины 3&apos; остова, используется вся последовательность</translation>
+    </message>
+    <message>
         <location filename="../src/tasks/FindPresenceOfUnwantedParametersTask.cpp" line="54"/>
         <source>&lt;u&gt;5&apos; backbone&lt;/u&gt;&lt;br&gt;&lt;br&gt;</source>
         <translation>&lt;u&gt;5&apos; остов&lt;/u&gt;&lt;br&gt;&lt;br&gt;</translation>
@@ -372,91 +232,94 @@
     <message>
         <location filename="../src/tasks/FindUnwantedIslandsTask.cpp" line="41"/>
         <source>Searching of unwanted islands and areas between them in the region &quot;%1&quot; (+ %2 nucleotides to the %3, deep into the amplified fragment) has been started</source>
-        <translation>Поиск нежелательных островков и областей между ними &quot;%1&quot; (+ %2 нуклеотида к %3, вглубь амплифицируемого фрагмента) начался</translation>
+        <translation>Поиск нежелательных островков и областей между ними &quot;%1&quot; (+ %2 нуклеотида %3, вглубь амплифицируемого фрагмента) начался</translation>
     </message>
     <message>
-        <location filename="../src/tasks/FindUnwantedIslandsTask.cpp" line="44"/>
-        <source>The following unwanted parametes are used. Free Gibbs energy: %1 kj/mol, melting temperature: %2 C, maximum dimer length: %3 nt</source>
-        <translation>Следующие нежелательные параметры используются. Свободная энергия Гиббса: %1 кдж/моль, температрура плавления: %2 C, максимальная длина димера: %3 нт</translation>
+        <location filename="../src/tasks/FindUnwantedIslandsTask.cpp" line="34"/>
+        <source>Find Unwanted Islands Task</source>
+        <translation>Задача Найти Нежелательные Островки</translation>
     </message>
     <message>
-        <location filename="../src/tasks/FindUnwantedIslandsTask.cpp" line="57"/>
+        <location filename="../src/tasks/FindUnwantedIslandsTask.cpp" line="45"/>
+        <source>left</source>
+        <translation>влево</translation>
+    </message>
+    <message>
+        <location filename="../src/tasks/FindUnwantedIslandsTask.cpp" line="45"/>
+        <source>right</source>
+        <translation>вправо</translation>
+    </message>
+    <message>
+        <location filename="../src/tasks/FindUnwantedIslandsTask.cpp" line="46"/>
+        <source>The following unwanted parameters are used. Free Gibbs energy: %1 kj/mol, melting temperature: %2 C, maximum dimer length: %3 nt</source>
+        <translation>Следующие нежелательные параметры используются. Свободная энергия Гиббса: %1 кдж/моль, температура плавления: %2 C, максимальная длина димера: %3 нт</translation>
+    </message>
+    <message>
+        <location filename="../src/tasks/FindUnwantedIslandsTask.cpp" line="59"/>
         <source>The region between unwanted islands has been found: %1</source>
         <translation>Регион между нежелательными островками найден: %1</translation>
     </message>
     <message>
-        <location filename="../src/tasks/FindUnwantedIslandsTask.cpp" line="93"/>
+        <location filename="../src/tasks/FindUnwantedIslandsTask.cpp" line="95"/>
         <source>The following regions are located between unwanted islands: %1</source>
         <translation>Следующие регионы располагаются между нежелательными островками: %1</translation>
     </message>
     <message>
-        <location filename="../src/tasks/FindUnwantedIslandsTask.cpp" line="95"/>
+        <location filename="../src/tasks/FindUnwantedIslandsTask.cpp" line="97"/>
         <source>The whole region is filled with unwanted islands, no regions between them has been found</source>
         <translation>Регион полностью состоит из нежелательных островком, регионов между ними не найдено</translation>
     </message>
 </context>
 <context>
-    <name>U2::GTest</name>
-    <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTaskTest.cpp" line="91"/>
-        <source>context not found %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTaskTest.cpp" line="96"/>
-        <source>Sequence %1 not found</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>U2::PCRPrimerDesignForDNAAssemblyOPWidget</name>
     <message>
-        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="91"/>
+        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="92"/>
         <source>User primers</source>
         <translation>Праймеры пользователя</translation>
     </message>
     <message>
-        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="93"/>
+        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="94"/>
         <source>Choose generated sequences as user primer&apos;s end</source>
-        <translation>Выбрать последовательность на край праймера пользователя</translation>
+        <translation>Выбрать последовательность на край праймера
+пользователя</translation>
     </message>
     <message>
-        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="97"/>
+        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="98"/>
         <source>Parameters of priming sequences</source>
-        <translation>Парамертры последовательностей праймеров</translation>
+        <translation>Параметры последовательностей праймеров</translation>
     </message>
     <message>
-        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="101"/>
+        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="102"/>
         <source>Parameters to exclude in whole primers</source>
         <translation>Параметры, подлежащие исключению</translation>
     </message>
     <message>
-        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="105"/>
+        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="106"/>
         <source>Select areas for priming search</source>
         <translation>Выбрать области для поиска праймеров</translation>
     </message>
     <message>
-        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="109"/>
+        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="110"/>
         <source>Open the backbone sequence</source>
         <translation>Открыть последовательность остова</translation>
     </message>
     <message>
-        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="113"/>
+        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="114"/>
         <source>Other sequences in PCR reaction</source>
         <translation>Другие последовательности в реакции ПЦР</translation>
     </message>
     <message>
-        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="284"/>
+        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="285"/>
         <source>Multiple regions selection, the only first is set as primer search area.</source>
-        <translation>Выбрано несколько регионов, в качестве обюласти поиска праймеров выбран первый из них.</translation>
+        <translation>Выбрано несколько регионов, в качестве области поиска праймеров выбран первый из них.</translation>
     </message>
     <message>
-        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="329"/>
+        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="330"/>
         <source>Select a backbone sequence file</source>
         <translation>Выбрать файл с последовательностью остова</translation>
     </message>
     <message>
-        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="339"/>
+        <location filename="../src/PCRPrimerDesignForDNAAssemblyOPWidget.cpp" line="340"/>
         <source>Select an &quot;Other sequences in PCR reaction&quot; file</source>
         <translation>Выбрать файл &quot;Другие последовательности в реакции ПЦР&quot;</translation>
     </message>
@@ -481,162 +344,207 @@
         <source>PCR Primer Design for DNA assembly.</source>
         <translation>Дизайн праймеров для ПЦР для сборки ДНК,.</translation>
     </message>
+    <message>
+        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="33"/>
+        <source>&lt;p&gt;Error, see log.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Ошибка, смотрите лог.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="48"/>
+        <source>Forward user primer</source>
+        <translation>Прямой праймер пользователя</translation>
+    </message>
+    <message>
+        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="51"/>
+        <source>Reverse user primer</source>
+        <translation>Обратный праймер пользователя</translation>
+    </message>
+    <message>
+        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="54"/>
+        <source>Sequence</source>
+        <translation>Последовательность</translation>
+    </message>
+    <message>
+        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="57"/>
+        <source>Reverse complementary sequence</source>
+        <translation>Обратно-комплементарная последовательность</translation>
+    </message>
+    <message>
+        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="60"/>
+        <source>Other sequences in PCR reaction</source>
+        <translation>Другие последовательности в реакции ПЦР</translation>
+    </message>
+    <message>
+        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="65"/>
+        <source> and </source>
+        <translation> и </translation>
+    </message>
+    <message>
+        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="124"/>
+        <source>&lt;p&gt;There are no primers that meet the specified parameters.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Нет праймеров, подходящих под заданные параметры.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="130"/>
+        <source>&lt;h3&gt;Details:&lt;/h3&gt;&lt;p&gt;&lt;u&gt;Underlined&lt;/u&gt;&amp;#8211;backbone sequence&amp;#59;&lt;br&gt;&lt;b&gt;Bold&lt;/b&gt;&amp;#8211;primer sequence.&lt;/p&gt;</source>
+        <translation>&lt;h3&gt;Детали:&lt;/h3&gt;&lt;p&gt;&lt;u&gt;Подчеркнутый шрифт&lt;/u&gt; &amp;#8211; последовательность остова&amp;#59;&lt;br&gt;&lt;b&gt;Жирный шрифт &lt;/b&gt;&amp;#8211; последовательность праймера.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="187"/>
+        <source>&lt;h2&gt;Unwanted connections of user primers&lt;/h2&gt;</source>
+        <translation>&lt;h2&gt;Нежелательные соединения пользовательских праймеров&lt;/h2&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="190"/>
+        <source>Self-dimers</source>
+        <translation>Гомодимеры</translation>
+    </message>
+    <message>
+        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="205"/>
+        <source>Hetero-dimers</source>
+        <translation>Гетеродимеры</translation>
+    </message>
+    <message>
+        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="206"/>
+        <source>Another user primer</source>
+        <translation>Другой праймер пользователя</translation>
+    </message>
+    <message>
+        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="245"/>
+        <source>Yes</source>
+        <translation>Есть</translation>
+    </message>
+    <message>
+        <location filename="../src/utils/PCRPrimerDesignTaskReportUtils.cpp" line="245"/>
+        <source>No</source>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="../src/utils/UnwantedConnectionsUtils.cpp" line="47"/>
+        <source>&lt;b&gt;Self-dimer:&lt;/b&gt;&lt;br&gt;</source>
+        <translation>&lt;b&gt;Гомодимер:&lt;/b&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/utils/UnwantedConnectionsUtils.cpp" line="69"/>
+        <source>&lt;b&gt;Hetero-dimer:&lt;/b&gt;&lt;br&gt;</source>
+        <translation>&lt;b&gt;Гетеродимер:&lt;/b&gt;&lt;br&gt;</translation>
+    </message>
 </context>
 <context>
     <name>U2::PCRPrimerDesignForDNAAssemblyTask</name>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="68"/>
-        <source>Unknown file format!</source>
-        <translation>Неизвестный формат файла!</translation>
-    </message>
-    <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="166"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="156"/>
         <source>The &quot;B1 Forward&quot; primer with the region &quot;%1&quot; doesn&apos;t fit because there are no corresponding &quot;B1 Reverse&quot; primers</source>
         <translation>Праймер &quot;В1 прямой&quot;, находящийся на позиции %1 не подходит, т.к. соответствующий &quot;В1 Обратный&quot; праймер не был найден</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="176"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="166"/>
         <source>The &quot;A Forward&quot; and the &quot;A Reverse&quot; primers have been found</source>
         <translation>Праймеры &quot;А Прямой&quot; и &quot;А Обратный&quot; были найдены</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="189"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="179"/>
         <source>B2 and B3 primer pairs haven&apos;t been found, search again</source>
         <translation>Пары праймеров В2 и В3 не были найдены, ищем снова</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="225"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="214"/>
         <source>The backbone sequence without unwanted hairpins, self- and hetero-dimers has been found: %1</source>
         <translation>Последовательность остова без нежелательных шпилек, гомо- и гетеро-димеров была найдена: %1</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="232"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="221"/>
         <source>The following backbone sequence candidate contains parameters: %1</source>
         <translation>Текущий кандидат на последовательность остова содержит параметры: %1</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="251"/>
-        <source>The file &quot;%1&quot; doesn&apos;t contain the backbone sequence, which matchs the parameters. Skip the backbone sequence parameter.</source>
-        <translation>Файл &quot;%1&quot; не содержит последовательность остова, отвечающую параметрам. Пропск параметра последовательность остова.</translation>
-    </message>
-    <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="353"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="342"/>
         <source>&quot;B1 Forward&quot; and &quot;B1 Reverse&quot; have unwanted hetero-dimers, move on</source>
-        <translation>&quot;В1 Прямой&quot; и &quot;В1 Обратный&quot; содержат нежелательные гетеро-димеры, двигаемся дальше</translation>
+        <translation>&quot;В1 Прямой&quot; и &quot;В1 Обратный&quot; содержат нежелательные гетеродимеры, двигаемся дальше</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="361"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="350"/>
         <source>The &quot;B1 Reverse&quot; candidate primer region &quot;%1&quot; contains unwanted connections</source>
         <translation>Регион &quot;%1&quot; кандидата в праймер &quot;В1 Прямой&quot; содержит нежелательные соединения</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="342"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="331"/>
         <source>The &quot;B1 Reverse&quot; candidate primer region &quot;%1&quot; fits to &quot;Parameters of priming sequences&quot; values, checking for unwanted connections</source>
-        <translation>Кандидат в праймер &quot;В1 Обратный&quot;, находящийся в &quot;%1&quot; подходит к &quot;Парамертрам последовательностей праймеров&quot;, проверяем на наличие нежелательных соединений</translation>
+        <translation>Кандидат в праймер &quot;В1 Обратный&quot;, находящийся в &quot;%1&quot; подходит к &quot;Параметрам последовательностей праймеров&quot;, проверяем на наличие нежелательных соединений</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="45"/>
-        <source>A Forward</source>
-        <translation>А Прямой</translation>
-    </message>
-    <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="46"/>
-        <source>A Reverse</source>
-        <translation>А Обратный</translation>
-    </message>
-    <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="47"/>
-        <source>B1 Forward</source>
-        <translation>В1 Прямой</translation>
-    </message>
-    <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="48"/>
-        <source>B1 Reverse</source>
-        <translation>B1 Обратный</translation>
-    </message>
-    <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="49"/>
-        <source>B2 Forward</source>
-        <translation>В2 Прямой</translation>
-    </message>
-    <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="50"/>
-        <source>B2 Reverse</source>
-        <translation>В2 Обратный</translation>
-    </message>
-    <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="51"/>
-        <source>B3 Forward</source>
-        <translation>В3 Прямой</translation>
-    </message>
-    <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="52"/>
-        <source>B3 Reverse</source>
-        <translation>В3 Обратный</translation>
-    </message>
-    <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="407"/>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="485"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="396"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="474"/>
         <source>The &quot;%1&quot; candidate primer region &quot;%2&quot; fits to &quot;Parameters of priming sequences&quot; values, checking for unwanted connections</source>
-        <translation>Кандидат в праймер &quot;%1&quot;, находящийся в &quot;%2&quot; подходит к &quot;Парамертрам последовательностей праймеров&quot;, проверяем на наличие нежелательных соединений</translation>
+        <translation>Кандидат в праймер &quot;%1&quot;, находящийся в &quot;%2&quot; подходит к &quot;Параметрам последовательностей праймеров&quot;, проверяем на наличие нежелательных соединений</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="425"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="414"/>
         <source>The &quot;%1&quot; primer with the region &quot;%2&quot; doesn&apos;t fit because there are no corresponding &quot;%3&quot; primers</source>
-        <translation>Кандидат в праймер &quot;%1&quot;, находящийся в &quot;%2&quot;  не подходит потому, что нет подходящего праймера &quot;%3&quot;</translation>
+        <translation>Кандидат в праймер &quot;%1&quot;, находящийся в &quot;%2&quot; не подходит потому, что нет подходящего праймера &quot;%3&quot;</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="443"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="432"/>
         <source>The &quot;%1&quot; candidate primer region &quot;%2&quot; contains unwanted connections</source>
         <translation>Кандидат в праймер &quot;%1&quot;, находящийся в &quot;%2&quot; содержит нежелательные соединения</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="495"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="484"/>
         <source>&quot;%1&quot; and &quot;%2&quot; have unwanted hetero-dimers, move on</source>
-        <translation>&quot;%1&quot; and &quot;%2&quot; have unwanted hetero-dimers, move on</translation>
+        <translation>&quot;%1&quot; и &quot;%2&quot; содержат нежелательные гетеродимеры, двигаемся дальше</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="511"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="500"/>
         <source>The &quot;B2 Reverse&quot; candidate primer region &quot;%1&quot; contains unwanted connections</source>
         <translation>Регион &quot;%1&quot; кандидата в праймер &quot;В2 Обратный&quot; содержит нежелательные соединения</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="522"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="511"/>
         <source>No user primers</source>
         <translation>Нет праймеров пользователя</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="524"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="513"/>
         <source>No forward user primer. Reverse user primer ignored</source>
         <translation>Нет прямого праймера пользователя. Обратный праймер пользователя игнорируется</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="526"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="515"/>
         <source>No reverse user primer. Forward user primer ignored</source>
         <translation>Нет обратного праймера пользователя. Прямой праймер пользователя игнорируется</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="289"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="278"/>
         <source>The file &quot;%1&quot; wasn&apos;t loaded</source>
         <translation>Файл &quot;%1&quot; не был загружен</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="154"/>
-        <source>The &quot;B1 Forward&quot; candidate primer region &quot;%1&quot; fits to &quot;Parameters of priming sequences&quot; values, checking for unwanted connections</source>
-        <translation>Кандидат в праймер &quot;В1 Прямой&quot;, находящийся в &quot;%1&quot; подходит к &quot;Парамертрам последовательностей праймеров&quot;, проверяем на наличие нежелательных соединений</translation>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="56"/>
+        <source>PCR Primer Design For DNA Assembly Task</source>
+        <translation>Задача Дизайн Праймеров для ПЦР для Сборки ДНК</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="292"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="144"/>
+        <source>The &quot;B1 Forward&quot; candidate primer region &quot;%1&quot; fits to &quot;Parameters of priming sequences&quot; values, checking for unwanted connections</source>
+        <translation>Кандидат в праймер &quot;В1 Прямой&quot;, находящийся в &quot;%1&quot; подходит к &quot;Параметрам последовательностей праймеров&quot;, проверяем на наличие нежелательных соединений</translation>
+    </message>
+    <message>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="240"/>
+        <source>The file &quot;%1&quot; doesn&apos;t contain the backbone sequence, which matches the parameters. Skip the backbone sequence parameter.</source>
+        <translation>Файл &quot;%1&quot; не содержит последовательность остова, отвечающую параметрам. Пропуск параметра последовательность остова.</translation>
+    </message>
+    <message>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="281"/>
         <source>No objects in the file &quot;%1&quot;</source>
         <translation>Нет объектов в файле &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="304"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="293"/>
         <source>No sequences in the file &quot;%1&quot;</source>
         <translation>Нет последовательностей в файле &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="198"/>
+        <location filename="../src/tasks/PCRPrimerDesignForDNAAssemblyTask.cpp" line="188"/>
         <source>The candidate primer region &quot;%1&quot; contains unwanted connections</source>
         <translation>Регион &quot;%1&quot; кандидатного праймера содержит нежелательные соединения</translation>
     </message>
@@ -653,10 +561,28 @@
         <source>Region</source>
         <translation>Регион</translation>
     </message>
+</context>
+<context>
+    <name>U2::UnwantedStructuresInBackboneDialog</name>
     <message>
-        <location filename="../src/options_panel/ResultTable.cpp" line="57"/>
-        <source>%1-%2</source>
-        <translation></translation>
+        <location filename="../src/UnwantedStructuresInBackboneDialog.cpp" line="39"/>
+        <source>are no sequences</source>
+        <translation>0</translation>
+    </message>
+    <message>
+        <location filename="../src/UnwantedStructuresInBackboneDialog.cpp" line="42"/>
+        <source>is 1 sequence</source>
+        <translation>1</translation>
+    </message>
+    <message>
+        <location filename="../src/UnwantedStructuresInBackboneDialog.cpp" line="45"/>
+        <source>are %1 sequences</source>
+        <translation>%1</translation>
+    </message>
+    <message>
+        <location filename="../src/UnwantedStructuresInBackboneDialog.cpp" line="47"/>
+        <source>There %1 in the file left. Use this sequence as the backbone?</source>
+        <translation>Последовательностей осталось: %1. Использовать текущую в качестве остова?</translation>
     </message>
 </context>
 <context>
@@ -696,7 +622,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../src/UnwantedStructuresInBackboneDialog.ui" line="59"/>
-        <source>There no sequences in the file left. Use this sequence as the backbone?</source>
+        <source>There are no sequences in the file left. Use this sequence as the backbone?</source>
         <translation>В файле больше не осталось последовательностей. Использовать текущую в качестве остова?</translation>
     </message>
 </context>


### PR DESCRIPTION
#### Working on translations. Considered comments on the review [1](https://github.com/ugeneunipro/ugene/pull/619#discussion_r748554556), [2](https://github.com/ugeneunipro/ugene/pull/619#discussion_r748554820), [3](https://github.com/ugeneunipro/ugene/pull/619#discussion_r748560974), [4](https://github.com/ugeneunipro/ugene/pull/619#discussion_r762815950).

- After [a comment from the review](https://github.com/ugeneunipro/ugene/pull/619#discussion_r748554820), I replaced [initialization of global static string with a method call](https://github.com/ugeneunipro/ugene/pull/619/commits/87e424d607f5cc20a0814033066e6990da7d3d19). Now I found a [better solution](https://github.com/ugeneunipro/ugene/blob/f9ea08e16b0be5f080313cd2395a68c8a3f799f7/src/corelibs/U2Gui/src/util/RegionSelectorController.cpp#L71) and [put](https://github.com/ugeneunipro/ugene/pull/654/files#diff-052a9c1dd7c1f537b79e6334510c612df218999734b80ae99890c136719c0b08) the global static string back.
- Fixed grammatical errors ([1](https://github.com/ugeneunipro/ugene/pull/654/files#diff-f54c29a813a70a5355b550cfa34aeb8c342715ad927b69f087e8e7d707eed1e8), [2](https://github.com/ugeneunipro/ugene/pull/654/files#diff-dd7b84843aa577ff7357e5fc44a64d2fe008f9918d90a787349829f4f595a7cbL248)).
- Removed unnecessary `tr` ([1](https://github.com/ugeneunipro/ugene/pull/654/files#diff-0305f5e907376d7ea0bc06b925789838cbde1066ee6bf68ecd5530a17eedf7d4), [2](https://github.com/ugeneunipro/ugene/pull/654/files#diff-7a2f544cfd7bd717e928b6d3a9b0bf79fdbea05c779714cda8860f8a4e7da2c7), [3](https://github.com/ugeneunipro/ugene/pull/654/files#diff-6d787dca669f60225aa05103f7ecbe1b6430707ec13b54b17841a7b707938be0R86), [4](https://github.com/ugeneunipro/ugene/pull/654/files#diff-6d787dca669f60225aa05103f7ecbe1b6430707ec13b54b17841a7b707938be0L114-R111), [5](https://github.com/ugeneunipro/ugene/pull/654/files#diff-6d787dca669f60225aa05103f7ecbe1b6430707ec13b54b17841a7b707938be0L119-R116)).
- Added missing `tr` ([1](https://github.com/ugeneunipro/ugene/pull/654/files#diff-3509b71806f7f8e1ef935f57544602f31c8c899bac8ed1b7620aced71a5d181c), [2](https://github.com/ugeneunipro/ugene/pull/654/files#diff-b025728fbfcde872c4c62605fb49bf18e4697464c393a4d666c711ab507d5e9f)).
- Fixed typos ([1](https://github.com/ugeneunipro/ugene/pull/654/files#diff-b025728fbfcde872c4c62605fb49bf18e4697464c393a4d666c711ab507d5e9fL44), [2](https://github.com/ugeneunipro/ugene/pull/654/files#diff-9f6e06859bb57d4a68333e1d8f0b97860bdaf7f02c013dbdbac503f98c00af6c), [3](https://github.com/ugeneunipro/ugene/pull/654/files#diff-dd7b84843aa577ff7357e5fc44a64d2fe008f9918d90a787349829f4f595a7cbL380), [4](https://github.com/ugeneunipro/ugene/pull/654/files#diff-dd7b84843aa577ff7357e5fc44a64d2fe008f9918d90a787349829f4f595a7cbL426-R289), [5](https://github.com/ugeneunipro/ugene/pull/654/files#diff-dd7b84843aa577ff7357e5fc44a64d2fe008f9918d90a787349829f4f595a7cbL451-R314), [6](https://github.com/ugeneunipro/ugene/pull/654/files#diff-dd7b84843aa577ff7357e5fc44a64d2fe008f9918d90a787349829f4f595a7cbL581-R479), [7](https://github.com/ugeneunipro/ugene/pull/654/files#diff-dd7b84843aa577ff7357e5fc44a64d2fe008f9918d90a787349829f4f595a7cbL626-R529), [8](https://github.com/ugeneunipro/ugene/pull/654/files#diff-dd7b84843aa577ff7357e5fc44a64d2fe008f9918d90a787349829f4f595a7cbL520)).
- lupdate didn't process lines in PCRPrimerDesignTaskReportUtils.cpp after [changes](https://github.com/ugeneunipro/ugene/pull/619/commits/07b312b6dacd44f7ab9589f59f1411f8020f769a#diff-6d787dca669f60225aa05103f7ecbe1b6430707ec13b54b17841a7b707938be0). The `tr` method alias [has been removed](https://github.com/ugeneunipro/ugene/pull/654/files#diff-6d787dca669f60225aa05103f7ecbe1b6430707ec13b54b17841a7b707938be0).
- "File sequence" [is replaced](https://github.com/ugeneunipro/ugene/pull/654/files#diff-6d787dca669f60225aa05103f7ecbe1b6430707ec13b54b17841a7b707938be0R54) by "Sequence".
- Fixed spelling errors ([1](https://github.com/ugeneunipro/ugene/pull/654/files#diff-6d787dca669f60225aa05103f7ecbe1b6430707ec13b54b17841a7b707938be0L192-R190), [2](https://github.com/ugeneunipro/ugene/pull/654/files#diff-6d787dca669f60225aa05103f7ecbe1b6430707ec13b54b17841a7b707938be0L207), [3](https://github.com/ugeneunipro/ugene/pull/654/files#diff-dd7b84843aa577ff7357e5fc44a64d2fe008f9918d90a787349829f4f595a7cbL525)).
- Added missing translation ([1](https://github.com/ugeneunipro/ugene/pull/654/files#diff-dd7b84843aa577ff7357e5fc44a64d2fe008f9918d90a787349829f4f595a7cbL34-R34), [2](https://github.com/ugeneunipro/ugene/pull/654/files#diff-dd7b84843aa577ff7357e5fc44a64d2fe008f9918d90a787349829f4f595a7cbL596-R494)).
- Modified some Russian translations for better UI display ([1](https://github.com/ugeneunipro/ugene/pull/654/files#diff-dd7b84843aa577ff7357e5fc44a64d2fe008f9918d90a787349829f4f595a7cbL116-R116), [2](https://github.com/ugeneunipro/ugene/pull/654/files#diff-dd7b84843aa577ff7357e5fc44a64d2fe008f9918d90a787349829f4f595a7cbL421-R284)).
- Removed some outdated translation contexts (QObject, GTest). Translations from QObject have mostly migrated to PCRPrimerDesignForDNAAssemblyPlugin in accordance with [the comment](https://github.com/ugeneunipro/ugene/pull/619#discussion_r748560974) on the review.
- [Fixed](https://github.com/ugeneunipro/ugene/pull/654/files#diff-dd7b84843aa577ff7357e5fc44a64d2fe008f9918d90a787349829f4f595a7cbL375-R235) translation in accordance with [the changes](https://github.com/ugeneunipro/ugene/pull/654/files#diff-b025728fbfcde872c4c62605fb49bf18e4697464c393a4d666c711ab507d5e9fR45).
- Fixed translations in accordance with the typing rules ([1](https://github.com/ugeneunipro/ugene/pull/654/files#diff-dd7b84843aa577ff7357e5fc44a64d2fe008f9918d90a787349829f4f595a7cbR390), [2](https://github.com/ugeneunipro/ugene/pull/654/files#diff-dd7b84843aa577ff7357e5fc44a64d2fe008f9918d90a787349829f4f595a7cbL586-R484)).
- [Fixed](https://github.com/ugeneunipro/ugene/pull/654/files#diff-dd7b84843aa577ff7357e5fc44a64d2fe008f9918d90a787349829f4f595a7cbL247-L248) tags in translation.