### PR TITLE
Move undo-redo controller instantiation from UI to MAEditor

### DIFF
--- a/src/corelibs/U2View/src/UndoRedoFramework.cpp
+++ b/src/corelibs/U2View/src/UndoRedoFramework.cpp
@@ -29,119 +29,120 @@
 
 #include <U2Gui/GUIUtils.h>
 
-#include "ov_msa/MaCollapseModel.h"
-
 namespace U2 {
 
-MsaUndoRedoFramework::MsaUndoRedoFramework(QObject *p, MultipleAlignmentObject *_maObj)
-    : QObject(p),
-      maObj(_maObj),
-      stateComplete(true),
-      undoStepsAvailable(0),
-      redoStepsAvailable(0) {
-    SAFE_POINT(maObj != nullptr, "NULL MSA Object!", );
+MaUndoRedoFramework::MaUndoRedoFramework(QObject *parent, MultipleAlignmentObject *_maObject)
+    : QObject(parent),
+      maObject(_maObject) {
+    SAFE_POINT(maObject != nullptr, "NULL MSA Object!", );
 
-    undoAction = new QAction(this);
-    undoAction->setText(tr("Undo"));
-    undoAction->setIcon(QIcon(":core/images/undo.png"));
+    undoAction = new QAction(QIcon(":core/images/undo.png"), tr("Undo"), this);
+    undoAction->setObjectName("msa_action_undo");
     undoAction->setShortcut(QKeySequence::Undo);
     GUIUtils::updateActionToolTip(undoAction);
 
-    redoAction = new QAction(this);
-    redoAction->setText(tr("Redo"));
-    redoAction->setIcon(QIcon(":core/images/redo.png"));
+    redoAction = new QAction(QIcon(":core/images/redo.png"), tr("Redo"), this);
+    redoAction->setObjectName("msa_action_redo");
     redoAction->setShortcut(QKeySequence::Redo);
     GUIUtils::updateActionToolTip(redoAction);
 
     checkUndoRedoEnabled();
 
-    connect(maObj, SIGNAL(si_alignmentChanged(const MultipleAlignment &, const MaModificationInfo &)), SLOT(sl_updateUndoRedoState()));
-    connect(maObj, SIGNAL(si_completeStateChanged(bool)), SLOT(sl_completeStateChanged(bool)));
-    connect(maObj, SIGNAL(si_lockedStateChanged()), SLOT(sl_updateUndoRedoState()));
+    connect(maObject, SIGNAL(si_alignmentChanged(const MultipleAlignment &, const MaModificationInfo &)), SLOT(sl_updateUndoRedoState()));
+    connect(maObject, SIGNAL(si_completeStateChanged(bool)), SLOT(sl_completeStateChanged(bool)));
+    connect(maObject, SIGNAL(si_lockedStateChanged()), SLOT(sl_updateUndoRedoState()));
     connect(undoAction, SIGNAL(triggered()), this, SLOT(sl_undo()));
     connect(redoAction, SIGNAL(triggered()), this, SLOT(sl_redo()));
 }
 
-void MsaUndoRedoFramework::sl_completeStateChanged(bool _stateComplete) {
+void MaUndoRedoFramework::sl_completeStateChanged(bool _stateComplete) {
     stateComplete = _stateComplete;
 }
 
-void MsaUndoRedoFramework::sl_updateUndoRedoState() {
+void MaUndoRedoFramework::sl_updateUndoRedoState() {
     checkUndoRedoEnabled();
 }
 
-void MsaUndoRedoFramework::checkUndoRedoEnabled() {
-    SAFE_POINT(maObj != nullptr, "NULL MSA Object!", );
+void MaUndoRedoFramework::checkUndoRedoEnabled() {
+    SAFE_POINT(maObject != nullptr, "NULL MSA Object!", );
 
-    if (maObj->isStateLocked() || !stateComplete) {
+    if (maObject->isStateLocked() || !stateComplete) {
         undoAction->setEnabled(false);
         redoAction->setEnabled(false);
         return;
     }
 
     U2OpStatus2Log os;
-    DbiConnection con(maObj->getEntityRef().dbiRef, os);
+    DbiConnection con(maObject->getEntityRef().dbiRef, os);
     SAFE_POINT_OP(os, );
 
     U2ObjectDbi *objDbi = con.dbi->getObjectDbi();
-    SAFE_POINT(nullptr != objDbi, "NULL Object Dbi!", );
+    SAFE_POINT(objDbi != nullptr, "NULL Object Dbi!", );
 
-    bool enableUndo = objDbi->canUndo(maObj->getEntityRef().entityId, os);
+    bool enableUndo = objDbi->canUndo(maObject->getEntityRef().entityId, os);
     SAFE_POINT_OP(os, );
-    bool enableRedo = objDbi->canRedo(maObj->getEntityRef().entityId, os);
+    bool enableRedo = objDbi->canRedo(maObject->getEntityRef().entityId, os);
     SAFE_POINT_OP(os, );
 
     undoAction->setEnabled(enableUndo);
     redoAction->setEnabled(enableRedo);
     if (!enableUndo) {
-        maObj->setModified(false);
+        maObject->setModified(false);
     }
 }
 
-void MsaUndoRedoFramework::sl_undo() {
-    SAFE_POINT(maObj != nullptr, "NULL MSA Object!", );
+void MaUndoRedoFramework::sl_undo() {
+    SAFE_POINT(maObject != nullptr, "NULL MSA Object!", );
 
     U2OpStatus2Log os;
-    U2EntityRef msaRef = maObj->getEntityRef();
+    U2EntityRef msaRef = maObject->getEntityRef();
 
     assert(stateComplete);
-    assert(!maObj->isStateLocked());
+    assert(!maObject->isStateLocked());
 
     DbiConnection con(msaRef.dbiRef, os);
     SAFE_POINT_OP(os, );
 
     U2ObjectDbi *objDbi = con.dbi->getObjectDbi();
-    SAFE_POINT(nullptr != objDbi, "NULL Object Dbi!", );
+    SAFE_POINT(objDbi != nullptr, "NULL Object Dbi!", );
 
     objDbi->undo(msaRef.entityId, os);
     SAFE_POINT_OP(os, );
 
     MaModificationInfo modInfo;
     modInfo.type = MaModificationType_Undo;
-    maObj->updateCachedMultipleAlignment(modInfo);
+    maObject->updateCachedMultipleAlignment(modInfo);
 }
 
-void MsaUndoRedoFramework::sl_redo() {
-    SAFE_POINT(maObj != nullptr, "NULL MSA Object!", );
+void MaUndoRedoFramework::sl_redo() {
+    SAFE_POINT(maObject != nullptr, "NULL MSA Object!", );
 
     U2OpStatus2Log os;
-    U2EntityRef msaRef = maObj->getEntityRef();
+    U2EntityRef msaRef = maObject->getEntityRef();
 
     assert(stateComplete);
-    assert(!maObj->isStateLocked());
+    assert(!maObject->isStateLocked());
 
     DbiConnection con(msaRef.dbiRef, os);
     SAFE_POINT_OP(os, );
 
     U2ObjectDbi *objDbi = con.dbi->getObjectDbi();
-    SAFE_POINT(nullptr != objDbi, "NULL Object Dbi!", );
+    SAFE_POINT(objDbi != nullptr, "NULL Object Dbi!", );
 
     objDbi->redo(msaRef.entityId, os);
     SAFE_POINT_OP(os, );
 
     MaModificationInfo modInfo;
     modInfo.type = MaModificationType_Redo;
-    maObj->updateCachedMultipleAlignment(modInfo);
+    maObject->updateCachedMultipleAlignment(modInfo);
+}
+
+QAction *MaUndoRedoFramework::getUndoAction() const {
+    return undoAction;
+}
+
+QAction *MaUndoRedoFramework::getRedoAction() const {
+    return redoAction;
 }
 
 }  // namespace U2

--- a/src/corelibs/U2View/src/UndoRedoFramework.h
+++ b/src/corelibs/U2View/src/UndoRedoFramework.h
@@ -31,17 +31,14 @@ namespace U2 {
 
 class MultipleAlignmentObject;
 
-class MsaUndoRedoFramework : public QObject {
+class MaUndoRedoFramework : public QObject {
     Q_OBJECT
 public:
-    MsaUndoRedoFramework(QObject *p, MultipleAlignmentObject *_maObj);
+    MaUndoRedoFramework(QObject *parent, MultipleAlignmentObject *maObject);
 
-    QAction *getUndoAction() const {
-        return undoAction;
-    }
-    QAction *getRedoAction() const {
-        return redoAction;
-    }
+    QAction *getUndoAction() const;
+
+    QAction *getRedoAction() const;
 
 private slots:
     void sl_updateUndoRedoState();
@@ -53,14 +50,11 @@ private slots:
 private:
     void checkUndoRedoEnabled();
 
-    MultipleAlignmentObject *maObj;
-    bool stateComplete;
+    MultipleAlignmentObject *maObject = nullptr;
+    bool stateComplete = true;
 
-    QAction *undoAction;
-    QAction *redoAction;
-
-    qint64 undoStepsAvailable;
-    qint64 redoStepsAvailable;
+    QAction *undoAction = nullptr;
+    QAction *redoAction = nullptr;
 };
 
 }  // namespace U2

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.cpp
@@ -195,8 +195,8 @@ void MSAEditorSequenceArea::updateCollapseModel(const MaModificationInfo &modInf
 void MSAEditorSequenceArea::sl_buildStaticToolbar(GObjectView *v, QToolBar *t) {
     Q_UNUSED(v);
 
-    t->addAction(ui->getUndoAction());
-    t->addAction(ui->getRedoAction());
+    t->addAction(editor->undoAction);
+    t->addAction(editor->redoAction);
     t->addAction(removeAllGapsAction);
     t->addSeparator();
 

--- a/src/corelibs/U2View/src/ov_msa/MaEditor.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditor.cpp
@@ -42,6 +42,7 @@
 #include <U2View/MSAEditorOffsetsView.h>
 #include <U2View/MSAEditorOverviewArea.h>
 #include <U2View/MSAEditorSequenceArea.h>
+#include <U2View/UndoRedoFramework.h>
 
 #include "MaCollapseModel.h"
 #include "MaEditorState.h"
@@ -81,6 +82,10 @@ MaEditor::MaEditor(GObjectViewFactoryId factoryId, const QString &viewName, Mult
         U2OpStatus2Log os;
         maObject->setTrackMod(os, TrackOnUpdate);
     }
+
+    undoRedoFramework = new MaUndoRedoFramework(this, obj);
+    undoAction = undoRedoFramework->getUndoAction();
+    redoAction = undoRedoFramework->getRedoAction();
 
     // SANGER_TODO: move to separate method
     // do that in createWidget along with initActions?
@@ -376,6 +381,11 @@ void MaEditor::initActions() {
     connect(selectionController,
             SIGNAL(si_selectionChanged(const MaEditorSelection &, const MaEditorSelection &)),
             SLOT(sl_selectionChanged(const MaEditorSelection &, const MaEditorSelection &)));
+
+    connect(undoAction, &QAction::triggered, [this]() { GCounter::increment("Undo", factoryId); });
+    connect(redoAction, &QAction::triggered, [this]() { GCounter::increment("Redo", factoryId); });
+    ui->addAction(undoAction);
+    ui->addAction(redoAction);
 }
 
 void MaEditor::initZoom() {
@@ -556,6 +566,10 @@ void MaEditor::sl_gotoSelectedRead() {
 
 MaCollapseModel *MaEditor::getCollapseModel() const {
     return collapseModel;
+}
+
+MaUndoRedoFramework *MaEditor::getUndoRedoFramework() const {
+    return undoRedoFramework;
 }
 
 }  // namespace U2

--- a/src/corelibs/U2View/src/ov_msa/MaEditor.h
+++ b/src/corelibs/U2View/src/ov_msa/MaEditor.h
@@ -55,13 +55,14 @@ namespace U2 {
 #define MOBJECT_DEFAULT_FONT_SIZE 10
 #define MOBJECT_DEFAULT_ZOOM_FACTOR 1.0
 
-class MaEditorWgt;
-class MultipleAlignmentObject;
+class MaCollapseModel;
 class MaEditorSelection;
 class MaEditorSelectionController;
-class MultipleAlignment;
-class MaCollapseModel;
+class MaEditorWgt;
 class MaModificationInfo;
+class MaUndoRedoFramework;
+class MultipleAlignment;
+class MultipleAlignmentObject;
 
 class SNPSettings {
 public:
@@ -203,6 +204,9 @@ public:
     /** Returns collapse model instance. The returned value is never null. */
     MaCollapseModel *getCollapseModel() const;
 
+    /** Returns undo-redo framework. The returned value is never null. */
+    MaUndoRedoFramework *getUndoRedoFramework() const;
+
 signals:
     void si_fontChanged(const QFont &f);
     void si_zoomOperationPerformed(bool resizeModeChanged);
@@ -293,6 +297,9 @@ protected:
     /** Collapse model instance. Created in the constructor and is never changed. */
     MaCollapseModel *const collapseModel;
 
+    /** Undo-redo support. */
+    MaUndoRedoFramework *undoRedoFramework = nullptr;
+
 public:
     QAction *saveAlignmentAction = nullptr;
     QAction *saveAlignmentAsAction = nullptr;
@@ -322,6 +329,12 @@ public:
      * When the action is triggered for the already selected read it tries to center the opposite side of the read: 'start' -> 'end', 'end' -> 'start'.
      */
     QAction *gotoSelectedReadAction = nullptr;
+
+    /** Undo action in MA Editor. Never null after the initialization. */
+    QAction *undoAction = nullptr;
+
+    /** Redo action. Never null after the initialization.*/
+    QAction *redoAction = nullptr;
 };
 
 }  // namespace U2

--- a/src/corelibs/U2View/src/ov_msa/McaEditor.cpp
+++ b/src/corelibs/U2View/src/ov_msa/McaEditor.cpp
@@ -336,8 +336,8 @@ void McaEditor::addEditMenu(QMenu *menu) {
     editMenu->addAction(editorNameList->getRemoveSequenceAction());
     editMenu->addSeparator();
 
-    editMenu->addAction(ui->getUndoAction());
-    editMenu->addAction(ui->getRedoAction());
+    editMenu->addAction(undoAction);
+    editMenu->addAction(redoAction);
 }
 
 MaEditorSelectionController *McaEditor::getSelectionController() const {

--- a/src/corelibs/U2View/src/ov_msa/McaEditorSequenceArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/McaEditorSequenceArea.cpp
@@ -283,8 +283,8 @@ void McaEditorSequenceArea::sl_buildStaticToolbar(GObjectView * /*v*/, QToolBar 
     consensusArea->buildStaticToolbar(t);
 
     t->addSeparator();
-    t->addAction(ui->getUndoAction());
-    t->addAction(ui->getRedoAction());
+    t->addAction(editor->undoAction);
+    t->addAction(editor->redoAction);
 }
 
 void McaEditorSequenceArea::sl_addInsertion() {

--- a/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorSequenceArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorSequenceArea.cpp
@@ -68,15 +68,10 @@ const QChar MaEditorSequenceArea::emDash = QChar(0x2015);
 MaEditorSequenceArea::MaEditorSequenceArea(MaEditorWgt *ui, GScrollBar *hb, GScrollBar *vb)
     : editor(ui->getEditor()),
       ui(ui),
-      colorScheme(nullptr),
-      highlightingScheme(nullptr),
       shBar(hb),
       svBar(vb),
       editModeAnimationTimer(this),
       prevPressedButton(Qt::NoButton),
-      maVersionBeforeShifting(-1),
-      replaceCharacterAction(nullptr),
-      useDotsAction(nullptr),
       changeTracker(editor->getMaObject()->getEntityRef()) {
     rubberBand = new QRubberBand(QRubberBand::Rectangle, this);
     // show rubber band for selection in MSA editor only
@@ -124,8 +119,8 @@ MaEditorSequenceArea::MaEditorSequenceArea(MaEditorWgt *ui, GScrollBar *hb, GScr
 
     connect(editor->getMaObject(), SIGNAL(si_alignmentChanged(const MultipleAlignment &, const MaModificationInfo &)), SLOT(sl_alignmentChanged(const MultipleAlignment &, const MaModificationInfo &)));
 
-    connect(this, SIGNAL(si_startMaChanging()), ui->getUndoRedoFramework(), SLOT(sl_updateUndoRedoState()));
-    connect(this, SIGNAL(si_stopMaChanging(bool)), ui->getUndoRedoFramework(), SLOT(sl_updateUndoRedoState()));
+    connect(this, SIGNAL(si_startMaChanging()), editor->getUndoRedoFramework(), SLOT(sl_updateUndoRedoState()));
+    connect(this, SIGNAL(si_stopMaChanging(bool)), editor->getUndoRedoFramework(), SLOT(sl_updateUndoRedoState()));
     connect(editor->getSelectionController(),
             SIGNAL(si_selectionChanged(const MaEditorSelection &, const MaEditorSelection &)),
             SLOT(sl_onSelectionChanged(const MaEditorSelection &, const MaEditorSelection &)));

--- a/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorSequenceArea.h
+++ b/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorSequenceArea.h
@@ -309,18 +309,18 @@ protected:
     MaEditor *const editor;
     MaEditorWgt *const ui;
 
-    MsaColorScheme *colorScheme;
-    MsaHighlightingScheme *highlightingScheme;
+    MsaColorScheme *colorScheme = nullptr;
+    MsaHighlightingScheme *highlightingScheme = nullptr;
 
-    GScrollBar *shBar;
-    GScrollBar *svBar;
-    QRubberBand *rubberBand;
+    GScrollBar *const shBar;
+    GScrollBar *const svBar;
+    QRubberBand *rubberBand = nullptr;
     bool showRubberBandOnSelection;
 
-    SequenceAreaRenderer *renderer;
+    SequenceAreaRenderer *renderer = nullptr;
 
-    QPixmap *cachedView;
-    bool completeRedraw;
+    QPixmap *cachedView = nullptr;
+    bool completeRedraw = false;
 
     MaMode maMode;
     QTimer editModeAnimationTimer;
@@ -345,14 +345,14 @@ protected:
     /** Selected MA row columns within the current view selection. */
     U2Region selectedColumns;
 
-    int maVersionBeforeShifting;
+    int maVersionBeforeShifting = -1;
     SelectionModificationHelper::MovableSide movableBorder;
 
     QList<U2MsaGap> ctrlModeGapModel;
     qint64 lengthOnMousePress;
 
-    QAction *replaceCharacterAction;
-    QAction *fillWithGapsinsSymAction;
+    QAction *replaceCharacterAction = nullptr;
+    QAction *fillWithGapsinsSymAction = nullptr;
 
 public:
     QAction *useDotsAction;

--- a/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorWgt.cpp
+++ b/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorWgt.cpp
@@ -35,7 +35,6 @@
 #include <U2View/MSAEditorSequenceArea.h>
 #include <U2View/MaEditorNameList.h>
 #include <U2View/MaEditorStatusBar.h>
-#include <U2View/UndoRedoFramework.h>
 
 #include "MaEditorUtils.h"
 #include "SequenceAreaRenderer.h"
@@ -73,11 +72,7 @@ MaEditorWgt::MaEditorWgt(MaEditor *_editor)
       pasteBeforeAction(nullptr),
       cutSelectionAction(nullptr) {
     SAFE_POINT(editor != nullptr, "MaEditor is null!", );
-    undoFWK = new MsaUndoRedoFramework(this, editor->getMaObject());
     setFocusPolicy(Qt::ClickFocus);
-
-    connect(getUndoAction(), SIGNAL(triggered()), SLOT(sl_countUndo()));
-    connect(getRedoAction(), SIGNAL(triggered()), SLOT(sl_countRedo()));
 }
 
 QWidget *MaEditorWgt::createHeaderLabelWidget(const QString &text, Qt::Alignment alignment, QWidget *heightTarget, bool proxyMouseEventsToNameList) {
@@ -91,18 +86,6 @@ QWidget *MaEditorWgt::createHeaderLabelWidget(const QString &text, Qt::Alignment
 
 MaEditorStatusBar *MaEditorWgt::getStatusBar() const {
     return statusBar;
-}
-
-QAction *MaEditorWgt::getUndoAction() const {
-    QAction *a = undoFWK->getUndoAction();
-    a->setObjectName("msa_action_undo");
-    return a;
-}
-
-QAction *MaEditorWgt::getRedoAction() const {
-    QAction *a = undoFWK->getRedoAction();
-    a->setObjectName("msa_action_redo");
-    return a;
 }
 
 void MaEditorWgt::initWidgets() {
@@ -270,17 +253,6 @@ void MaEditorWgt::initActions() {
     cutSelectionAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     cutSelectionAction->setToolTip(QString("%1 (%2)").arg(cutSelectionAction->text()).arg(cutSelectionAction->shortcut().toString()));
     addAction(cutSelectionAction);
-
-    addAction(getUndoAction());
-    addAction(getRedoAction());
-}
-
-void MaEditorWgt::sl_countUndo() {
-    GCounter::increment("Undo", editor->getFactoryId());
-}
-
-void MaEditorWgt::sl_countRedo() {
-    GCounter::increment("Redo", editor->getFactoryId());
 }
 
 MaEditor *MaEditorWgt::getEditor() const {

--- a/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorWgt.h
+++ b/src/corelibs/U2View/src/ov_msa/view_rendering/MaEditorWgt.h
@@ -45,7 +45,6 @@ class MaEditorNameList;
 class MaEditorOverviewArea;
 class MaEditorSequenceArea;
 class RowHeightController;
-class MsaUndoRedoFramework;
 class ScrollController;
 class SequenceAreaRenderer;
 
@@ -103,10 +102,6 @@ public:
         return drawHelper;
     }
 
-    QAction *getUndoAction() const;
-
-    QAction *getRedoAction() const;
-
     /* If 'true' and collapse group has only 1 row it will have expand/collapse control. */
     bool isCollapsingOfSingleRowGroupsEnabled() const {
         return enableCollapsingOfSingleRowGroups;
@@ -116,18 +111,10 @@ public:
         return seqAreaHeader;
     }
 
-    MsaUndoRedoFramework *getUndoRedoFramework() const {
-        return undoFWK;
-    }
-
 signals:
     void si_startMaChanging();
     void si_stopMaChanging(bool modified = false);
     void si_completeRedraw();
-
-private slots:
-    void sl_countUndo();
-    void sl_countRedo();
 
 protected:
     virtual void initWidgets();
@@ -155,8 +142,6 @@ protected:
     QGridLayout *seqAreaLayout;
     QVBoxLayout *nameAreaLayout;
     MaSplitterController maSplitter;
-
-    MsaUndoRedoFramework *undoFWK;
 
     bool enableCollapsingOfSingleRowGroups;
     ScrollController *scrollController;

--- a/src/corelibs/U2View/transl/russian.ts
+++ b/src/corelibs/U2View/transl/russian.ts
@@ -7158,7 +7158,7 @@ Simple overview is unavailable.</source>
     </message>
 </context>
 <context>
-    <name>U2::MsaUndoRedoFramework</name>
+    <name>U2::MaUndoRedoFramework</name>
     <message>
         <location filename="../src/UndoRedoFramework.cpp" line="45"/>
         <source>Undo</source>

--- a/src/corelibs/U2View/transl/turkish.ts
+++ b/src/corelibs/U2View/transl/turkish.ts
@@ -7136,7 +7136,7 @@ Basit bir genel bakış kullanılamaz.</translation>
     </message>
 </context>
 <context>
-    <name>U2::MsaUndoRedoFramework</name>
+    <name>U2::MaUndoRedoFramework</name>
     <message>
         <location filename="../src/UndoRedoFramework.cpp" line="45"/>
         <source>Undo</source>


### PR DESCRIPTION
No behavior change in this PR, only move of the Undo-Redo controller instantiation/pointer from the UI component (MaEditorWgt) to the controller (MaEditor).
The final goal is to remove any logic except layout creation (like in UI files) from MaEditorWgt