### PR TITLE
Move visual and descriptive properties of annotations from GenbankFea…

### DIFF
--- a/src/corelibs/U2Core/src/datatype/U2FeatureType.cpp
+++ b/src/corelibs/U2Core/src/datatype/U2FeatureType.cpp
@@ -21,6 +21,7 @@
 
 #include "U2FeatureType.h"
 
+#include <U2Core/FeatureColors.h>
 #include <U2Core/U2SafePoints.h>
 
 namespace U2 {
@@ -38,10 +39,34 @@ QList<U2FeatureTypes::U2FeatureType> U2FeatureTypes::getTypes(const Alphabets &a
     return types;
 }
 
-QString U2FeatureTypes::getVisualName(U2FeatureType type) {
-    const int typeInfoIndex = typeInfoIndexByType.value(type, -1);
-    SAFE_POINT(typeInfoIndex >= 0, "Unexpected feature type", QString());
+QString U2FeatureTypes::getVisualName(const U2FeatureType &type) {
+    int typeInfoIndex = typeInfoIndexByType.value(type, -1);
+    SAFE_POINT(typeInfoIndex >= 0, "Unexpected feature type", "");
     return typeInfos[typeInfoIndex].visualName;
+}
+
+U2FeatureTypes::Alphabets U2FeatureTypes::getAlphabets(const U2FeatureType &type) {
+    int typeInfoIndex = typeInfoIndexByType.value(type, -1);
+    SAFE_POINT(typeInfoIndex >= 0, "Unexpected feature type", Alphabet_None);
+    return typeInfos[typeInfoIndex].alphabets;
+}
+
+QColor U2FeatureTypes::getColor(const U2FeatureType &type) {
+    int typeInfoIndex = typeInfoIndexByType.value(type, -1);
+    SAFE_POINT(typeInfoIndex >= 0, "Unexpected feature type", {});
+    return typeInfos[typeInfoIndex].color;
+}
+
+QColor U2FeatureTypes::getDescription(const U2FeatureType &type) {
+    int typeInfoIndex = typeInfoIndexByType.value(type, -1);
+    SAFE_POINT(typeInfoIndex >= 0, "Unexpected feature type", {});
+    return typeInfos[typeInfoIndex].description;
+}
+
+bool U2FeatureTypes::isShowOnAminoFrame(const U2FeatureType &type) {
+    int typeInfoIndex = typeInfoIndexByType.value(type, -1);
+    SAFE_POINT(typeInfoIndex >= 0, "Unexpected feature type", {});
+    return typeInfos[typeInfoIndex].isShowOnAminoFrame;
 }
 
 U2FeatureType U2FeatureTypes::getTypeByName(const QString &visualName) {
@@ -59,8 +84,20 @@ QList<U2FeatureTypes::U2FeatureTypeInfo> U2FeatureTypes::initFeatureTypes() {
     int typeInfoIndex = 0;
 
     // Registers U2FeatureType.
-    auto r = [&typeInfoList, &typeInfoIndex](const U2FeatureType &type, const QString &name, const Alphabets &alphabets) {
-        typeInfoList << U2FeatureTypeInfo(type, name, alphabets);
+    auto r = [&typeInfoList, &typeInfoIndex](const U2FeatureType &type,
+                                             const QString &name,
+                                             const Alphabets &alphabets,
+                                             const QString &description = "",
+                                             const QString &colorName = "",
+                                             bool isShowOnAminoFrame = false) {
+        SAFE_POINT(colorName.isEmpty() || colorName.startsWith("#"), "Got invalid color name: " + colorName, );
+        QColor color(colorName);
+        if (!color.isValid()) {
+            color = FeatureColors::genLightColor(colorName);
+        }
+        SAFE_POINT(color.isValid(), "Got invalid color for feature: " + name, );
+        SAFE_POINT(alphabets.testFlag(U2FeatureTypes::Alphabet_Nucleic) || !isShowOnAminoFrame, "Only features with nucleic alphabet may have isShowOnAminoFrame ON", );
+        typeInfoList << U2FeatureTypeInfo(type, name, alphabets, color, description, isShowOnAminoFrame);
         typeInfoIndexByType[type] = typeInfoIndex;
         typeInfoIndex++;
     };
@@ -68,58 +105,60 @@ QList<U2FeatureTypes::U2FeatureTypeInfo> U2FeatureTypes::initFeatureTypes() {
     // The DDBJ/ENA/GenBank/EMBL Feature Table Definition.
     // See https://www.insdc.org/files/feature_table.html#7.2 (Genbank)
     // or https://www.ebi.ac.uk/ena/WebFeat/ (EMBL).
-    r(AssemblyGap, "assembly_gap", Alphabet_Nucleic);
-    r(CRegion, "C_region", Alphabet_Nucleic);
-    r(Cds, "CDS", Alphabet_Nucleic);
-    r(Centromere, "centromere", Alphabet_Nucleic);
-    r(DLoop, "D-Loop", Alphabet_Nucleic);
-    r(DSegment, "D_segment", Alphabet_Nucleic);
-    r(Exon, "exon", Alphabet_Nucleic);
-    r(Gap, "gap", Alphabet_Nucleic);
-    r(Gene, "gene", Alphabet_Nucleic);
-    r(IDna, "iDNA", Alphabet_Nucleic);
-    r(Intron, "intron", Alphabet_Nucleic);
-    r(JSegment, "J_segment", Alphabet_Nucleic);
-    r(MaturePeptide, "mat_peptide", Alphabet_Nucleic);
-    r(MiscBindingSite, "misc_binding", Alphabet_Nucleic | Alphabet_Amino);
-    r(MiscDifference, "misc_difference", Alphabet_Nucleic);
-    r(MiscFeature, "misc_feature", Alphabet_Nucleic | Alphabet_Amino);
-    r(MiscRecombination, "misc_recomb", Alphabet_Nucleic);
-    r(MiscRna, "misc_RNA", Alphabet_Nucleic);
-    r(MiscStructure, "misc_structure", Alphabet_Nucleic);
-    r(MobileElement, "mobile_element", Alphabet_Nucleic);
-    r(ModifiedBase, "modified_base", Alphabet_Nucleic);
-    r(MRna, "mRNA", Alphabet_Nucleic);
-    r(NcRna, "ncRNA", Alphabet_Nucleic);
-    r(NRegion, "N_region", Alphabet_Nucleic);
-    r(OldSequence, "old_sequence", Alphabet_Nucleic);
-    r(Operon, "operon", Alphabet_Nucleic);
-    r(OriT, "oriT", Alphabet_Nucleic);
-    r(PolyASite, "polyA_site", Alphabet_Nucleic);
-    r(PrecursorRna, "precursor_RNA", Alphabet_Nucleic);
-    r(PrimaryTranscript, "prim_transcript", Alphabet_Nucleic);
-    r(PrimerBindingSite, "primer_bind", Alphabet_Nucleic);
-    r(Propeptide, "propeptide", Alphabet_Nucleic | Alphabet_Amino);
-    r(ProteinBindingSite, "protein_bind", Alphabet_Nucleic);
-    r(Regulatory, "regulatory", Alphabet_Nucleic);
-    r(RepeatRegion, "repeat_region", Alphabet_Nucleic);
-    r(ReplicationOrigin, "rep_origin", Alphabet_Nucleic);
-    r(RRna, "rRNA", Alphabet_Nucleic);
-    r(SRegion, "S_region", Alphabet_Nucleic);
-    r(SignalPeptide, "sig_peptide", Alphabet_Nucleic);
-    r(Source, "source", Alphabet_Nucleic | Alphabet_Amino);
-    r(StemLoop, "stem_loop", Alphabet_Nucleic);
-    r(Sts, "STS", Alphabet_Nucleic);
-    r(Telomere, "telomere", Alphabet_Nucleic);
-    r(TmRna, "tmRNA", Alphabet_Nucleic);
-    r(TransitPeptide, "transit_peptide", Alphabet_Nucleic | Alphabet_Amino);
-    r(TRna, "tRNA", Alphabet_Nucleic);
-    r(Unsure, "unsure", Alphabet_Nucleic);
-    r(VRegion, "V_region", Alphabet_Nucleic);
-    r(VSegment, "V_segment", Alphabet_Nucleic);
-    r(Variation, "variation", Alphabet_Nucleic | Alphabet_Amino);
-    r(ThreePrimeUtr, "3'UTR", Alphabet_Nucleic);
-    r(FivePrimeUtr, "5'UTR", Alphabet_Nucleic);
+    r(AssemblyGap, "assembly_gap", Alphabet_Nucleic, QObject::tr("Gap between two components of a genome or transcriptome assembly"));
+    r(CRegion, "C_region", Alphabet_Nucleic, QObject::tr("Span of the C immunological feature"));
+    r(Cds, "CDS", Alphabet_Nucleic, QObject::tr("Sequence coding for amino acids in protein (includes stop codon)"), "#9bffff", true);
+    r(Centromere, "centromere", Alphabet_Nucleic, QObject::tr("Region of biological interest identified as a centromere and which has been experimentally characterized"));
+    r(DLoop, "D-Loop", Alphabet_Nucleic, QObject::tr("Displacement loop"));
+    r(DSegment, "D_segment", Alphabet_Nucleic, QObject::tr("Span of the D immunological feature"));
+    r(Exon, "exon", Alphabet_Nucleic, QObject::tr("Region that codes for part of spliced mRNA"));
+    r(Gap, "gap", Alphabet_Nucleic, QObject::tr("Gap in the sequence"));
+    r(Gene, "gene", Alphabet_Nucleic, QObject::tr("Region that defines a functional gene, possibly including upstream (promoter, enhancer, etc) and downstream control elements, and for which a name has been assigned."), "#00ffc8");
+    r(IDna, "iDNA", Alphabet_Nucleic, QObject::tr("Intervening DNA eliminated by recombination"));
+    r(Intron, "intron", Alphabet_Nucleic, QObject::tr("Transcribed region excised by mRNA splicing"));
+    r(JSegment, "J_segment", Alphabet_Nucleic, QObject::tr("Joining segment of immunoglobulin light and heavy chains, and T-cell receptor alpha, beta, and gamma chains"));
+    r(MaturePeptide, "mat_peptide", Alphabet_Nucleic, QObject::tr("Mature peptide coding region (does not include stop codon)"), "", true);
+    r(MiscBindingSite, "misc_binding", Alphabet_Nucleic | Alphabet_Amino, QObject::tr("Miscellaneous binding site"));
+    r(MiscDifference, "misc_difference", Alphabet_Nucleic, QObject::tr("Miscellaneous difference feature"));
+    r(MiscFeature, "misc_feature", Alphabet_Nucleic | Alphabet_Amino, QObject::tr("Region of biological significance that cannot be described by any other feature"));
+    r(MiscRecombination, "misc_recomb", Alphabet_Nucleic, QObject::tr("Miscellaneous, recombination feature"));
+    r(MiscRna, "misc_RNA", Alphabet_Nucleic, QObject::tr("Miscellaneous transcript feature not defined by other RNA keys"));
+    r(MiscStructure, "misc_structure", Alphabet_Nucleic, QObject::tr("Miscellaneous DNA or RNA structure"));
+    r(MobileElement, "mobile_element", Alphabet_Nucleic, QObject::tr("Region of genome containing mobile elements"));
+    r(ModifiedBase, "modified_base", Alphabet_Nucleic, QObject::tr("The indicated base is a modified nucleotide"));
+    r(MRna, "mRNA", Alphabet_Nucleic, QObject::tr("Messenger RNA"));
+    r(NcRna, "ncRNA", Alphabet_Nucleic, QObject::tr("A non-protein-coding gene, other than ribosomal RNA and transfer RNA, the functional molecule of which is the RNA transcript"));
+    r(NRegion, "N_region", Alphabet_Nucleic, QObject::tr("Span of the N immunological feature"));
+    r(OldSequence, "old_sequence", Alphabet_Nucleic, QObject::tr("Presented sequence revises a previous version"));
+    r(Operon, "operon", Alphabet_Nucleic, QObject::tr("Region containing polycistronic transcript including a cluster of genes that are under the control of the same regulatory sequences/promoter and in the same biological pathway"));
+    r(OriT, "oriT", Alphabet_Nucleic, QObject::tr("Origin of transfer; region of a DNA molecule where transfer is initiated during the process of conjugation or mobilization"));
+    r(PolyASite, "polyA_site", Alphabet_Nucleic, QObject::tr("Site at which polyadenine is added to mRNA"));
+    r(PrecursorRna, "precursor_RNA", Alphabet_Nucleic, QObject::tr("Any RNA species that is not yet the mature RNA product"));
+    r(PrimaryTranscript, "prim_transcript", Alphabet_Nucleic, QObject::tr("Primary (unprocessed) transcript"));
+    r(PrimerBindingSite, "primer_bind", Alphabet_Nucleic, QObject::tr("Non-covalent primer binding site"));
+    r(Propeptide, "propeptide", Alphabet_Nucleic | Alphabet_Amino, QObject::tr("Coding sequence for the domain of a proprotein that is cleaved to form the mature protein product"));
+    r(ProteinBindingSite, "protein_bind", Alphabet_Nucleic, QObject::tr("Non-covalent protein binding site on DNA or RNA"));
+    // This feature has replaced the following Feature Keys on 15-DEC-2014:
+    // enhancer, promoter, CAAT_signal, TATA_signal, -35_signal, -10_signal, RBS, GC_signal, polyA_signal, attenuator, terminator, misc_signal.
+    r(Regulatory, "regulatory", Alphabet_Nucleic, QObject::tr("Any region of sequence that functions in the regulation of transcription or translation"));
+    r(RepeatRegion, "repeat_region", Alphabet_Nucleic, QObject::tr("Sequence containing repeated subsequences"), "#ccccff");
+    r(ReplicationOrigin, "rep_origin", Alphabet_Nucleic, QObject::tr("Replication origin for duplex DNA"));
+    r(RRna, "rRNA", Alphabet_Nucleic, QObject::tr("Ribosomal RNA"));
+    r(SRegion, "S_region", Alphabet_Nucleic, QObject::tr("Span of the S immunological feature"));
+    r(SignalPeptide, "sig_peptide", Alphabet_Nucleic, QObject::tr("Signal peptide coding region"));
+    r(Source, "source", Alphabet_Nucleic | Alphabet_Amino, QObject::tr("Identifies the biological source of the specified span of the sequence"), "#cccccc");
+    r(StemLoop, "stem_loop", Alphabet_Nucleic, QObject::tr("Hair-pin loop structure in DNA or RNA"));
+    r(Sts, "STS", Alphabet_Nucleic, QObject::tr("Sequence Tagged Site; operationally unique sequence that identifies the combination of primer spans used in a PCR assay"), "#00dcdc");
+    r(Telomere, "telomere", Alphabet_Nucleic, QObject::tr("Region of biological interest identified as a telomere and which has been experimentally characterized"));
+    r(TmRna, "tmRNA", Alphabet_Nucleic, QObject::tr("Transfer messenger RNA; tmRNA acts as a tRNA first, and then as an mRNA that encodes a peptide tag; the ribosome translates this mRNA region of tmRNA and attaches the encoded peptide tag to the C-terminus of the unfinished protein; this attached tag targets the protein for destruction or proteolysis"));
+    r(TransitPeptide, "transit_peptide", Alphabet_Nucleic | Alphabet_Amino, QObject::tr("Transit peptide coding region"));
+    r(TRna, "tRNA", Alphabet_Nucleic, QObject::tr("Transfer RNA"), "#c8fac8");
+    r(Unsure, "unsure", Alphabet_Nucleic, QObject::tr("Authors are unsure about the sequence in this region"));
+    r(VRegion, "V_region", Alphabet_Nucleic, QObject::tr("Span of the V immunological feature"));
+    r(VSegment, "V_segment", Alphabet_Nucleic, QObject::tr("Variable segment of immunoglobulin light and heavy chains, and T-cell receptor alpha, beta, and gamma chains; codes for most of the variable region (V_region) and the last few amino acids of the leader peptide"));
+    r(Variation, "variation", Alphabet_Nucleic | Alphabet_Amino, QObject::tr("A related population contains stable mutation"), "#e32636");
+    r(ThreePrimeUtr, "3'UTR", Alphabet_Nucleic, QObject::tr("3' untranslated region (trailer)"), "#ffcde6");
+    r(FivePrimeUtr, "5'UTR", Alphabet_Nucleic, QObject::tr("5' untranslated region (leader)"), "#ffc8c8");
 
     // Extra types not related to any public format/specification.
     // Mapped to 'misc_feature' when saved to EMBL/Genbank format. The original name is saved/loaded using a special qualifier (GBFeatureUtils::QUALIFIER_NAME).
@@ -131,7 +170,7 @@ QList<U2FeatureTypes::U2FeatureTypeInfo> U2FeatureTypes::initFeatureTypes() {
     r(AlphaHelix, "Alpha-Helix", Alphabet_Amino);
     r(AlteredSite, "Altered Site", Alphabet_Amino);
     r(Amidation, "Amidation", Alphabet_Amino);
-    r(Attenuator, "Attenuator", Alphabet_Nucleic);
+    r(Attenuator, "Attenuator", Alphabet_Nucleic, QObject::tr("Sequence related to transcription termination"));
     r(BHlhDomain, "bHLH Domain", Alphabet_Nucleic);
     r(Basic, "Basic", Alphabet_Amino);
     r(BetaSheet, "Beta-Sheet", Alphabet_Amino);
@@ -139,7 +178,7 @@ QList<U2FeatureTypes::U2FeatureTypeInfo> U2FeatureTypes::initFeatureTypes() {
     r(BiotinBindingSite, "Biotin Binding Site", Alphabet_Amino);
     r(Blocked, "Blocked", Alphabet_Amino);
     r(C2, "C2", Alphabet_Amino);
-    r(CaatSignal, "CAAT Signal", Alphabet_Nucleic);
+    r(CaatSignal, "CAAT Signal", Alphabet_Nucleic, QObject::tr("`CAAT box' in eukaryotic promoters"));
     r(Calcium, "Calcium", Alphabet_Amino);
     r(CatalyticRegion, "Catalytic Region", Alphabet_Amino);
     r(CellAttachment, "Cell Attachment", Alphabet_Amino);
@@ -149,21 +188,21 @@ QList<U2FeatureTypes::U2FeatureTypeInfo> U2FeatureTypes::initFeatureTypes() {
     r(CoiledCoil, "Coiled coil", Alphabet_Amino);
     r(CollagenType, "Collagen-type", Alphabet_Amino);
     r(Comment, "Comment", Alphabet_None);
-    r(Conflict, "Conflict", Alphabet_Nucleic | Alphabet_Amino);
+    r(Conflict, "Conflict", Alphabet_Nucleic | Alphabet_Amino, QObject::tr("Independent sequence determinations differ"));
     r(ConnectingPeptide, "Connecting Peptide", Alphabet_Amino);
     r(Cub, "CUB", Alphabet_Amino);
     r(Cytoplasmic, "Cytoplasmic", Alphabet_Amino);
-    r(Disulfide, "Disulfide", Alphabet_Amino);
+    r(Disulfide, "Disulfide", Alphabet_Amino, QObject::tr("Describes disulfide bonds (for protein files)"));
     r(Egf, "EGF", Alphabet_Amino);
-    r(Enhancer, "Enhancer", Alphabet_Nucleic);
+    r(Enhancer, "Enhancer", Alphabet_Nucleic, QObject::tr("Cis-acting enhancer of promoter function"));
     r(Exoplasmic, "Exoplasmic", Alphabet_Amino);
     r(Extracellular, "Extracellular", Alphabet_Amino);
     r(Farnesyl, "Farnesyl", Alphabet_Amino);
     r(Fibronectin, "Fibronectin", Alphabet_Amino);
-    r(FivePrimeClip, "5' Clip", Alphabet_Nucleic);
+    r(FivePrimeClip, "5' Clip", Alphabet_Nucleic, QObject::tr("5'-most region of a precursor transcript removed in processing"));
     r(Formylation, "Formylation", Alphabet_Amino);
     r(GammaCarboxyglumaticAcid, "Gamma-Carboxyglumatic Acid", Alphabet_Amino);
-    r(GcSignal, "GC-Signal", Alphabet_Nucleic);
+    r(GcSignal, "GC-Signal", Alphabet_Nucleic, QObject::tr("`GC box' in eukaryotic promoters"));
     r(GeranylGeranyl, "Geranyl-Geranyl", Alphabet_Amino);
     r(Glycosylation, "Glycosylation", Alphabet_Amino);
     r(GlycosylationSite, "Glycosylation Site", Alphabet_Nucleic);
@@ -178,17 +217,17 @@ QList<U2FeatureTypes::U2FeatureTypeInfo> U2FeatureTypes::initFeatureTypes() {
     r(Immunoglobulin, "Immunoglobulin", Alphabet_Amino);
     r(Insertion, "Insertion", Alphabet_Nucleic);
     r(Intracellular, "Intracellular", Alphabet_Amino);
-    r(JRegion, "J-Region", Alphabet_Nucleic);
+    r(JRegion, "J-Region", Alphabet_Nucleic, QObject::tr("Span of the J immunological feature"));
     r(Kh, "KH", Alphabet_Amino);
     r(Kinase, "Kinase", Alphabet_Amino);
     r(LeucineZipper, "Leucine Zipper", Alphabet_Amino);
     r(LeucineZipperDomain, "Leucine Zipper Domain", Alphabet_Nucleic);
     r(Loci, "Loci", Alphabet_Nucleic);
-    r(Ltr, "LTR", Alphabet_Nucleic);
+    r(Ltr, "LTR", Alphabet_Nucleic, QObject::tr("Long terminal repeat"));
     r(MatureChain, "Mature chain", Alphabet_Amino);
     r(Methylation, "Methylation", Alphabet_Amino);
-    r(Minus10Signal, "-10 Signal", Alphabet_Nucleic);
-    r(Minus35Signal, "-35 Signal", Alphabet_Nucleic);
+    r(Minus10Signal, "-10 Signal", Alphabet_Nucleic, QObject::tr("`Pribnow box' in prokaryotic promoters"));
+    r(Minus35Signal, "-35 Signal", Alphabet_Nucleic, QObject::tr("`-35 box' in prokaryotic promoters"));
     r(MiscBond, "Bond: Misc", Alphabet_Amino);
     r(MiscDnaRnaBindingRegion, "DNA/RNA binding region: Misc", Alphabet_Amino);
     r(MiscDomain, "Domain: Misc", Alphabet_Amino);
@@ -198,7 +237,7 @@ QList<U2FeatureTypes::U2FeatureTypeInfo> U2FeatureTypes::initFeatureTypes() {
     r(MiscNpBindingRegion, "NP binding region: Misc", Alphabet_Amino);
     r(MiscRegion, "Region: Misc", Alphabet_Amino);
     r(MiscResidueModification, "Residue Modification: Misc", Alphabet_Amino);
-    r(MiscSignal, "Misc. Signal", Alphabet_Nucleic | Alphabet_Amino);
+    r(MiscSignal, "Misc. Signal", Alphabet_Nucleic | Alphabet_Amino, QObject::tr("Miscellaneous signal"));
     r(MiscSite, "Site: Misc", Alphabet_Amino);
     r(Mutation, "Mutation", Alphabet_Nucleic);
     r(Myristate, "Myristate", Alphabet_Amino);
@@ -210,12 +249,12 @@ QList<U2FeatureTypes::U2FeatureTypeInfo> U2FeatureTypes::initFeatureTypes() {
     r(Periplasmic, "Periplasmic", Alphabet_Amino);
     r(Ph, "PH", Alphabet_Amino);
     r(Phosphorylation, "Phosphorylation", Alphabet_Amino);
-    r(PolyASignal, "PolyA Signal", Alphabet_Nucleic);
+    r(PolyASignal, "PolyA Signal", Alphabet_Nucleic, QObject::tr("Signal for cleavage & polyadenylation"));
     r(PolyAa, "Poly-AA", Alphabet_Amino);
     r(Precursor, "Precursor", Alphabet_Amino);
-    r(Primer, "Primer", Alphabet_Nucleic);
+    r(Primer, "Primer", Alphabet_Nucleic, QObject::tr("Primer binding region used with PCR"));
     r(ProcessedActivePeptide, "Processed active peptide", Alphabet_Amino);
-    r(Promoter, "Promoter", Alphabet_Nucleic);
+    r(Promoter, "Promoter", Alphabet_Nucleic, QObject::tr("A region involved in transcription initiation"));
     r(PromoterEukaryotic, "Promoter Eukaryotic", Alphabet_Nucleic);
     r(PromoterProkaryotic, "Promoter Prokaryotic", Alphabet_Nucleic);
     r(Proprotein, "Proprotein", Alphabet_Amino);
@@ -224,13 +263,13 @@ QList<U2FeatureTypes::U2FeatureTypeInfo> U2FeatureTypes::initFeatureTypes() {
     r(Provirus, "Provirus", Alphabet_Nucleic);
     r(PyridoxalPhBindingSite, "Pyridoxal Ph. Binding Site", Alphabet_Amino);
     r(PyrrolidoneCarboxylicAcid, "Pyrrolidone Carboxylic Acid", Alphabet_Amino);
-    r(Rbs, "RBS", Alphabet_Nucleic);
+    r(Rbs, "RBS", Alphabet_Nucleic, QObject::tr("Ribosome binding site"));
     r(Region, "Region", Alphabet_Nucleic);
-    r(RepeatUnit, "Repeat Unit", Alphabet_Nucleic);
+    r(RepeatUnit, "Repeat Unit", Alphabet_Nucleic, QObject::tr("One repeated unit of a repeat_region"), "#ccccff");
     r(RepetitiveRegion, "Repetitive region", Alphabet_Amino);
     r(RestrictionSite, "Restriction Site", Alphabet_Nucleic);
-    r(Satellite, "Satellite", Alphabet_Nucleic);
-    r(ScRna, "scRNA", Alphabet_Nucleic);
+    r(Satellite, "Satellite", Alphabet_Nucleic, QObject::tr("Satellite repeated sequence"));
+    r(ScRna, "scRNA", Alphabet_Nucleic, QObject::tr("Small cytoplasmic RNA"));
     r(SecondaryStructure, "Secondary structure", Alphabet_Amino);
     r(Sh2, "SH2", Alphabet_Amino);
     r(Sh3, "SH3", Alphabet_Amino);
@@ -238,19 +277,18 @@ QList<U2FeatureTypes::U2FeatureTypeInfo> U2FeatureTypes::initFeatureTypes() {
     r(Silencer, "Silencer", Alphabet_Nucleic);
     r(Similarity, "Similarity", Alphabet_Amino);
     r(Site, "Site", Alphabet_Nucleic);
-    r(SnRna, "snRNA", Alphabet_Nucleic);
+    r(SnRna, "snRNA", Alphabet_Nucleic, QObject::tr("Small nuclear RNA"));
     r(SnoRna, "snoRNA", Alphabet_Nucleic);
     r(SplicingSignal, "Splicing Signal", Alphabet_Nucleic);
     r(SplicingVariant, "Splicing Variant", Alphabet_Amino);
     r(Sulfatation, "Sulfatation", Alphabet_Amino);
-    r(TataSignal, "TATA Signal", Alphabet_Nucleic);
-    r(Terminator, "Terminator", Alphabet_Nucleic);
+    r(TataSignal, "TATA Signal", Alphabet_Nucleic, QObject::tr("`TATA box' in eukaryotic promoters"));
+    r(Terminator, "Terminator", Alphabet_Nucleic, QObject::tr("Sequence causing transcription termination"));
     r(Thioether, "Thioether", Alphabet_Amino);
     r(Thiolester, "Thiolester", Alphabet_Amino);
-    r(ThreePrimeClip, "3' Clip", Alphabet_Nucleic);
-    r(ThreePrimeUtr, "3' UTR", Alphabet_Nucleic);
+    r(ThreePrimeClip, "3' Clip", Alphabet_Nucleic, QObject::tr("3'-most region of a precursor transcript removed in processing"));
     r(TransmembraneRegion, "Transmembrane Region", Alphabet_Amino);
-    r(Transposon, "Transposon", Alphabet_Nucleic);
+    r(Transposon, "Transposon", Alphabet_Nucleic, QObject::tr("Transposable element (TN)"));
     r(Uncertainty, "Uncertainty", Alphabet_Amino);
     r(Variant, "Variant", Alphabet_Amino);
     r(Virion, "Virion", Alphabet_Nucleic);
@@ -260,10 +298,18 @@ QList<U2FeatureTypes::U2FeatureTypeInfo> U2FeatureTypes::initFeatureTypes() {
     return typeInfoList;
 }
 
-U2FeatureTypes::U2FeatureTypeInfo::U2FeatureTypeInfo(U2FeatureType featureType, const QString &visualName, Alphabets alphabets)
-    : featureType(featureType),
-      visualName(visualName),
-      alphabets(alphabets) {
+U2FeatureTypes::U2FeatureTypeInfo::U2FeatureTypeInfo(const U2FeatureType &_featureType,
+                                                     const QString &_visualName,
+                                                     const Alphabets &_alphabets,
+                                                     const QColor &_color,
+                                                     const QString &_description,
+                                                     bool _isShowOnAminoFrame)
+    : featureType(_featureType),
+      visualName(_visualName),
+      alphabets(_alphabets),
+      color(_color),
+      description(_description),
+      isShowOnAminoFrame(_isShowOnAminoFrame) {
 }
 
 }  // namespace U2

--- a/src/corelibs/U2Core/src/datatype/U2FeatureType.cpp
+++ b/src/corelibs/U2Core/src/datatype/U2FeatureType.cpp
@@ -120,7 +120,7 @@ QList<U2FeatureTypes::U2FeatureTypeInfo> U2FeatureTypes::initFeatureTypes() {
     r(MaturePeptide, "mat_peptide", Alphabet_Nucleic, QObject::tr("Mature peptide coding region (does not include stop codon)"), "", true);
     r(MiscBindingSite, "misc_binding", Alphabet_Nucleic | Alphabet_Amino, QObject::tr("Miscellaneous binding site"));
     r(MiscDifference, "misc_difference", Alphabet_Nucleic, QObject::tr("Miscellaneous difference feature"));
-    r(MiscFeature, "misc_feature", Alphabet_Nucleic | Alphabet_Amino, QObject::tr("Region of biological significance that cannot be described by any other feature"));
+    r(MiscFeature, "misc_feature", Alphabet_Nucleic | Alphabet_Amino, QObject::tr("Region of biological significance that cannot be described by any other feature"), "#ffff99");
     r(MiscRecombination, "misc_recomb", Alphabet_Nucleic, QObject::tr("Miscellaneous, recombination feature"));
     r(MiscRna, "misc_RNA", Alphabet_Nucleic, QObject::tr("Miscellaneous transcript feature not defined by other RNA keys"));
     r(MiscStructure, "misc_structure", Alphabet_Nucleic, QObject::tr("Miscellaneous DNA or RNA structure"));

--- a/src/corelibs/U2Core/src/datatype/U2FeatureType.h
+++ b/src/corelibs/U2Core/src/datatype/U2FeatureType.h
@@ -22,6 +22,8 @@
 #ifndef _U2_FEATURE_TYPE_H_
 #define _U2_FEATURE_TYPE_H_
 
+#include <QColor>
+
 #include <U2Core/global.h>
 
 namespace U2 {
@@ -224,16 +226,45 @@ public:
     Q_DECLARE_FLAGS(Alphabets, Alphabet)
 
     static QList<U2FeatureType> getTypes(const Alphabets &alphabets);
-    static QString getVisualName(U2FeatureType type);
+
+    /** Returns visual feature type by feature type. */
+    static QString getVisualName(const U2FeatureType &type);
+
+    /** Returns alphabets info by feature type. */
+    static Alphabets getAlphabets(const U2FeatureType &type);
+
+    /** Returns feature color by feature type. */
+    static QColor getColor(const U2FeatureType &type);
+
+    /** Returns feature description by feature type. */
+    static QColor getDescription(const U2FeatureType &type);
+
+    /** Returns true if the feature should be drawn on amino frame when has a nucleic alphabet. Example: CDS. */
+    static bool isShowOnAminoFrame(const U2FeatureType &type);
+
     static U2FeatureType getTypeByName(const QString &visualName);
 
     class U2FeatureTypeInfo {
     public:
-        U2FeatureTypeInfo(U2FeatureType featureType = U2FeatureTypes::Invalid, const QString &visualName = "", Alphabets alphabets = Alphabet_None);
+        U2FeatureTypeInfo(const U2FeatureType &featureType,
+                          const QString &visualName,
+                          const Alphabets &alphabets,
+                          const QColor &color,
+                          const QString &description,
+                          bool isShowOnAminoFrame);
 
         U2FeatureType featureType;
         QString visualName;
         Alphabets alphabets;
+
+        /** A default color used to render the feature in UGENE. */
+        QColor color;
+
+        /** Detailed description of the feature meaning. */
+        QString description;
+
+        /** If true a nucleic feature must be highlighted  on amino frame. */
+        bool isShowOnAminoFrame = false;
     };
 
 private:

--- a/src/corelibs/U2Core/src/dbi/U2Dbi.h
+++ b/src/corelibs/U2Core/src/dbi/U2Dbi.h
@@ -27,7 +27,6 @@
 
 #include <U2Core/GUrl.h>
 #include <U2Core/U2Assembly.h>
-#include <U2Core/U2Feature.h>
 #include <U2Core/U2FormatCheckResult.h>
 #include <U2Core/U2Mod.h>
 #include <U2Core/U2Msa.h>

--- a/src/corelibs/U2Core/src/util/GenbankFeatures.cpp
+++ b/src/corelibs/U2Core/src/util/GenbankFeatures.cpp
@@ -24,17 +24,14 @@
 #include <QHash>
 #include <QMutex>
 
-#include <U2Core/FeatureColors.h>
+#include <U2Core/U2SafePoints.h>
 
 namespace U2 {
 
 QMutex GBFeatureUtils::allKeys_mutex;
-QMutex GBFeatureUtils::getKeyGroups_mutex;
 QMutex GBFeatureUtils::getKey_mutex;
 
 const QByteArray GBFeatureUtils::QUALIFIER_AMINO_STRAND("ugene_amino_strand");
-const QByteArray GBFeatureUtils::QUALIFIER_AMINO_STRAND_YES("yes");
-const QByteArray GBFeatureUtils::QUALIFIER_AMINO_STRAND_NO("no");
 
 const QByteArray GBFeatureUtils::QUALIFIER_NAME("ugene_name");
 const QByteArray GBFeatureUtils::QUALIFIER_GROUP("ugene_group");
@@ -45,22 +42,14 @@ const QString GBFeatureUtils::QUALIFIER_CUT = "cut";
 const QString GBFeatureUtils::QUALIFIER_NOTE = "note";
 const QString GBFeatureUtils::QUALIFIER_TRANSLATION = "translation";
 
-static QColor cl(const QString &txt) {
-    QColor res;
-    if (txt != "000000") {
-        res.setNamedColor("#" + txt);
-    }
-    return res;
-}
-
-#define FKE(key, type, text, color, amino, desc, quals) \
-    features[key] = GBFeatureKeyInfo(key, type, text, color.isValid() ? color : FeatureColors::genLightColor(text), amino, desc); \
+#define FKE(key, type, text, quals) \
+    features[key] = GBFeatureKeyInfo(key, type, text); \
     if (strlen(quals) > 0) { \
         features[key].namingQuals = QString(quals).split(",", QString::SkipEmptyParts); \
     }
 
-#define FK(key, type, text, color, amino, desc) \
-    FKE(key, type, text, color, amino, desc, "label")
+#define FK(key, type, text) \
+    FKE(key, type, text, "label")
 
 const QVector<GBFeatureKeyInfo> &GBFeatureUtils::allKeys() {
     QMutexLocker locker(&allKeys_mutex);
@@ -70,216 +59,91 @@ const QVector<GBFeatureKeyInfo> &GBFeatureUtils::allKeys() {
         return features;
     }
     inited = true;
-    FK(GBFeatureKey_assembly_gap, U2FeatureTypes::AssemblyGap, "assemlby_gap", cl("000000"), false, QObject::tr("Gap between two components of a genome or transcriptome assembly"));
-    FK(GBFeatureKey_attenuator, U2FeatureTypes::Attenuator, "attenuator", cl("000000"), false, QObject::tr("Sequence related to transcription termination"));
-    FK(GBFeatureKey_bond, U2FeatureTypes::Disulfide, "Bond", cl("000000"), false, QObject::tr("Describes disulfide bonds (for protein files)"));
-    FK(GBFeatureKey_C_region, U2FeatureTypes::CRegion, "C_region", cl("000000"), false, QObject::tr("Span of the C immunological feature"));
-    FK(GBFeatureKey_CAAT_signal, U2FeatureTypes::CaatSignal, "CAAT_signal", cl("000000"), false, QObject::tr("`CAAT box' in eukaryotic promoters"));
-    FKE(GBFeatureKey_CDS, U2FeatureTypes::Cds, "CDS", cl("9bffff"), true, QObject::tr("Sequence coding for amino acids in protein (includes stop codon)"), "label,protein_id,locus_tag,gene,function,product");
-    FK(GBFeatureKey_conflict, U2FeatureTypes::Conflict, "conflict", cl("000000"), false, QObject::tr("Independent sequence determinations differ"));
-    FK(GBFeatureKey_centromere, U2FeatureTypes::Centromere, "centromere", cl("000000"), false, QObject::tr("Region of biological interest identified as a centromere and which has been experimentally characterized"));
-    FK(GBFeatureKey_D_loop, U2FeatureTypes::DLoop, "D-loop", cl("000000"), false, QObject::tr("Displacement loop"));
-    FK(GBFeatureKey_D_segment, U2FeatureTypes::DSegment, "D_segment", cl("000000"), false, QObject::tr("Span of the D immunological feature"));
-    FK(GBFeatureKey_enhancer, U2FeatureTypes::Enhancer, "enhancer", cl("000000"), false, QObject::tr("Cis-acting enhancer of promoter function"));
-    FK(GBFeatureKey_exon, U2FeatureTypes::Exon, "exon", cl("000000"), false, QObject::tr("Region that codes for part of spliced mRNA"));
-    FK(GBFeatureKey_gap, U2FeatureTypes::Gap, "gap", cl("000000"), false, QObject::tr("Gap in the sequence"));
-    FKE(GBFeatureKey_gene, U2FeatureTypes::Gene, "gene", cl("00ffc8"), false, QObject::tr("Region that defines a functional gene, possibly including upstream (promotor, enhancer, etc) and downstream control elements, and for which a name has been assigned."), "label,gene,locus_tag,product,function");
-    FK(GBFeatureKey_GC_signal, U2FeatureTypes::GcSignal, "GC_signal", cl("000000"), false, QObject::tr("`GC box' in eukaryotic promoters"));
-    FK(GBFeatureKey_iDNA, U2FeatureTypes::IDna, "iDNA", cl("000000"), false, QObject::tr("Intervening DNA eliminated by recombination"));
-    FK(GBFeatureKey_intron, U2FeatureTypes::Intron, "intron", cl("000000"), false, QObject::tr("Transcribed region excised by mRNA splicing"));
-    FK(GBFeatureKey_J_region, U2FeatureTypes::JRegion, "J_region", cl("000000"), false, QObject::tr("Span of the J immunological feature"));
-    FK(GBFeatureKey_J_segment, U2FeatureTypes::JSegment, "J_segment", cl("000000"), false, QObject::tr("Joining segment of immunoglobulin light and heavy chains, and T-cell receptor alpha, beta, and gamma chains"));
-    FK(GBFeatureKey_LTR, U2FeatureTypes::Ltr, "LTR", cl("000000"), false, QObject::tr("Long terminal repeat"));
-    FK(GBFeatureKey_mat_peptide, U2FeatureTypes::MaturePeptide, "mat_peptide", cl("000000"), true, QObject::tr("Mature peptide coding region (does not include stop codon)"));
-    FK(GBFeatureKey_misc_binding, U2FeatureTypes::MiscBindingSite, "misc_binding", cl("000000"), false, QObject::tr("Miscellaneous binding site"));
-    FK(GBFeatureKey_misc_difference, U2FeatureTypes::MiscDifference, "misc_difference", cl("000000"), false, QObject::tr("Miscellaneous difference feature"));
-    FKE(GBFeatureKey_misc_feature, U2FeatureTypes::MiscFeature, "misc_feature", cl("000000"), false, QObject::tr("Region of biological significance that cannot be described by any other feature"), "label,note");
-    FK(GBFeatureKey_misc_recomb, U2FeatureTypes::MiscRecombination, "misc_recomb", cl("000000"), false, QObject::tr("Miscellaneous, recombination feature"));
-    FK(GBFeatureKey_misc_RNA, U2FeatureTypes::MiscRna, "misc_RNA", cl("000000"), false, QObject::tr("Miscellaneous transcript feature not defined by other RNA keys"));
-    FK(GBFeatureKey_misc_signal, U2FeatureTypes::MiscSignal, "misc_signal", cl("000000"), false, QObject::tr("Miscellaneous signal"));
-    FK(GBFeatureKey_misc_structure, U2FeatureTypes::MiscStructure, "misc_structure", cl("000000"), false, QObject::tr("Miscellaneous DNA or RNA structure"));
-    FK(GBFeatureKey_mobile_element, U2FeatureTypes::MobileElement, "mobile_element", cl("000000"), false, QObject::tr("Region of genome containing mobile elements"));
-    FK(GBFeatureKey_modified_base, U2FeatureTypes::ModifiedBase, "modified_base", cl("000000"), false, QObject::tr("The indicated base is a modified nucleotide"));
-    FK(GBFeatureKey_mRNA, U2FeatureTypes::MRna, "mRNA", cl("000000"), false, QObject::tr("Messenger RNA"));
-    FK(GBFeatureKey_ncRNA, U2FeatureTypes::NcRna, "ncRNA", cl("000000"), false, QObject::tr("A non-protein-coding gene, other than ribosomal RNA and transfer RNA, the functional molecule of which is the RNA transcrip"))
-    FK(GBFeatureKey_N_region, U2FeatureTypes::NRegion, "N_region", cl("000000"), false, QObject::tr("Span of the N immunological feature"));
-    FK(GBFeatureKey_old_sequence, U2FeatureTypes::OldSequence, "old_sequence", cl("000000"), false, QObject::tr("Presented sequence revises a previous version"));
-    FK(GBFeatureKey_operon, U2FeatureTypes::Operon, "operon", cl("000000"), false, QObject::tr("Region containing polycistronic transcript including a cluster of genes that are under the control of the same regulatory sequences/promotor and in the same biological pathway"));
-    FK(GBFeatureKey_oriT, U2FeatureTypes::OriT, "oriT", cl("000000"), false, QObject::tr("Origin of transfer; region of a DNA molecule where transfer is initiated during the process of conjugation or mobilization"));
-    FK(GBFeatureKey_polyA_signal, U2FeatureTypes::PolyASignal, "polyA_signal", cl("000000"), false, QObject::tr("Signal for cleavage & polyadenylation"));
-    FK(GBFeatureKey_polyA_site, U2FeatureTypes::PolyASite, "polyA_site", cl("000000"), false, QObject::tr("Site at which polyadenine is added to mRNA"));
-    FK(GBFeatureKey_precursor_RNA, U2FeatureTypes::PrecursorRna, "precursor_RNA", cl("000000"), false, QObject::tr("Any RNA species that is not yet the mature RNA product"));
-    FK(GBFeatureKey_prim_transcript, U2FeatureTypes::PrimaryTranscript, "prim_transcript", cl("000000"), false, QObject::tr("Primary (unprocessed) transcript"));
-    FK(GBFeatureKey_primer, U2FeatureTypes::Primer, "primer", cl("000000"), false, QObject::tr("Primer binding region used with PCR"));
-    FK(GBFeatureKey_primer_bind, U2FeatureTypes::PrimerBindingSite, "primer_bind", cl("000000"), false, QObject::tr("Non-covalent primer binding site"));
-    FK(GBFeatureKey_promoter, U2FeatureTypes::Promoter, "promoter", cl("000000"), false, QObject::tr("A region involved in transcription initiation"));
-    FK(GBFeatureKey_protein_bind, U2FeatureTypes::ProteinBindingSite, "protein_bind", cl("000000"), false, QObject::tr("Non-covalent protein binding site on DNA or RNA"));
-    FK(GBFeatureKey_RBS, U2FeatureTypes::Rbs, "RBS", cl("000000"), false, QObject::tr("Ribosome binding site"));
-    FK(GBFeatureKey_rep_origin, U2FeatureTypes::ReplicationOrigin, "rep_origin", cl("000000"), false, QObject::tr("Replication origin for duplex DNA"));
-    FK(GBFeatureKey_repeat_region, U2FeatureTypes::RepeatRegion, "repeat_region", cl("ccccff"), false, QObject::tr("Sequence containing repeated subsequences"));
-    FK(GBFeatureKey_repeat_unit, U2FeatureTypes::RepeatUnit, "repeat_unit", cl("ccccff"), false, QObject::tr("One repeated unit of a repeat_region"));
-    FK(GBFeatureKey_rRNA, U2FeatureTypes::RRna, "rRNA", cl("000000"), false, QObject::tr("Ribosomal RNA"));
-    FK(GBFeatureKey_S_region, U2FeatureTypes::SRegion, "S_region", cl("000000"), false, QObject::tr("Span of the S immunological feature"));
-    FK(GBFeatureKey_satellite, U2FeatureTypes::Satellite, "satellite", cl("000000"), false, QObject::tr("Satellite repeated sequence"));
-    FK(GBFeatureKey_scRNA, U2FeatureTypes::ScRna, "scRNA", cl("000000"), false, QObject::tr("Small cytoplasmic RNA"));
-    FK(GBFeatureKey_sig_peptide, U2FeatureTypes::SignalPeptide, "sig_peptide", cl("000000"), false, QObject::tr("Signal peptide coding region"));
-    FK(GBFeatureKey_snRNA, U2FeatureTypes::SnRna, "snRNA", cl("000000"), false, QObject::tr("Small nuclear RNA"));
-    FK(GBFeatureKey_source, U2FeatureTypes::Source, "source", cl("cccccc"), false, QObject::tr("Identifies the biological source of the specified span of the sequence"));
-    FK(GBFeatureKey_stem_loop, U2FeatureTypes::StemLoop, "stem_loop", cl("000000"), false, QObject::tr("Hair-pin loop structure in DNA or RNA"));
-    FK(GBFeatureKey_STS, U2FeatureTypes::Sts, "STS", cl("00dcdc"), false, QObject::tr("Sequence Tagged Site; operationally unique sequence that identifies the combination of primer spans used in a PCR assay"));
-    FK(GBFeatureKey_TATA_signal, U2FeatureTypes::TataSignal, "TATA_signal", cl("000000"), false, QObject::tr("`TATA box' in eukaryotic promoters"));
-    FK(GBFeatureKey_telomere, U2FeatureTypes::Telomere, "telomere", cl("000000"), false, QObject::tr("Region of biological interest identified as a telomere and which has been experimentally characterized"));
-    FK(GBFeatureKey_terminator, U2FeatureTypes::Terminator, "terminator", cl("000000"), false, QObject::tr("Sequence causing transcription termination"));
-    FK(GBFeatureKey_tmRNA, U2FeatureTypes::TmRna, "tmRNA", cl("000000"), false, QObject::tr("Transfer messenger RNA; tmRNA acts as a tRNA first, and then as an mRNA that encodes a peptide tag; the ribosome translates this mRNA region of tmRNA and attaches the encoded peptide tag to the C-terminus of the unfinished protein; this attached tag targets the protein for destruction or proteolysis"));
-    FK(GBFeatureKey_transit_peptide, U2FeatureTypes::TransitPeptide, "transit_peptide", cl("000000"), false, QObject::tr("Transit peptide coding region"));
-    FK(GBFeatureKey_transposon, U2FeatureTypes::Transposon, "transposon", cl("000000"), false, QObject::tr("Transposable element (TN)"));
-    FK(GBFeatureKey_tRNA, U2FeatureTypes::TRna, "tRNA", cl("c8fac8"), false, QObject::tr("Transfer RNA"));
-    FK(GBFeatureKey_unsure, U2FeatureTypes::Unsure, "unsure", cl("000000"), false, QObject::tr("Authors are unsure about the sequence in this region"));
-    FK(GBFeatureKey_V_region, U2FeatureTypes::VRegion, "V_region", cl("000000"), false, QObject::tr("Span of the V immunological feature"));
-    FK(GBFeatureKey_V_segment, U2FeatureTypes::VSegment, "V_segment", cl("000000"), false, QObject::tr("Variable segment of immunoglobulin light and heavy chains, and T-cell receptor alpha, beta, and gamma chains; codes for most of the variable region (V_region) and the last few amino acids of the leader peptide"));
-    FK(GBFeatureKey_variation, U2FeatureTypes::Variation, "variation", cl("e32636"), false, QObject::tr("A related population contains stable mutation"));
-    FK(GBFeatureKey__10_signal, U2FeatureTypes::Minus10Signal, "-10_signal", cl("000000"), false, QObject::tr("`Pribnow box' in prokaryotic promoters"));
-    FK(GBFeatureKey__35_signal, U2FeatureTypes::Minus35Signal, "-35_signal", cl("000000"), false, QObject::tr("`-35 box' in prokaryotic promoters"));
-    FK(GBFeatureKey_3_clip, U2FeatureTypes::ThreePrimeClip, "3'clip", cl("000000"), false, QObject::tr("3'-most region of a precursor transcript removed in processing"));
-    FK(GBFeatureKey_3_UTR, U2FeatureTypes::ThreePrimeUtr, "3'UTR", cl("ffcde6"), false, QObject::tr("3' untranslated region (trailer)"));
-    FK(GBFeatureKey_5_clip, U2FeatureTypes::FivePrimeClip, "5'clip", cl("000000"), false, QObject::tr("5'-most region of a precursor transcript removed in processing"));
-    FK(GBFeatureKey_5_UTR, U2FeatureTypes::FivePrimeUtr, "5'UTR", cl("ffc8c8"), false, QObject::tr("5' untranslated region (leader)"));
-    FK(GBFeatureKey_Protein, U2FeatureTypes::Protein, "Protein", cl("000000"), false, QObject::tr("'Protein' feature key"));
-    FK(GBFeatureKey_Region, U2FeatureTypes::Region, "Region", cl("000000"), false, QObject::tr("'Region' feature key"));
-    FK(GBFeatureKey_Site, U2FeatureTypes::Site, "Site", cl("000000"), false, QObject::tr("'Site' feature key"));
-    FK(GBFeatureKey_regulatory, U2FeatureTypes::Regulatory, "regulatory", cl("000000"), false, QObject::tr("Any region of sequence that functions in the regulation of transcription or translation"));
+    FK(GBFeatureKey_assembly_gap, U2FeatureTypes::AssemblyGap, "assembly_gap");
+    FK(GBFeatureKey_attenuator, U2FeatureTypes::Attenuator, "attenuator");
+    FK(GBFeatureKey_bond, U2FeatureTypes::Disulfide, "Bond");
+    FK(GBFeatureKey_C_region, U2FeatureTypes::CRegion, "C_region");
+    FK(GBFeatureKey_CAAT_signal, U2FeatureTypes::CaatSignal, "CAAT_signal");
+    FKE(GBFeatureKey_CDS, U2FeatureTypes::Cds, "CDS", "label,protein_id,locus_tag,gene,function,product");
+    FK(GBFeatureKey_conflict, U2FeatureTypes::Conflict, "conflict");
+    FK(GBFeatureKey_centromere, U2FeatureTypes::Centromere, "centromere");
+    FK(GBFeatureKey_D_loop, U2FeatureTypes::DLoop, "D-loop");
+    FK(GBFeatureKey_D_segment, U2FeatureTypes::DSegment, "D_segment");
+    FK(GBFeatureKey_enhancer, U2FeatureTypes::Enhancer, "enhancer");
+    FK(GBFeatureKey_exon, U2FeatureTypes::Exon, "exon");
+    FK(GBFeatureKey_gap, U2FeatureTypes::Gap, "gap");
+    FKE(GBFeatureKey_gene, U2FeatureTypes::Gene, "gene", "label,gene,locus_tag,product,function");
+    FK(GBFeatureKey_GC_signal, U2FeatureTypes::GcSignal, "GC_signal");
+    FK(GBFeatureKey_iDNA, U2FeatureTypes::IDna, "iDNA");
+    FK(GBFeatureKey_intron, U2FeatureTypes::Intron, "intron");
+    FK(GBFeatureKey_J_region, U2FeatureTypes::JRegion, "J_region");
+    FK(GBFeatureKey_J_segment, U2FeatureTypes::JSegment, "J_segment");
+    FK(GBFeatureKey_LTR, U2FeatureTypes::Ltr, "LTR");
+    FK(GBFeatureKey_mat_peptide, U2FeatureTypes::MaturePeptide, "mat_peptide");
+    FK(GBFeatureKey_misc_binding, U2FeatureTypes::MiscBindingSite, "misc_binding");
+    FK(GBFeatureKey_misc_difference, U2FeatureTypes::MiscDifference, "misc_difference");
+    FKE(GBFeatureKey_misc_feature, U2FeatureTypes::MiscFeature, "misc_feature", "label,note");
+    FK(GBFeatureKey_misc_recomb, U2FeatureTypes::MiscRecombination, "misc_recomb");
+    FK(GBFeatureKey_misc_RNA, U2FeatureTypes::MiscRna, "misc_RNA");
+    FK(GBFeatureKey_misc_signal, U2FeatureTypes::MiscSignal, "misc_signal");
+    FK(GBFeatureKey_misc_structure, U2FeatureTypes::MiscStructure, "misc_structure");
+    FK(GBFeatureKey_mobile_element, U2FeatureTypes::MobileElement, "mobile_element");
+    FK(GBFeatureKey_modified_base, U2FeatureTypes::ModifiedBase, "modified_base");
+    FK(GBFeatureKey_mRNA, U2FeatureTypes::MRna, "mRNA");
+    FK(GBFeatureKey_ncRNA, U2FeatureTypes::NcRna, "ncRNA")
+    FK(GBFeatureKey_N_region, U2FeatureTypes::NRegion, "N_region");
+    FK(GBFeatureKey_old_sequence, U2FeatureTypes::OldSequence, "old_sequence");
+    FK(GBFeatureKey_operon, U2FeatureTypes::Operon, "operon");
+    FK(GBFeatureKey_oriT, U2FeatureTypes::OriT, "oriT");
+    FK(GBFeatureKey_polyA_signal, U2FeatureTypes::PolyASignal, "polyA_signal");
+    FK(GBFeatureKey_polyA_site, U2FeatureTypes::PolyASite, "polyA_site");
+    FK(GBFeatureKey_precursor_RNA, U2FeatureTypes::PrecursorRna, "precursor_RNA");
+    FK(GBFeatureKey_prim_transcript, U2FeatureTypes::PrimaryTranscript, "prim_transcript");
+    FK(GBFeatureKey_primer, U2FeatureTypes::Primer, "primer");
+    FK(GBFeatureKey_primer_bind, U2FeatureTypes::PrimerBindingSite, "primer_bind");
+    FK(GBFeatureKey_promoter, U2FeatureTypes::Promoter, "promoter");
+    FK(GBFeatureKey_protein_bind, U2FeatureTypes::ProteinBindingSite, "protein_bind");
+    FK(GBFeatureKey_RBS, U2FeatureTypes::Rbs, "RBS");
+    FK(GBFeatureKey_rep_origin, U2FeatureTypes::ReplicationOrigin, "rep_origin");
+    FK(GBFeatureKey_repeat_region, U2FeatureTypes::RepeatRegion, "repeat_region");
+    FK(GBFeatureKey_repeat_unit, U2FeatureTypes::RepeatUnit, "repeat_unit");
+    FK(GBFeatureKey_rRNA, U2FeatureTypes::RRna, "rRNA");
+    FK(GBFeatureKey_S_region, U2FeatureTypes::SRegion, "S_region");
+    FK(GBFeatureKey_satellite, U2FeatureTypes::Satellite, "satellite");
+    FK(GBFeatureKey_scRNA, U2FeatureTypes::ScRna, "scRNA");
+    FK(GBFeatureKey_sig_peptide, U2FeatureTypes::SignalPeptide, "sig_peptide");
+    FK(GBFeatureKey_snRNA, U2FeatureTypes::SnRna, "snRNA");
+    FK(GBFeatureKey_source, U2FeatureTypes::Source, "source");
+    FK(GBFeatureKey_stem_loop, U2FeatureTypes::StemLoop, "stem_loop");
+    FK(GBFeatureKey_STS, U2FeatureTypes::Sts, "STS");
+    FK(GBFeatureKey_TATA_signal, U2FeatureTypes::TataSignal, "TATA_signal");
+    FK(GBFeatureKey_telomere, U2FeatureTypes::Telomere, "telomere");
+    FK(GBFeatureKey_terminator, U2FeatureTypes::Terminator, "terminator");
+    FK(GBFeatureKey_tmRNA, U2FeatureTypes::TmRna, "tmRNA");
+    FK(GBFeatureKey_transit_peptide, U2FeatureTypes::TransitPeptide, "transit_peptide");
+    FK(GBFeatureKey_transposon, U2FeatureTypes::Transposon, "transposon");
+    FK(GBFeatureKey_tRNA, U2FeatureTypes::TRna, "tRNA");
+    FK(GBFeatureKey_unsure, U2FeatureTypes::Unsure, "unsure");
+    FK(GBFeatureKey_V_region, U2FeatureTypes::VRegion, "V_region");
+    FK(GBFeatureKey_V_segment, U2FeatureTypes::VSegment, "V_segment");
+    FK(GBFeatureKey_variation, U2FeatureTypes::Variation, "variation");
+    FK(GBFeatureKey__10_signal, U2FeatureTypes::Minus10Signal, "-10_signal");
+    FK(GBFeatureKey__35_signal, U2FeatureTypes::Minus35Signal, "-35_signal");
+    FK(GBFeatureKey_3_clip, U2FeatureTypes::ThreePrimeClip, "3'clip");
+    FK(GBFeatureKey_3_UTR, U2FeatureTypes::ThreePrimeUtr, "3'UTR");
+    FK(GBFeatureKey_5_clip, U2FeatureTypes::FivePrimeClip, "5'clip");
+    FK(GBFeatureKey_5_UTR, U2FeatureTypes::FivePrimeUtr, "5'UTR");
+    FK(GBFeatureKey_Protein, U2FeatureTypes::Protein, "Protein");
+    FK(GBFeatureKey_Region, U2FeatureTypes::Region, "Region");
+    FK(GBFeatureKey_Site, U2FeatureTypes::Site, "Site");
+    FK(GBFeatureKey_regulatory, U2FeatureTypes::Regulatory, "regulatory");
 
-#ifdef _DEBUG
     for (int i = 0; i < features.size(); i++) {
-        assert(features[i].id != GBFeatureKey_UNKNOWN && features[i].id == i);
-        assert(!features[i].text.isEmpty());
-        assert(!features[i].desc.isEmpty());
-        assert(features[i].color.isValid());
+        SAFE_POINT(features[i].id != GBFeatureKey_UNKNOWN && features[i].id == i, "Invalid Genbank feature id", features);
+        SAFE_POINT(!features[i].text.isEmpty(), "Invalid Genbank feature key", features);
     }
-#endif
 
     return features;
-}
-
-const QMultiMap<QString, GBFeatureKey> &GBFeatureUtils::getKeyGroups() {
-    QMutexLocker locker(&getKeyGroups_mutex);
-    static QMultiMap<QString, GBFeatureKey> groups;
-
-    if (groups.isEmpty()) {
-        QString genes = QObject::tr("Genes");
-        groups.insert(genes, GBFeatureKey_CDS);
-        groups.insert(genes, GBFeatureKey_exon);
-        groups.insert(genes, GBFeatureKey_gene);
-        groups.insert(genes, GBFeatureKey_intron);
-        groups.insert(genes, GBFeatureKey_mRNA);
-        groups.insert(genes, GBFeatureKey_polyA_site);
-        groups.insert(genes, GBFeatureKey_precursor_RNA);
-        groups.insert(genes, GBFeatureKey_prim_transcript);
-        groups.insert(genes, GBFeatureKey_promoter);
-        groups.insert(genes, GBFeatureKey_3_clip);
-        groups.insert(genes, GBFeatureKey_3_UTR);
-        groups.insert(genes, GBFeatureKey_5_clip);
-        groups.insert(genes, GBFeatureKey_5_UTR);
-
-        QString signls = QObject::tr("Signals");
-        groups.insert(signls, GBFeatureKey_attenuator);
-        groups.insert(signls, GBFeatureKey_CAAT_signal);
-        groups.insert(signls, GBFeatureKey_GC_signal);
-        groups.insert(signls, GBFeatureKey_enhancer);
-        groups.insert(signls, GBFeatureKey_mat_peptide);
-        groups.insert(signls, GBFeatureKey_misc_signal);
-        groups.insert(signls, GBFeatureKey_oriT);
-        groups.insert(signls, GBFeatureKey_rep_origin);
-        groups.insert(signls, GBFeatureKey_polyA_site);
-        groups.insert(signls, GBFeatureKey_polyA_signal);
-        groups.insert(signls, GBFeatureKey_promoter);
-        groups.insert(signls, GBFeatureKey_RBS);
-        groups.insert(signls, GBFeatureKey_sig_peptide);
-        groups.insert(signls, GBFeatureKey_terminator);
-        groups.insert(signls, GBFeatureKey_transit_peptide);
-        groups.insert(signls, GBFeatureKey_TATA_signal);
-        groups.insert(signls, GBFeatureKey__35_signal);
-        groups.insert(signls, GBFeatureKey__10_signal);
-        groups.insert(signls, GBFeatureKey_regulatory);
-
-        QString binding = QObject::tr("Binding");
-        groups.insert(binding, GBFeatureKey_misc_binding);
-        groups.insert(binding, GBFeatureKey_primer_bind);
-        groups.insert(binding, GBFeatureKey_protein_bind);
-        groups.insert(binding, GBFeatureKey_bond);
-
-        QString variation = QObject::tr("Variation");
-        groups.insert(variation, GBFeatureKey_conflict);
-        groups.insert(variation, GBFeatureKey_misc_difference);
-        groups.insert(variation, GBFeatureKey_modified_base);
-        groups.insert(variation, GBFeatureKey_old_sequence);
-        groups.insert(variation, GBFeatureKey_STS);
-        groups.insert(variation, GBFeatureKey_unsure);
-        groups.insert(variation, GBFeatureKey_variation);
-
-        QString repeats = QObject::tr("Repeats");
-        groups.insert(repeats, GBFeatureKey_LTR);
-        groups.insert(repeats, GBFeatureKey_repeat_region);
-        groups.insert(repeats, GBFeatureKey_repeat_unit);
-        groups.insert(repeats, GBFeatureKey_satellite);
-        groups.insert(repeats, GBFeatureKey_transposon);  // TODO: recheck grouping
-
-        QString rna = QObject::tr("RNA");
-        groups.insert(rna, GBFeatureKey_ncRNA);
-        groups.insert(rna, GBFeatureKey_misc_RNA);
-        groups.insert(rna, GBFeatureKey_mRNA);
-        groups.insert(rna, GBFeatureKey_rRNA);
-        groups.insert(rna, GBFeatureKey_scRNA);
-        groups.insert(rna, GBFeatureKey_snRNA);
-        groups.insert(rna, GBFeatureKey_tRNA);
-        groups.insert(rna, GBFeatureKey_tmRNA);
-
-        QString misc = QObject::tr("Misc");
-        groups.insert(misc, GBFeatureKey_assembly_gap);
-        groups.insert(misc, GBFeatureKey_centromere);
-        groups.insert(misc, GBFeatureKey_D_loop);
-        groups.insert(misc, GBFeatureKey_gap);
-        groups.insert(misc, GBFeatureKey_iDNA);
-        groups.insert(misc, GBFeatureKey_misc_binding);
-        groups.insert(misc, GBFeatureKey_misc_feature);
-        groups.insert(misc, GBFeatureKey_misc_recomb);
-        groups.insert(misc, GBFeatureKey_misc_structure);
-        groups.insert(misc, GBFeatureKey_mobile_element);
-        groups.insert(misc, GBFeatureKey_operon);
-        groups.insert(misc, GBFeatureKey_primer);  // TODO: recheck grouping
-        groups.insert(misc, GBFeatureKey_source);
-        groups.insert(misc, GBFeatureKey_stem_loop);
-        groups.insert(misc, GBFeatureKey_telomere);
-        groups.insert(misc, GBFeatureKey_Protein);
-        groups.insert(misc, GBFeatureKey_Region);
-        groups.insert(misc, GBFeatureKey_Site);
-
-        QString spans = QObject::tr("Spans");
-        groups.insert(spans, GBFeatureKey_C_region);
-        groups.insert(spans, GBFeatureKey_D_segment);
-        groups.insert(spans, GBFeatureKey_J_region);
-        groups.insert(spans, GBFeatureKey_J_segment);
-        groups.insert(spans, GBFeatureKey_N_region);
-        groups.insert(spans, GBFeatureKey_S_region);
-        groups.insert(spans, GBFeatureKey_V_region);
-        groups.insert(spans, GBFeatureKey_V_segment);
-
-#ifdef _DEBUG
-        // check that no feature lost
-        QVector<bool> featureInGroup(GBFeatureKey_NUM_KEYS, false);
-        foreach (const QString &groupName, groups.keys()) {
-            QList<GBFeatureKey> values = groups.values(groupName);
-            for (const GBFeatureKey &k : qAsConst(values)) {
-                featureInGroup[k] = true;
-            }
-        }
-        for (int i = 0; i < GBFeatureKey_NUM_KEYS; i++) {
-            GBFeatureKey fk = GBFeatureKey(i);
-            assert(featureInGroup[fk]);
-        }
-#endif
-    }
-    return groups;
 }
 
 bool GBFeatureUtils::isFeatureHasNoValue(const QString &featureName) {

--- a/src/corelibs/U2Core/src/util/GenbankFeatures.h
+++ b/src/corelibs/U2Core/src/util/GenbankFeatures.h
@@ -118,19 +118,15 @@ enum GBFeatureKey {
 
 class U2CORE_EXPORT GBFeatureKeyInfo {
 public:
-    GBFeatureKeyInfo()
-        : id(GBFeatureKey_UNKNOWN), showOnaminoFrame(false) {
-    }
-    GBFeatureKeyInfo(GBFeatureKey _id, U2FeatureType type, const QString &_text, const QColor &_color, bool _aminoFrame, QString _desc)
-        : id(_id), type(type), text(_text), color(_color), showOnaminoFrame(_aminoFrame), desc(_desc) {
+    GBFeatureKeyInfo() = default;
+
+    GBFeatureKeyInfo(const GBFeatureKey &_id, const U2FeatureType &type, const QString &_text)
+        : id(_id), type(type), text(_text) {
     }
 
-    GBFeatureKey id;
-    U2FeatureType type;
+    GBFeatureKey id = GBFeatureKey_UNKNOWN;
+    U2FeatureType type = U2FeatureTypes::Invalid;
     QString text;
-    QColor color;
-    bool showOnaminoFrame;
-    QString desc;
     QStringList namingQuals;
 };
 
@@ -140,14 +136,11 @@ public:
     static QMutex allKeys_mutex;
     static const QVector<GBFeatureKeyInfo> &allKeys();
 
-    static QMutex getKeyGroups_mutex;
     static const GBFeatureKeyInfo &getKeyInfo(GBFeatureKey key) {
         return allKeys().at(key);
     }
 
     static QMutex getKey_mutex;
-    static const QMultiMap<QString, GBFeatureKey> &getKeyGroups();
-
     static GBFeatureKey getKey(const QString &text);
     static GBFeatureKey getKey(U2FeatureType featureType);
 
@@ -155,8 +148,6 @@ public:
     static bool isFeatureHasNoValue(const QString &featureName);
 
     static const QByteArray QUALIFIER_AMINO_STRAND;
-    static const QByteArray QUALIFIER_AMINO_STRAND_YES;
-    static const QByteArray QUALIFIER_AMINO_STRAND_NO;
 
     static const QByteArray QUALIFIER_NAME;
     static const QByteArray QUALIFIER_GROUP;

--- a/src/corelibs/U2Formats/src/DocumentFormatUtils.cpp
+++ b/src/corelibs/U2Formats/src/DocumentFormatUtils.cpp
@@ -29,18 +29,15 @@
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DNASequenceObject.h>
 #include <U2Core/GObjectRelationRoles.h>
-#include <U2Core/GObjectTypes.h>
 #include <U2Core/GenbankFeatures.h>
 #include <U2Core/L10n.h>
 #include <U2Core/MultipleSequenceAlignment.h>
 #include <U2Core/MultipleSequenceAlignmentObject.h>
 #include <U2Core/TextUtils.h>
-#include <U2Core/U2AlphabetUtils.h>
 #include <U2Core/U2DbiRegistry.h>
 #include <U2Core/U2ObjectDbi.h>
 #include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
-#include <U2Core/U2SequenceUtils.h>
 
 namespace U2 {
 
@@ -81,20 +78,6 @@ AnnotationTableObject *DocumentFormatUtils::addAnnotationsForMergedU2Sequence(co
     return ao;
 }
 
-class ExtComparator {
-public:
-    ExtComparator(const QString &_ext)
-        : ext(_ext) {
-    }
-
-    bool operator()(const DocumentFormat *f1, const DocumentFormat *f2) const {
-        int v1 = f1->getSupportedDocumentFileExtensions().contains(ext) ? 1 : 0;
-        int v2 = f2->getSupportedDocumentFileExtensions().contains(ext) ? 1 : 0;
-        return v2 < v1;  // reverse sort -> make higher vals on the top
-    }
-    QString ext;
-};
-
 QList<DocumentFormatId> DocumentFormatUtils::toIds(const QList<DocumentFormat *> &formats) {
     QList<DocumentFormatId> result;
     foreach (DocumentFormat *f, formats) {
@@ -106,16 +89,16 @@ QList<DocumentFormatId> DocumentFormatUtils::toIds(const QList<DocumentFormat *>
 QList<AnnotationSettings *> DocumentFormatUtils::predefinedSettings() {
     QList<AnnotationSettings *> predefined;
     foreach (GBFeatureKeyInfo fi, GBFeatureUtils::allKeys()) {
-        AnnotationSettings *as = new AnnotationSettings();
-        as->name = fi.text;
-        as->amino = fi.showOnaminoFrame;
-        as->color = fi.color;
-        as->visible = as->name != "source";
-        as->nameQuals = fi.namingQuals;
+        auto settings = new AnnotationSettings();
+        settings->name = fi.text;
+        settings->amino = U2FeatureTypes::isShowOnAminoFrame(fi.type);
+        settings->color = U2FeatureTypes::getColor(fi.type);
+        settings->visible = settings->name != "source";
+        settings->nameQuals = fi.namingQuals;
         if (!fi.namingQuals.isEmpty()) {
-            as->showNameQuals = true;
+            settings->showNameQuals = true;
         }
-        predefined.append(as);
+        predefined.append(settings);
     }
     AnnotationSettings *secStructAnnotationSettings = new AnnotationSettings(BioStruct3D::SecStructAnnotationTag, true, QColor(102, 255, 0), true);
     secStructAnnotationSettings->nameQuals.append(BioStruct3D::SecStructTypeQualifierName);

--- a/src/libs_3rdparty/samtools/CMakeLists.txt
+++ b/src/libs_3rdparty/samtools/CMakeLists.txt
@@ -19,7 +19,7 @@ file(GLOB TS_FILES transl/*.ts)
 
 qt5_add_translation(QM_FILES ${TS_FILES})
 
-# Supress original samtools warnings
+# Suppress original samtools warnings
 if (CMAKE_COMPILER_IS_GNUCC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
 endif (CMAKE_COMPILER_IS_GNUCC)

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/annotations/GTTestsCreateAnnotationWidget.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/annotations/GTTestsCreateAnnotationWidget.cpp
@@ -3199,27 +3199,27 @@ GUI_TEST_CLASS_DEFINITION(test_0043) {
 
     //    3. Ensure that description field is empty. Click "Create annotations" button.
     setAnnotationName(os, "test_0043_1");
-    GTLineEdit::setText(os, GTWidget::findExactWidget<QLineEdit *>(os, "leDescription"), "");
+    GTLineEdit::setText(os, GTWidget::findLineEdit(os, "leDescription"), "");
 
     GTUtilsOptionPanelSequenceView::clickGetAnnotation(os);
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
     //    Expected state: a new annotation appears, it hasn't qualifier "note".
-    GTUtilsAnnotationsTreeView::selectItems(os, QStringList() << "test_0043_1");
+    GTUtilsAnnotationsTreeView::selectItems(os, {"test_0043_1"});
     QTreeWidgetItem *descriptionItem = GTUtilsAnnotationsTreeView::findItem(os, "note", GTGlobals::FindOptions(false));
     CHECK_SET_ERR(descriptionItem == nullptr, "There is an unexpected note qualifier");
 
     //    4. Set any description. Click "Create annotations" button.
     setAnnotationName(os, "test_0043_2");
-    GTLineEdit::setText(os, GTWidget::findExactWidget<QLineEdit *>(os, "leDescription"), "test_0043_2 description");
+    GTLineEdit::setText(os, GTWidget::findLineEdit(os, "leDescription"), "test_0043_2 description");
 
     GTUtilsOptionPanelSequenceView::clickGetAnnotation(os);
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
     //    Expected state: a new annotation appears, it has a qualifier "note" with description.
-    GTUtilsAnnotationsTreeView::selectItems(os, QStringList() << "test_0043_2");
-    const QString description = GTUtilsAnnotationsTreeView::getQualifierValue(os, "note", "test_0043_2");
-    CHECK_SET_ERR("test_0043_2 description" == description,
+    GTUtilsAnnotationsTreeView::selectItems(os, {"test_0043_2"});
+    QString description = GTUtilsAnnotationsTreeView::getQualifierValue(os, "note", "test_0043_2");
+    CHECK_SET_ERR(description == "test_0043_2 description",
                   QString("An unexpected annotation description: expect '%1', got '%2'")
                       .arg("test_0043_2 description")
                       .arg(description));

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/sequence_view/GTTestsSequenceView.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/sequence_view/GTTestsSequenceView.cpp
@@ -1328,7 +1328,7 @@ GUI_TEST_CLASS_DEFINITION(test_0042) {
 
 GUI_TEST_CLASS_DEFINITION(test_0043) {
     //    Open murine.gb
-    GTFileDialog::openFile(os, dataDir + "samples/Genbank/", "murine.gb");
+    GTFileDialog::openFile(os, dataDir + "samples/Genbank/murine.gb");
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
     //    move mouse to annotation on det view
@@ -1338,11 +1338,11 @@ GUI_TEST_CLASS_DEFINITION(test_0043) {
     QString expected = "<table><tr><td bgcolor=#ffff99 bordercolor=black width=15></td><td><big>misc_feature</big></td></tr><tr><td></td><td><b>Location"
                        "</b> = 2..590</td></tr><tr><td/><td><nobr><b>note</b> = 5' terminal repeat</nobr><br><nobr><b>Sequence</b> = AATGAAAGACCCCACCCGTAGGTGGCAAGCTAGCTTAAGT"
                        " ...</nobr><br><nobr><b>Translation</b> = NERPHP*VAS*LK ...</nobr></td></tr></table>";
-    CHECK_SET_ERR(tooltip == expected, "Unexpected toolip: " + tooltip)
+    CHECK_SET_ERR(tooltip == expected, "Unexpected tooltip: " + tooltip)
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0044) {
-    // Overview weel event
+    // Overview wheel event
     GTFileDialog::openFile(os, dataDir + "samples/FASTA/", "human_T1.fa");
     GTUtilsTaskTreeView::waitTaskFinished(os);
 


### PR DESCRIPTION
…ture to U2FeatureType

This is a next minor step in https://ugene.dev/tracker/browse/UGENE-7513 epic.

The colors & text descriptions were moved out of the Genbank format

The next step is to show the description we always had in "Create annotation" dialog