### PR TITLE
UGENE-7410. Make all File Dialog filters use non-restrictive 'All files' variant.

### DIFF
--- a/src/corelibs/U2Core/U2Core.pro
+++ b/src/corelibs/U2Core/U2Core.pro
@@ -228,6 +228,7 @@ HEADERS += src/cmdline/CMDLineCoreOptions.h \
            src/util/DatatypeSerializeUtils.h \
            src/util/FileAndDirectoryUtils.h \
            src/util/FilesIterator.h \
+           src/util/FileFilters.h \
            src/util/FileStorageUtils.h \
            src/util/FormatUtils.h \
            src/util/Formatters.h \
@@ -462,6 +463,7 @@ SOURCES += src/cmdline/CMDLineCoreOptions.cpp \
            src/util/DatatypeSerializeUtils.cpp \
            src/util/FileAndDirectoryUtils.cpp \
            src/util/FilesIterator.cpp \
+           src/util/FileFilters.cpp \
            src/util/FileStorageUtils.cpp \
            src/util/FormatUtils.cpp \
            src/util/Formatters.cpp \

--- a/src/corelibs/U2Core/src/util/FileFilters.cpp
+++ b/src/corelibs/U2Core/src/util/FileFilters.cpp
@@ -1,0 +1,144 @@
+/**
+ * UGENE - Integrated Bioinformatics Tools.
+ * Copyright (C) 2008-2022 UniPro <ugene@unipro.ru>
+ * http://ugene.net
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#include "FileFilters.h"
+
+#include <U2Core/AppContext.h>
+#include <U2Core/BaseDocumentFormats.h>
+#include <U2Core/DocumentImport.h>
+#include <U2Core/DocumentModel.h>
+#include <U2Core/U2SafePoints.h>
+
+namespace U2 {
+
+/** Separates individual named filters in filters list. */
+static const QString FILTER_SEPARATOR = ";;";
+
+QString FileFilters::createAllFilesFilter() {
+    return QObject::tr("All files") + " ( * )";
+}
+
+QString FileFilters::createSingleFileFilter(const QString &name, const QStringList &extensions, bool addGzipVariant) {
+    QString filters;
+    for (const QString &extension : qAsConst(extensions)) {
+        filters += " *." + extension;
+    }
+    if (addGzipVariant) {
+        for (const QString &extension : qAsConst(extensions)) {
+            filters += " *." + extension + ".gz";
+        }
+    }
+    return name + " (" + filters + ")";
+}
+
+QString FileFilters::createSingleFileFilter(const DocumentFormat *documentFormat) {
+    SAFE_POINT(documentFormat != nullptr, "Document format is null", "");
+    const QString &name = documentFormat->getFormatName();
+    QStringList extensions = documentFormat->getSupportedDocumentFileExtensions();
+    SAFE_POINT(!extensions.isEmpty(), "Document format has empty extensions list", "");
+    bool isGzipSupported = !documentFormat->getFlags().testFlag(DocumentFormatFlag_NoPack);
+    return createSingleFileFilter(name, extensions, isGzipSupported);
+}
+
+QString FileFilters::createSingleFileFilterByDocumentFormatId(const QString &documentFormatId) {
+    DocumentFormat *documentFormat = AppContext::getDocumentFormatRegistry()->getFormatById(documentFormatId);
+    SAFE_POINT(documentFormat != nullptr, "Document format not found: " + documentFormatId, "");
+    return createSingleFileFilter(documentFormat);
+}
+
+QString FileFilters::createFileFilter(const QString &name, const QStringList &extensions, bool useGzipVariant) {
+    return createSingleFileFilter(name, extensions, useGzipVariant) + FILTER_SEPARATOR + createAllFilesFilter();
+}
+
+QString FileFilters::createFileFilter(const QMap<QString, QStringList> &formatExtensionsByName, bool addGzipVariant) {
+    QStringList filters;
+    QList<QString> names = formatExtensionsByName.keys();
+    for (const QString &name : qAsConst(names)) {
+        filters << createSingleFileFilter(name, formatExtensionsByName[name], addGzipVariant);
+    }
+
+    filters << createAllFilesFilter();
+    return filters.join(FILTER_SEPARATOR);
+}
+
+QString FileFilters::createFileFilter(const QString &name, const QStringList &extensions) {
+    return createSingleFileFilter(name, extensions, false) + FILTER_SEPARATOR + createAllFilesFilter();
+}
+
+QString FileFilters::createFileFilterByDocumentFormatId(const DocumentFormatId &documentFormatId) {
+    DocumentFormat *documentFormat = AppContext::getDocumentFormatRegistry()->getFormatById(documentFormatId);
+    SAFE_POINT(documentFormat != nullptr, "Document format not found: " + documentFormatId, createAllFilesFilter());
+    return createSingleFileFilter(documentFormat) + FILTER_SEPARATOR + createAllFilesFilter();
+}
+
+QString FileFilters::createAllSupportedFormatsFileFilter(const QMap<QString, QStringList> &extraFormats) {
+    DocumentFormatRegistry *formatRegistry = AppContext::getDocumentFormatRegistry();
+    QList<DocumentFormatId> formatIds = formatRegistry->getRegisteredFormats();
+    QStringList filters;
+    for (const DocumentFormatId &id : qAsConst(formatIds)) {
+        if (id == BaseDocumentFormats::DATABASE_CONNECTION) {
+            continue;
+        }
+        DocumentFormat *documentFormat = formatRegistry->getFormatById(id);
+        filters << createSingleFileFilter(documentFormat);
+    }
+    QList<DocumentImporter *> importers = formatRegistry->getImportSupport()->getImporters();
+    for (DocumentImporter *importer : qAsConst(importers)) {
+        QStringList extensions = importer->getSupportedFileExtensions();
+        filters << createSingleFileFilter(importer->getImporterName(), extensions, false);
+    }
+    QStringList extraFormatFilterNames = extraFormats.keys();
+    for (const QString &name : qAsConst(extraFormatFilterNames)) {
+        filters << createSingleFileFilter(name, extraFormats.value(name), false);
+    }
+    filters.sort();
+    filters.prepend(createAllFilesFilter());
+    return filters.join(FILTER_SEPARATOR);
+}
+
+QString FileFilters::createFileFilter(const DocumentFormatConstraints &constraints) {
+    DocumentFormatRegistry *formatRegistry = AppContext::getDocumentFormatRegistry();
+    QStringList filters;
+    QList<DocumentFormatId> formatIds = AppContext::getDocumentFormatRegistry()->getRegisteredFormats();
+    for (const DocumentFormatId &formatId : qAsConst(formatIds)) {
+        if (formatId == BaseDocumentFormats::DATABASE_CONNECTION) {
+            continue;
+        }
+        DocumentFormat *documentFormat = formatRegistry->getFormatById(formatId);
+        if (documentFormat->checkConstraints(constraints)) {
+            filters << createSingleFileFilter(documentFormat);
+        }
+    }
+    filters.sort();
+    filters.prepend(createAllFilesFilter());
+    return filters.join(FILTER_SEPARATOR);
+}
+
+QString FileFilters::createFileFilterByObjectTypes(const QList<GObjectType> &objectTypes, bool useWriteOnlyFormats) {
+    DocumentFormatConstraints constraints;
+    if (useWriteOnlyFormats) {
+        constraints.flagsToSupport.setFlag(DocumentFormatFlag_SupportWriting, true);
+    }
+    constraints.supportedObjectTypes += objectTypes.toSet();
+    return createFileFilter(constraints);
+}
+
+}  // namespace U2

--- a/src/corelibs/U2Core/src/util/FileFilters.h
+++ b/src/corelibs/U2Core/src/util/FileFilters.h
@@ -1,0 +1,76 @@
+/**
+ * UGENE - Integrated Bioinformatics Tools.
+ * Copyright (C) 2008-2022 UniPro <ugene@unipro.ru>
+ * http://ugene.net
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#ifndef _U2_FILE_FILTERS_H_
+#define _U2_FILE_FILTERS_H_
+
+#include <QStringList>
+
+#include <U2Core/global.h>
+
+namespace U2 {
+
+class DocumentFormatConstraints;
+class DocumentFormat;
+
+/**
+ * Set of builders of file filters in FileDialog way.
+ * Placed in U2Core but not U2Gui because there are some dependencies in U2Lang package.
+ */
+class U2CORE_EXPORT FileFilters {
+public:
+    /** Returns "All files" filter line. */
+    static QString createAllFilesFilter();
+
+    /** Creates a single filter. No 'All files' included. */
+    static QString createSingleFileFilter(const QString &name, const QStringList &extensions, bool addGzipVariant);
+
+    /** Creates a single filter with all document extensions. No 'All files' included. */
+    static QString createSingleFileFilter(const DocumentFormat *documentFormat);
+
+    /** Creates a single filter with all document extensions. No 'All files' included. */
+    static QString createSingleFileFilterByDocumentFormatId(const QString &documentFormatId);
+
+    /** Returns filters string with the given name and extension. 'All files' filter. */
+    static QString createFileFilter(const QString &name, const QStringList &extensions, bool useGzipVariant);
+
+    /** Returns filters string with all formats listed in 'formatExtensionsByName' plus 'All files' filter. */
+    static QString createFileFilter(const QMap<QString, QStringList> &formatExtensionsByName, bool addGzipVariant);
+
+    /** Returns a filter with the given name and file extensions plus 'All files' filter. */
+    static QString createFileFilter(const QString &name, const QStringList &extensions);
+
+    /** Returns a filter with all document format extensions plus 'All files' filter. */
+    static QString createFileFilterByDocumentFormatId(const DocumentFormatId &documentFormatId);
+
+    /** Returns a filter with all document formats supported by UGENE plus 'All files' filter. */
+    static QString createAllSupportedFormatsFileFilter(const QMap<QString, QStringList>& extraFilters = {});
+
+    /** Returns a filter with all document formats accepted by the given constraints plus 'All files' filter. */
+    static QString createFileFilter(const DocumentFormatConstraints &constraints);
+
+    /** Returns a filter with all document formats what support writing of the given object types plus 'All files' filter. */
+    static QString createFileFilterByObjectTypes(const QList<GObjectType> &objectTypes, bool useWriteOnlyFormats = false);
+};
+
+}  // namespace U2
+
+#endif  // _U2_FILE_FILTERS_H_

--- a/src/corelibs/U2Core/src/util/FormatUtils.h
+++ b/src/corelibs/U2Core/src/util/FormatUtils.h
@@ -22,8 +22,6 @@
 #ifndef _U2_FORMAT_UTILS_H_
 #define _U2_FORMAT_UTILS_H_
 
-#include <QStringList>
-
 #include <U2Core/global.h>
 
 namespace U2 {
@@ -42,14 +40,6 @@ public:
     // This is English version of this function, required by EMBL and Genbank
     // for correct date formatting
     static QString getShortMonthName(int num);
-
-    static QString prepareFileFilter(const QMap<QString, QStringList> &formatNamesWithExtensions, bool allowAnyFiles = true, const QStringList &extraExtensions = QStringList(".gz"));
-    static QString prepareFileFilter(const QString &name, const QStringList &exts, bool any = true, const QStringList &extraExts = QStringList(".gz"));
-    static QString prepareDocumentsFileFilter(const DocumentFormatId &fid, bool any, const QStringList &extra = QStringList(".gz"));
-    // returns filter for all formats supported. All-docs filter is returned first if any==true
-    static QString prepareDocumentsFileFilter(bool any, const QStringList &extraExts = QStringList(".gz"));
-    static QString prepareDocumentsFileFilter(const DocumentFormatConstraints &c, bool any);
-    static QString prepareDocumentsFileFilterByObjType(const GObjectType &t, bool any);
 };
 
 }  // namespace U2

--- a/src/corelibs/U2Designer/src/DelegateEditors.cpp
+++ b/src/corelibs/U2Designer/src/DelegateEditors.cpp
@@ -26,12 +26,10 @@
 #include <U2Core/AppContext.h>
 #include <U2Core/DocumentModel.h>
 #include <U2Core/L10n.h>
-#include <U2Core/Log.h>
 #include <U2Core/QObjectScopedPointer.h>
 #include <U2Core/SaveDocumentTask.h>
 #include <U2Core/U2SafePoints.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/ScriptEditorDialog.h>
 

--- a/src/corelibs/U2Designer/src/DesignerUtils.cpp
+++ b/src/corelibs/U2Designer/src/DesignerUtils.cpp
@@ -21,19 +21,16 @@
 
 #include "DesignerUtils.h"
 
-#include <U2Gui/DialogUtils.h>
+#include <U2Core/FileFilters.h>
 
 #include <U2Lang/WorkflowUtils.h>
 
-// TODO FIX translator
 namespace U2 {
 
-QString DesignerUtils::getSchemaFileFilter(bool any, bool addOldExt) {
-    QStringList exts(WorkflowUtils::WD_FILE_EXTENSIONS);
-    if (addOldExt) {
-        exts << WorkflowUtils::WD_XML_FORMAT_EXTENSION;
-    }
-    return DialogUtils::prepareFileFilter(WorkflowUtils::tr("UGENE workflow documents"), exts, any);
+QString DesignerUtils::getSchemaFileFilter() {
+    QStringList extensions(WorkflowUtils::WD_FILE_EXTENSIONS);
+    extensions << WorkflowUtils::WD_XML_FORMAT_EXTENSION;
+    return FileFilters::createFileFilter(WorkflowUtils::tr("UGENE workflow documents"), extensions);
 }
 
 }  // namespace U2

--- a/src/corelibs/U2Designer/src/DesignerUtils.h
+++ b/src/corelibs/U2Designer/src/DesignerUtils.h
@@ -27,7 +27,7 @@ namespace U2 {
 
 class U2DESIGNER_EXPORT DesignerUtils {
 public:
-    static QString getSchemaFileFilter(bool any, bool addOldExt = false);
+    static QString getSchemaFileFilter();
 };  // DesignerUtils
 
 }  // namespace U2

--- a/src/corelibs/U2Gui/src/util/AddNewDocumentDialogImpl.cpp
+++ b/src/corelibs/U2Gui/src/util/AddNewDocumentDialogImpl.cpp
@@ -32,7 +32,6 @@
 #include <U2Core/Settings.h>
 #include <U2Core/U2SafePoints.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/SaveDocumentController.h>

--- a/src/corelibs/U2Gui/src/util/CreateAnnotationWidgetController.cpp
+++ b/src/corelibs/U2Gui/src/util/CreateAnnotationWidgetController.cpp
@@ -56,13 +56,11 @@
 
 #include <U2Formats/GenbankLocationParser.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
 #include <U2Gui/MainWindow.h>
 #include <U2Gui/ProjectTreeController.h>
 #include <U2Gui/ProjectTreeItemSelectorDialog.h>
 #include <U2Gui/SaveDocumentController.h>
-#include <U2Gui/ShowHideSubgroupWidget.h>
 
 #include "CreateAnnotationFullWidget.h"
 #include "CreateAnnotationNormalWidget.h"

--- a/src/corelibs/U2Gui/src/util/CreateDocumentFromTextDialogController.h
+++ b/src/corelibs/U2Gui/src/util/CreateDocumentFromTextDialogController.h
@@ -27,8 +27,6 @@
 #include <U2Core/DocumentModel.h>
 #include <U2Core/global.h>
 
-#include <U2Gui/DialogUtils.h>
-
 #include "SeqPasterWidgetController.h"
 
 class Ui_CreateDocumentFromTextDialog;

--- a/src/corelibs/U2Gui/src/util/DialogUtils.cpp
+++ b/src/corelibs/U2Gui/src/util/DialogUtils.cpp
@@ -22,15 +22,11 @@
 #include "DialogUtils.h"
 
 #include <QCoreApplication>
-#include <QDir>
 #include <QMessageBox>
 #include <QWizard>
 
-#include <U2Core/AppContext.h>
-#include <U2Core/DocumentImport.h>
 #include <U2Core/DocumentModel.h>
 #include <U2Core/FormatUtils.h>
-#include <U2Core/Settings.h>
 #include <U2Core/Task.h>
 
 #include <U2Gui/LastUsedDirHelper.h>
@@ -38,40 +34,7 @@
 
 namespace U2 {
 
-void DialogUtils::showProjectIsLockedWarning(QWidget *p) {
-    QMessageBox::critical(p, tr("Error"), tr("Project is locked"), QMessageBox::Ok, QMessageBox::NoButton);
-}
-
-QString DialogUtils::prepareFileFilter(const QString &name, const QStringList &exts, bool any, const QStringList &extra) {
-    return FormatUtils::prepareFileFilter(name, exts, any, extra);
-}
-
-QString DialogUtils::prepareDocumentsFileFilter(const DocumentFormatId &fid, bool any, const QStringList &extra) {
-    return FormatUtils::prepareDocumentsFileFilter(fid, any, extra);
-}
-
-QString DialogUtils::prepareDocumentsFileFilter(bool any, const QStringList &extra) {
-    return FormatUtils::prepareDocumentsFileFilter(any, extra);
-}
-
-QString DialogUtils::prepareDocumentsFileFilter(const DocumentFormatConstraints &c, bool any) {
-    return FormatUtils::prepareDocumentsFileFilter(c, any);
-}
-
-QString DialogUtils::prepareDocumentsFileFilterByObjType(const GObjectType &t, bool any) {
-    return FormatUtils::prepareDocumentsFileFilterByObjType(t, any);
-}
-
-QString DialogUtils::prepareDocumentsFileFilterByObjTypes(const QList<GObjectType>& types, bool any) {
-    DocumentFormatConstraints c;
-    c.allowPartialTypeMapping = true;
-    for (const auto& t : types) {
-        c.supportedObjectTypes.insert(t);
-    }
-    return FormatUtils::prepareDocumentsFileFilter(c, any);
-}
-
-void DialogUtils::setWizardMinimumSize(QWizard *wizard, const QSize &minimumSize) {
+void WizardUtils::setWizardMinimumSize(QWizard *wizard, const QSize &minimumSize) {
     QSize bestSize = minimumSize;
     foreach (int pageId, wizard->pageIds()) {
         QWizardPage *page = wizard->page(pageId);

--- a/src/corelibs/U2Gui/src/util/DialogUtils.h
+++ b/src/corelibs/U2Gui/src/util/DialogUtils.h
@@ -35,30 +35,9 @@ class DocumentFormatConstraints;
 class Logger;
 class TaskStateInfo;
 
-class U2GUI_EXPORT DialogUtils : public QObject {
+class U2GUI_EXPORT WizardUtils : public QObject {
     Q_OBJECT
 public:
-    static void showProjectIsLockedWarning(QWidget *p = nullptr);
-
-    static QString prepareFileFilter(const QString &name, const QStringList &exts, bool any = true, const QStringList &extraExts = QStringList(".gz"));
-
-    static QString prepareDocumentsFileFilter(const DocumentFormatId &fid, bool any, const QStringList &extraExts = QStringList(".gz"));
-
-    // returns filter for all formats supported. All-docs filter is returned first if any==true
-    static QString prepareDocumentsFileFilter(bool any, const QStringList &extraExts = QStringList(".gz"));
-
-    static QString prepareDocumentsFileFilter(const DocumentFormatConstraints &c, bool any);
-
-    static QString prepareDocumentsFileFilterByObjType(const GObjectType &t, bool any);
-
-    /**
-     * Create a list, separated by ";;" of the supported formats.
-     * @types the list of types, which format should be supported.
-     * @any contain the "All files" filter if true.
-     * @return the ";;" separated list of filters.
-     */
-    static QString prepareDocumentsFileFilterByObjTypes(const QList<GObjectType>& types, bool any);
-
     static void setWizardMinimumSize(QWizard *wizard, const QSize &minimumSize = QSize());
 };
 

--- a/src/corelibs/U2Gui/src/util/EditSequenceDialogController.h
+++ b/src/corelibs/U2Gui/src/util/EditSequenceDialogController.h
@@ -28,7 +28,6 @@
 #include <U2Core/U1AnnotationUtils.h>
 #include <U2Core/U2Region.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/SeqPasterWidgetController.h>
 
 class Ui_EditSequenceDialog;

--- a/src/corelibs/U2Gui/src/util/ExportAnnotationsDialog.cpp
+++ b/src/corelibs/U2Gui/src/util/ExportAnnotationsDialog.cpp
@@ -27,9 +27,6 @@
 #include <U2Core/AppContext.h>
 #include <U2Core/BaseDocumentFormats.h>
 #include <U2Core/DocumentModel.h>
-#include <U2Core/FormatUtils.h>
-#include <U2Core/U2SafePoints.h>
-#include <U2Core/global.h>
 
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/SaveDocumentController.h>

--- a/src/corelibs/U2Gui/src/util/ExportDocumentDialogController.cpp
+++ b/src/corelibs/U2Gui/src/util/ExportDocumentDialogController.cpp
@@ -21,15 +21,12 @@
 
 #include "ExportDocumentDialogController.h"
 
-#include <QDir>
 #include <QPushButton>
 
 #include <U2Core/AppContext.h>
-#include <U2Core/DocumentUtils.h>
 #include <U2Core/GObject.h>
 #include <U2Core/GUrlUtils.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 
 #include "SaveDocumentController.h"

--- a/src/corelibs/U2Gui/src/util/RemovePartFromSequenceDialogController.cpp
+++ b/src/corelibs/U2Gui/src/util/RemovePartFromSequenceDialogController.cpp
@@ -23,21 +23,17 @@
 
 #include <QDir>
 #include <QMessageBox>
-#include <QPushButton>
 
 #include <U2Core/AnnotationData.h>
 #include <U2Core/AppContext.h>
 #include <U2Core/BaseDocumentFormats.h>
-#include <U2Core/DocumentModel.h>
 #include <U2Core/ModifySequenceObjectTask.h>
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Formats/DocumentFormatUtils.h>
 #include <U2Formats/GenbankLocationParser.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
-#include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/SaveDocumentController.h>
 #include <U2Gui/U2FileDialog.h>
 

--- a/src/corelibs/U2Gui/src/util/SaveDocumentController.h
+++ b/src/corelibs/U2Gui/src/util/SaveDocumentController.h
@@ -65,13 +65,15 @@ public:
         QString getFirstExtensionByName(const QString &formatName) const;
 
         QString getFormatNameById(const QString &id) const;
-        QString getFormatNameByExtension(const QString &ext) const;
+        QString getFormatNameByExtension(const QString &extension) const;
 
         QString getIdByName(const QString &name) const;
 
     private:
-        QMap<QString, QStringList> extensions;
-        QMap<QString, QString> names;
+        QMap<QString, QStringList> extensionsByFormatId;
+        QMap<QString, QString> formatIdByExtension;
+        QMap<QString, QString> nameByFormatId;
+        QMap<QString, QString> formatIdByName;
     };
 
     SaveDocumentController(const SaveDocumentControllerConfig &config,
@@ -84,7 +86,7 @@ public:
                            const SimpleFormatsInfo &formatsDesc,
                            QObject *parent);
 
-    void addFormat(const QString &id, const QString &name, const QStringList &extenstions);
+    void addFormat(const QString &id, const QString &name, const QStringList &extensions);
 
     void setPath(const QString &path, const QSet<QString> &excludeList = QSet<QString>());
     void setFormat(const QString &formatId);
@@ -121,7 +123,7 @@ private:
 
     SaveDocumentControllerConfig conf;
     SimpleFormatsInfo formatsInfo;
-    QString currentFormat;
+    QString currentFormatName;
     bool overwritingConfirmed;
 };
 

--- a/src/corelibs/U2Gui/src/util/ScriptEditorDialog.cpp
+++ b/src/corelibs/U2Gui/src/util/ScriptEditorDialog.cpp
@@ -25,10 +25,10 @@
 #include <QMessageBox>
 #include <QMouseEvent>
 
+#include <U2Core/FileFilters.h>
 #include <U2Core/L10n.h>
 #include <U2Core/ScriptEngine.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/U2FileDialog.h>
@@ -150,14 +150,14 @@ void ScriptEditorDialog::save(const QString &url) {
 }
 
 QString ScriptEditorDialog::getScriptsFileFilter() {
-    return DialogUtils::prepareFileFilter(tr("Script files"), QStringList("js"), true);
+    return FileFilters::createFileFilter(tr("Script files"), {"js"});
 }
 
 void ScriptEditorDialog::sl_checkSyntax() {
     QScriptEngine engine;
     QString header = scriptEdit->variablesText();
     QString scriptText = header + "\n" + scriptEdit->scriptText();
-    QScriptSyntaxCheckResult syntaxResult = engine.checkSyntax(scriptText);
+    QScriptSyntaxCheckResult syntaxResult = QScriptEngine::checkSyntax(scriptText);
     if (syntaxResult.state() != QScriptSyntaxCheckResult::Valid) {
         int line = syntaxResult.errorLineNumber();
         line -= header.split("\n").size();

--- a/src/corelibs/U2Lang/src/model/AttributeRelation.cpp
+++ b/src/corelibs/U2Lang/src/model/AttributeRelation.cpp
@@ -23,7 +23,7 @@
 
 #include <U2Core/AppContext.h>
 #include <U2Core/DocumentModel.h>
-#include <U2Core/FormatUtils.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GUrl.h>
 
 #include <U2Lang/ConfigurationEditor.h>
@@ -127,16 +127,14 @@ QVariant FileExtensionRelation::getAffectResult(const QVariant &influencingValue
 }
 
 void FileExtensionRelation::updateDelegateTags(const QVariant &influencingValue, DelegateTags *dependentTags) const {
-    QString newFormatId = influencingValue.toString();
-    DocumentFormat *newFormat = AppContext::getDocumentFormatRegistry()->getFormatById(newFormatId);
-    if (nullptr != dependentTags) {
-        dependentTags->set("format", newFormatId);
-        QString filter = newFormatId + " files (*." + newFormatId + ")";
-        if (nullptr != newFormat) {
-            filter = FormatUtils::prepareDocumentsFileFilter(newFormatId, true);
-        }
-        dependentTags->set("filter", filter);
-    }
+    CHECK(dependentTags != nullptr, );
+
+    QString formatId = influencingValue.toString();
+    dependentTags->set("format", formatId);
+
+    DocumentFormat *newFormat = AppContext::getDocumentFormatRegistry()->getFormatById(formatId);
+    QString filter = newFormat != nullptr ? FileFilters::createFileFilterByDocumentFormatId(formatId) : FileFilters::createAllFilesFilter();
+    dependentTags->set("filter", filter);
 }
 
 FileExtensionRelation *FileExtensionRelation::clone() const {

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyBrowser.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyBrowser.cpp
@@ -37,6 +37,7 @@
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DNASequenceObject.h>
 #include <U2Core/DocumentModel.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GObjectSelection.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/L10n.h>
@@ -56,7 +57,6 @@
 
 #include <U2Formats/ConvertAssemblyToSamTask.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/ExportImageDialog.h>
 #include <U2Gui/GUIUtils.h>
 #include <U2Gui/LastUsedDirHelper.h>
@@ -990,9 +990,9 @@ Task *createLoadReferenceTask(const QString &url) {
 }  // namespace
 
 QString AssemblyBrowser::chooseReferenceUrl() const {
-    const QString filter = DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::SEQUENCE, true);
+    QString filter = FileFilters::createFileFilterByObjectTypes({GObjectTypes::SEQUENCE});
     LastUsedDirHelper lod;
-    const QString url = U2FileDialog::getOpenFileName(ui, tr("Open file with a sequence"), lod.dir, filter);
+    QString url = U2FileDialog::getOpenFileName(ui, tr("Open file with a sequence"), lod.dir, filter);
     CHECK(!url.isEmpty(), "");
     lod.url = url;
     return url;

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyReadsArea.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyReadsArea.cpp
@@ -29,12 +29,10 @@
 #include <QPainter>
 #include <QResizeEvent>
 #include <QVBoxLayout>
-#include <QWheelEvent>
 
 #include <U2Core/BaseDocumentFormats.h>
 #include <U2Core/Counter.h>
 #include <U2Core/DocumentModel.h>
-#include <U2Core/FormatUtils.h>
 #include <U2Core/IOAdapter.h>
 #include <U2Core/IOAdapterUtils.h>
 #include <U2Core/L10n.h>
@@ -47,8 +45,6 @@
 #include <U2Core/U2AssemblyReadIterator.h>
 #include <U2Core/U2AssemblyUtils.h>
 #include <U2Core/U2SafePoints.h>
-
-#include <U2Gui/OpenViewTask.h>
 
 #include "AddReadsToDocumentTask.h"
 #include "AssemblyBrowser.h"

--- a/src/corelibs/U2View/src/ov_assembly/ExportCoverageDialog.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/ExportCoverageDialog.cpp
@@ -24,11 +24,9 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QMessageBox>
-#include <QPushButton>
 
 #include <U2Core/GUrlUtils.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/SaveDocumentController.h>

--- a/src/corelibs/U2View/src/ov_assembly/ExportReadsDialog.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/ExportReadsDialog.cpp
@@ -22,16 +22,13 @@
 #include "ExportReadsDialog.h"
 
 #include <QMessageBox>
-#include <QPushButton>
 
 #include <U2Core/AppContext.h>
 #include <U2Core/AppSettings.h>
-#include <U2Core/DocumentModel.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/U2SafePoints.h>
 #include <U2Core/UserApplicationsSettings.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/SaveDocumentController.h>

--- a/src/corelibs/U2View/src/ov_msa/CreateSubalignmentDialogController.cpp
+++ b/src/corelibs/U2View/src/ov_msa/CreateSubalignmentDialogController.cpp
@@ -31,7 +31,6 @@
 #include <U2Core/AppContext.h>
 #include <U2Core/BaseDocumentFormats.h>
 #include <U2Core/DocumentModel.h>
-#include <U2Core/DocumentUtils.h>
 #include <U2Core/FileAndDirectoryUtils.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/IOAdapter.h>
@@ -39,7 +38,6 @@
 
 #include <U2Formats/GenbankLocationParser.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/OpenViewTask.h>
 #include <U2Gui/SaveDocumentController.h>

--- a/src/corelibs/U2View/src/ov_msa/MSAEditor.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditor.cpp
@@ -35,7 +35,6 @@
 #include <U2Core/U2Mod.h>
 #include <U2Core/U2OpStatusUtils.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/ExportImageDialog.h>
 #include <U2Gui/GUIUtils.h>
 #include <U2Gui/GroupHeaderImageWidget.h>

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.cpp
@@ -37,6 +37,7 @@
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DNASequenceObject.h>
 #include <U2Core/DNATranslation.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/IOAdapter.h>
 #include <U2Core/MsaDbiUtils.h>
 #include <U2Core/MultipleSequenceAlignment.h>
@@ -56,7 +57,6 @@
 
 #include <U2Formats/FastaFormat.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/Notification.h>
@@ -611,7 +611,7 @@ void MSAEditorSequenceArea::sl_addSeqFromFile() {
     MultipleSequenceAlignmentObject *msaObject = getEditor()->getMaObject();
     CHECK(!msaObject->isStateLocked(), );
 
-    QString filter = DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::SEQUENCE, true);
+    QString filter = FileFilters::createFileFilterByObjectTypes({GObjectTypes::SEQUENCE});
 
     LastUsedDirHelper lod;
     QStringList urls = U2FileDialog::getOpenFileNames(this, tr("Open file with sequences"), lod.dir, filter);

--- a/src/corelibs/U2View/src/ov_msa/align_to_alignment/AlignSequencesToAlignmentSupport.cpp
+++ b/src/corelibs/U2View/src/ov_msa/align_to_alignment/AlignSequencesToAlignmentSupport.cpp
@@ -25,10 +25,10 @@
 #include <U2Algorithm/BaseAlignmentAlgorithmsIds.h>
 
 #include <U2Core/AppContext.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GObjectSelection.h>
 #include <U2Core/TaskWatchdog.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/ProjectView.h>
 #include <U2Gui/U2FileDialog.h>
@@ -164,7 +164,7 @@ void AlignSequencesToAlignmentAction::sl_activate() {
             AppContext::getTaskScheduler()->registerTopLevelTask(task);
         }
     } else {
-        QString filter = DialogUtils::prepareDocumentsFileFilterByObjTypes({GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, GObjectTypes::SEQUENCE}, true);
+        QString filter = FileFilters::createFileFilterByObjectTypes({GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, GObjectTypes::SEQUENCE});
         LastUsedDirHelper lod;
         QStringList urls = U2FileDialog::getOpenFileNames(nullptr, tr("Open file with sequences"), lod.dir, filter);
 

--- a/src/corelibs/U2View/src/ov_msa/export_consensus/MaExportConsensusWidget.cpp
+++ b/src/corelibs/U2View/src/ov_msa/export_consensus/MaExportConsensusWidget.cpp
@@ -27,8 +27,6 @@
 #include <U2Core/AppSettings.h>
 #include <U2Core/BaseDocumentFormats.h>
 #include <U2Core/Counter.h>
-#include <U2Core/DocumentModel.h>
-#include <U2Core/GObjectTypes.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/MultipleAlignmentObject.h>
 #include <U2Core/TaskWatchdog.h>
@@ -39,7 +37,6 @@
 
 #include <U2Formats/DocumentFormatUtils.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/SaveDocumentController.h>
 #include <U2Gui/ShowHideSubgroupWidget.h>
 #include <U2Gui/U2WidgetStateStorage.h>

--- a/src/corelibs/U2View/src/ov_msa/find_pattern/FindPatternMsaWidget.cpp
+++ b/src/corelibs/U2View/src/ov_msa/find_pattern/FindPatternMsaWidget.cpp
@@ -32,7 +32,6 @@
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DNATranslation.h>
 #include <U2Core/DocumentUtils.h>
-#include <U2Core/Log.h>
 #include <U2Core/ProjectModel.h>
 #include <U2Core/TaskWatchdog.h>
 #include <U2Core/TextUtils.h>
@@ -43,7 +42,6 @@
 
 #include <U2Formats/FastaFormat.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
 #include <U2Gui/ObjectViewModel.h>
 #include <U2Gui/ShowHideSubgroupWidget.h>

--- a/src/corelibs/U2View/src/ov_msa/move_to_object/MoveToObjectMaController.cpp
+++ b/src/corelibs/U2View/src/ov_msa/move_to_object/MoveToObjectMaController.cpp
@@ -27,6 +27,7 @@
 #include <U2Core/AppContext.h>
 #include <U2Core/Counter.h>
 #include <U2Core/DocumentModel.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GObject.h>
 #include <U2Core/GObjectUtils.h>
 #include <U2Core/L10n.h>
@@ -36,7 +37,6 @@
 
 #include <U2Formats/ExportTasks.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/OpenViewTask.h>
@@ -140,8 +140,9 @@ void MoveToObjectMaController::runMoveSelectedRowsToNewFileDialog() {
     LastUsedDirHelper lod;
     DocumentFormatConstraints formatConstraints;
     formatConstraints.supportedObjectTypes << GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT;
-    QString filter = DialogUtils::prepareDocumentsFileFilter(formatConstraints, false);
-    QString selectedFilter = DialogUtils::prepareDocumentsFileFilter(BaseDocumentFormats::CLUSTAL_ALN, false);
+    formatConstraints.flagsToSupport.setFlag(DocumentFormatFlag_SupportWriting, true);
+    QString filter = FileFilters::createFileFilter(formatConstraints);
+    QString selectedFilter = FileFilters::createSingleFileFilterByDocumentFormatId(BaseDocumentFormats::CLUSTAL_ALN);
     lod.url = U2FileDialog::getSaveFileName(ui, tr("Select a new file to move selected rows"), lod, filter, &selectedFilter);
     CHECK(!lod.url.isEmpty(), );
 
@@ -195,7 +196,7 @@ void RemoveRowsFromMaObjectTask::run() {
     CHECK_OP(stateInfo, );
 
     maObject->removeRowsById(rowIds);
-    // If not cleared explicitly another row is auto-selected and the result may be misinterpret like not all rows were moved.
+    // If not cleared explicitly another row is auto-selected and the result may be misinterpreted like not all rows were moved.
     maEditor->getSelectionController()->clearSelection();
 }
 

--- a/src/corelibs/U2View/src/ov_msa/phy_tree/MSAEditorTreeManager.cpp
+++ b/src/corelibs/U2View/src/ov_msa/phy_tree/MSAEditorTreeManager.cpp
@@ -34,6 +34,7 @@
 #include <U2Core/BaseDocumentFormats.h>
 #include <U2Core/DocumentModel.h>
 #include <U2Core/DocumentUtils.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GObjectRelationRoles.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/IOAdapterUtils.h>
@@ -46,7 +47,6 @@
 #include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/U2FileDialog.h>
 
@@ -301,7 +301,7 @@ void MSAEditorTreeManager::sl_openTreeTaskFinished(Task *task) {
 
 void MSAEditorTreeManager::openTreeFromFile() {
     LastUsedDirHelper h;
-    QString filter = DialogUtils::prepareDocumentsFileFilter(BaseDocumentFormats::NEWICK, false, QStringList());
+    QString filter = FileFilters::createFileFilterByObjectTypes({BaseDocumentFormats::NEWICK});
     QString file;
 #ifdef Q_OS_DARWIN
     if (qgetenv(ENV_GUI_TEST).toInt() == 1 && qgetenv(ENV_USE_NATIVE_DIALOGS).toInt() == 0) {

--- a/src/corelibs/U2View/src/ov_phyltree/TreeViewer.cpp
+++ b/src/corelibs/U2View/src/ov_phyltree/TreeViewer.cpp
@@ -48,7 +48,6 @@
 #include <U2Core/TaskSignalMapper.h>
 #include <U2Core/U2SafePoints.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/ExportImageDialog.h>
 #include <U2Gui/GUIUtils.h>
 #include <U2Gui/OPWidgetFactoryRegistry.h>

--- a/src/corelibs/U2View/src/ov_sequence/ADVSingleSequenceWidget.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/ADVSingleSequenceWidget.cpp
@@ -23,7 +23,6 @@
 
 #include <QApplication>
 #include <QDialog>
-#include <QMessageBox>
 #include <QToolButton>
 #include <QWidgetAction>
 
@@ -41,7 +40,6 @@
 #include <U2Core/Settings.h>
 #include <U2Core/U2SafePoints.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/ExportImageDialog.h>
 #include <U2Gui/GUIUtils.h>
 #include <U2Gui/OrderedToolbar.h>

--- a/src/corelibs/U2View/src/ov_sequence/find_pattern/FindPatternWidget.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/find_pattern/FindPatternWidget.cpp
@@ -37,6 +37,7 @@
 #include <U2Core/DNASequenceSelection.h>
 #include <U2Core/DNATranslation.h>
 #include <U2Core/DocumentUtils.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/Log.h>
 #include <U2Core/ProjectModel.h>
 #include <U2Core/TextUtils.h>
@@ -50,7 +51,6 @@
 #include <U2Formats/FastaFormat.h>
 
 #include <U2Gui/CreateAnnotationWidgetController.h>
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/ShowHideSubgroupWidget.h>
@@ -996,11 +996,8 @@ void FindPatternWidget::updateAnnotationsWidget() {
 void FindPatternWidget::sl_onFileSelectorClicked() {
     LastUsedDirHelper lod(FIND_PATTER_LAST_DIR);
 
-    QString filter = DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::SEQUENCE, true);
-    lod.url = U2FileDialog::getOpenFileName(dynamic_cast<QWidget *>(AppContext::getMainWindow()),
-                                            tr("Select file to open..."),
-                                            lod.dir,
-                                            filter);
+    QString filter = FileFilters::createFileFilterByObjectTypes({GObjectTypes::SEQUENCE});
+    lod.url = U2FileDialog::getOpenFileName(QApplication::activeWindow(), tr("Select file to open..."), lod.dir, filter);
     if (!lod.url.isEmpty())
         filePathLineEdit->setText(lod.url);
 }

--- a/src/corelibs/U2View/src/util_smith_waterman/SmithWatermanDialog.cpp
+++ b/src/corelibs/U2View/src/util_smith_waterman/SmithWatermanDialog.cpp
@@ -27,7 +27,6 @@
 #include <U2Algorithm/SmithWatermanReportCallback.h>
 
 #include <U2Core/AppContext.h>
-#include <U2Core/BaseDocumentFormats.h>
 #include <U2Core/DNASequenceObject.h>
 #include <U2Core/DNASequenceSelection.h>
 #include <U2Core/L10n.h>
@@ -40,7 +39,6 @@
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Gui/CreateAnnotationWidgetController.h>
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/U2FileDialog.h>
 

--- a/src/include/U2Core/FileFilters.h
+++ b/src/include/U2Core/FileFilters.h
@@ -1,0 +1,1 @@
+#include "../../corelibs/U2Core/src/util/FileFilters.h"

--- a/src/plugins/circular_view/src/CircularViewSplitter.cpp
+++ b/src/plugins/circular_view/src/CircularViewSplitter.cpp
@@ -25,23 +25,15 @@
 #include <QFileInfo>
 #include <QHBoxLayout>
 #include <QMessageBox>
-#include <QPainter>
-#include <QPixmap>
-#include <QPrinter>
 #include <QScrollArea>
 #include <QTreeWidget>
-#include <QVBoxLayout>
 
 #include <U2Core/DNASequenceObject.h>
-#include <U2Core/GObject.h>
-#include <U2Core/GObjectTypes.h>
 #include <U2Core/GUrlUtils.h>
-#include <U2Core/L10n.h>
 #include <U2Core/QObjectScopedPointer.h>
 #include <U2Core/Settings.h>
 #include <U2Core/U2SafePoints.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/ExportImageDialog.h>
 #include <U2Gui/OrderedToolbar.h>
 #include <U2Gui/WidgetWithLocalToolbar.h>

--- a/src/plugins/dbi_bam/src/ConvertToSQLiteDialog.cpp
+++ b/src/plugins/dbi_bam/src/ConvertToSQLiteDialog.cpp
@@ -30,14 +30,11 @@
 #include <U2Core/DocumentUtils.h>
 #include <U2Core/FileAndDirectoryUtils.h>
 #include <U2Core/FormatUtils.h>
-#include <U2Core/GUrlUtils.h>
 #include <U2Core/ProjectModel.h>
 #include <U2Core/QObjectScopedPointer.h>
-#include <U2Core/Task.h>
 #include <U2Core/Theme.h>
 #include <U2Core/U2SafePoints.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/ObjectViewModel.h>
 #include <U2Gui/SaveDocumentController.h>

--- a/src/plugins/dna_export/src/DNASequenceGenerator.cpp
+++ b/src/plugins/dna_export/src/DNASequenceGenerator.cpp
@@ -30,6 +30,7 @@
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DNASequenceObject.h>
 #include <U2Core/DocumentModel.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/IOAdapter.h>
 #include <U2Core/IOAdapterUtils.h>
 #include <U2Core/LoadDocumentTask.h>
@@ -43,7 +44,6 @@
 #include <U2Core/U2SequenceDbi.h>
 #include <U2Core/U2SequenceUtils.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/OpenViewTask.h>
 
 static const int MBYTE_TO_BYTE = 1048576;
@@ -53,9 +53,7 @@ namespace U2 {
 const QString DNASequenceGenerator::ID("dna_generator");
 
 QString DNASequenceGenerator::prepareReferenceFileFilter() {
-    QString filter = DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::SEQUENCE, true) +
-                     ";;" + DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, false);
-    return filter;
+    return FileFilters::createFileFilterByObjectTypes({GObjectTypes::SEQUENCE, GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT});
 }
 
 void DNASequenceGenerator::generateSequence(const QMap<char, qreal> &charFreqs,

--- a/src/plugins/dna_export/src/ExportAlignmentViewItems.cpp
+++ b/src/plugins/dna_export/src/ExportAlignmentViewItems.cpp
@@ -21,7 +21,6 @@
 
 #include "ExportAlignmentViewItems.h"
 
-#include <QDir>
 #include <QMainWindow>
 
 #include <U2Core/AppContext.h>
@@ -29,8 +28,6 @@
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DNATranslation.h>
 #include <U2Core/DocumentUtils.h>
-#include <U2Core/GObjectTypes.h>
-#include <U2Core/GObjectUtils.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/MultipleSequenceAlignmentObject.h>
 #include <U2Core/QObjectScopedPointer.h>
@@ -38,7 +35,6 @@
 
 #include <U2Formats/ExportTasks.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
 
 #include <U2View/MSAEditor.h>

--- a/src/plugins/dna_export/src/ExportBlastResultDialog.cpp
+++ b/src/plugins/dna_export/src/ExportBlastResultDialog.cpp
@@ -22,14 +22,11 @@
 #include "ExportBlastResultDialog.h"
 
 #include <QMessageBox>
-#include <QPushButton>
 
 #include <U2Core/AppContext.h>
 #include <U2Core/BaseDocumentFormats.h>
 #include <U2Core/L10n.h>
-#include <U2Core/Settings.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/SaveDocumentController.h>
 
@@ -63,7 +60,7 @@ void ExportBlastResultDialog::accept() {
     url = saveController->getSaveFileName();
     format = saveController->getFormatIdToSave();
     addToProjectFlag = addToProjectBox->isChecked();
-    qualiferId = nameIdBox->currentText();
+    qualifierId = nameIdBox->currentText();
     addRefFlag = addRefBox->isChecked();
     QDialog::accept();
 }
@@ -82,11 +79,6 @@ void ExportBlastResultDialog::initSaveController(const QString &defaultUrl) {
     formatConstraints.addFlagToSupport(DocumentFormatFlag_SupportWriting);
 
     saveController = new SaveDocumentController(config, formatConstraints, this);
-}
-
-void ExportBlastResultDialog::setOkButtonText(const QString &text) const {
-    QPushButton *okButton = buttonBox->button(QDialogButtonBox::Ok);
-    okButton->setText(text);
 }
 
 void ExportBlastResultDialog::setFileLabelText(const QString &text) const {

--- a/src/plugins/dna_export/src/ExportBlastResultDialog.h
+++ b/src/plugins/dna_export/src/ExportBlastResultDialog.h
@@ -22,11 +22,11 @@
 #ifndef _U2_EXPORT_BLAST_RESULT_DIALOG_H_
 #define _U2_EXPORT_BLAST_RESULT_DIALOG_H_
 
-#include <ui_ExportBlastResultDialog.h>
-
 #include <QDialog>
 
 #include <U2Core/global.h>
+
+#include <ui_ExportBlastResultDialog.h>
 
 namespace U2 {
 
@@ -37,17 +37,15 @@ class ExportBlastResultDialog : public QDialog, private Ui_ExportBlastResultDial
 public:
     ExportBlastResultDialog(QWidget *p, const QString &defaultUrl = QString());
 
-    void setOkButtonText(const QString &text) const;
     void setFileLabelText(const QString &text) const;
 
-    virtual void accept();
+    void accept() override;
 
 public:
     QString url;
     DocumentFormatId format;
-    QString qualiferId;
+    QString qualifierId;
     bool addToProjectFlag;
-    bool useGenbankHeader;
     bool addRefFlag;
 
 private:

--- a/src/plugins/dna_export/src/ExportMSA2MSADialog.cpp
+++ b/src/plugins/dna_export/src/ExportMSA2MSADialog.cpp
@@ -32,7 +32,6 @@
 #include <U2Core/Settings.h>
 #include <U2Core/U2SafePoints.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/SaveDocumentController.h>

--- a/src/plugins/dna_export/src/ExportMSA2SequencesDialog.cpp
+++ b/src/plugins/dna_export/src/ExportMSA2SequencesDialog.cpp
@@ -22,14 +22,12 @@
 #include "ExportMSA2SequencesDialog.h"
 
 #include <QMessageBox>
-#include <QPushButton>
 
 #include <U2Core/AppContext.h>
 #include <U2Core/BaseDocumentFormats.h>
 #include <U2Core/L10n.h>
 #include <U2Core/Settings.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/SaveDocumentController.h>
 

--- a/src/plugins/dna_export/src/ExportQualityScoresWorker.cpp
+++ b/src/plugins/dna_export/src/ExportQualityScoresWorker.cpp
@@ -22,13 +22,12 @@
 #include "ExportQualityScoresWorker.h"
 
 #include <U2Core/DNASequenceObject.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GUrl.h>
 #include <U2Core/Log.h>
 #include <U2Core/MultiTask.h>
 
 #include <U2Designer/DelegateEditors.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>
@@ -67,7 +66,7 @@ void ExportPhredQualityWorkerFactory::init() {
 
     QMap<QString, PropertyDelegate *> delegates;
     {
-        delegates[BaseAttributes::URL_OUT_ATTRIBUTE().getId()] = new URLDelegate(DialogUtils::prepareDocumentsFileFilter(true), QString(), false, false);
+        delegates[BaseAttributes::URL_OUT_ATTRIBUTE().getId()] = new URLDelegate(FileFilters::createAllSupportedFormatsFileFilter(), "", false, false);
     }
 
     Descriptor actorDesc(ACTOR_ID, ExportPhredQualityWorker::tr("Export PHRED Qualities"), ExportPhredQualityWorker::tr("Export corresponding PHRED quality scores from input sequences."));

--- a/src/plugins/dna_export/src/ExportSequenceViewItems.cpp
+++ b/src/plugins/dna_export/src/ExportSequenceViewItems.cpp
@@ -751,7 +751,7 @@ void ADVExportContext::sl_exportBlastResultToAlignment() {
     MultipleSequenceAlignment ma(MA_OBJECT_NAME);
     U2OpStatusImpl os;
 
-    prepareMAFromBlastAnnotations(ma, d->qualiferId, d->addRefFlag, os);
+    prepareMAFromBlastAnnotations(ma, d->qualifierId, d->addRefFlag, os);
 
     if (os.hasError()) {
         QMessageBox::critical(nullptr, L10N::errorTitle(), os.getError());

--- a/src/plugins/dna_export/src/ExportSequencesDialog.cpp
+++ b/src/plugins/dna_export/src/ExportSequencesDialog.cpp
@@ -34,7 +34,6 @@
 #include <U2Core/Settings.h>
 #include <U2Core/U2SafePoints.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/SaveDocumentController.h>

--- a/src/plugins/dna_export/src/ImportAnnotationsFromCSVDialog.cpp
+++ b/src/plugins/dna_export/src/ImportAnnotationsFromCSVDialog.cpp
@@ -23,11 +23,11 @@
 
 #include <QFileInfo>
 #include <QMessageBox>
-#include <QPushButton>
 
 #include <U2Core/Annotation.h>
 #include <U2Core/AppContext.h>
 #include <U2Core/BaseDocumentFormats.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/IOAdapter.h>
 #include <U2Core/IOAdapterUtils.h>
 #include <U2Core/L10n.h>
@@ -36,7 +36,6 @@
 #include <U2Core/TextUtils.h>
 #include <U2Core/U2SafePoints.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/SaveDocumentController.h>
@@ -344,7 +343,7 @@ void ImportAnnotationsFromCSVDialog::sl_prefixToSkipChanged(const QString &v) {
 void ImportAnnotationsFromCSVDialog::sl_readFileClicked() {
     // show the dialog
     LastUsedDirHelper lod("CSV");
-    QString filter = DialogUtils::prepareFileFilter(tr("CSV Files"), QStringList() << "csv", true, QStringList());
+    QString filter = FileFilters::createFileFilter(tr("CSV Files"), {"csv"});
     lod.url = U2FileDialog::getOpenFileName(this, tr("Select CSV file to read"), lod, filter);
     if (lod.url.isEmpty()) {
         return;
@@ -455,7 +454,7 @@ void ImportAnnotationsFromCSVDialog::preview(bool silent) {
     for (int row = 0; row < lines.size(); row++) {
         const QStringList &rowData = lines.at(row);
         for (int column = 0; column < rowData.size(); column++) {
-            QString token = rowData.at(column);
+            const QString &token = rowData.at(column);
             QTableWidgetItem *item = new QTableWidgetItem(token);
             item->setFlags(Qt::ItemIsEnabled);
             previewTable->setItem(row, column, item);

--- a/src/plugins/dna_export/src/ImportQualityScoresWorker.cpp
+++ b/src/plugins/dna_export/src/ImportQualityScoresWorker.cpp
@@ -23,14 +23,13 @@
 
 #include <U2Core/DNASequenceObject.h>
 #include <U2Core/FailTask.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GUrl.h>
 #include <U2Core/Log.h>
 #include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Designer/DelegateEditors.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>
@@ -78,7 +77,7 @@ void ImportPhredQualityWorkerFactory::init() {
 
     QMap<QString, PropertyDelegate *> delegates;
 
-    delegates[BaseAttributes::URL_IN_ATTRIBUTE().getId()] = new URLDelegate(DialogUtils::prepareDocumentsFileFilter(true), QString(), true, false, false);
+    delegates[BaseAttributes::URL_IN_ATTRIBUTE().getId()] = new URLDelegate(FileFilters::createAllSupportedFormatsFileFilter(), "", true, false, false);
 
     {
         QVariantMap m;

--- a/src/plugins/dotplot/src/DotPlotDialog.cpp
+++ b/src/plugins/dotplot/src/DotPlotDialog.cpp
@@ -27,14 +27,13 @@
 #include <U2Core/AppContext.h>
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DNASequenceObject.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GObjectUtils.h>
 #include <U2Core/ProjectModel.h>
 #include <U2Core/QObjectScopedPointer.h>
 #include <U2Core/U2SafePoints.h>
-#include <U2Core/global.h>
 
 #include <U2Gui/CreateAnnotationWidgetController.h>
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/U2FileDialog.h>
@@ -308,7 +307,7 @@ void DotPlotDialog::sl_invertedDefaultColorButton() {
 }
 
 void DotPlotDialog::sl_loadSequenceButton() {
-    QString filter = DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::SEQUENCE, true);
+    QString filter = FileFilters::createFileFilterByObjectTypes({GObjectTypes::SEQUENCE});
     LastUsedDirHelper lod("DotPlot file");
     lod.url = U2FileDialog::getOpenFileName(this, tr("Open file"), lod.dir, filter);
     if (!lod.url.isEmpty()) {

--- a/src/plugins/dotplot/src/DotPlotFilesDialog.cpp
+++ b/src/plugins/dotplot/src/DotPlotFilesDialog.cpp
@@ -22,14 +22,12 @@
 #include "DotPlotFilesDialog.h"
 
 #include <QMessageBox>
-#include <QPushButton>
 
 #include <U2Core/DocumentUtils.h>
-#include <U2Core/GObjectTypes.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/QObjectScopedPointer.h>
 #include <U2Core/U2SafePoints.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/U2FileDialog.h>
@@ -50,7 +48,7 @@ DotPlotFilesDialog::DotPlotFilesDialog(QWidget *parent)
     connect(mergeFirstCheckBox, SIGNAL(clicked()), SLOT(sl_mergeFirst()));
     connect(mergeSecondCheckBox, SIGNAL(clicked()), SLOT(sl_mergeSecond()));
 
-    filter = DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, true).append("\n").append(DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::SEQUENCE, false));
+    filter = FileFilters::createFileFilterByObjectTypes({GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, GObjectTypes::SEQUENCE});
 }
 
 void DotPlotFilesDialog::sl_oneSequence() {

--- a/src/plugins/dotplot/src/DotPlotWidget.cpp
+++ b/src/plugins/dotplot/src/DotPlotWidget.cpp
@@ -30,7 +30,6 @@
 #include <U2Algorithm/RepeatFinderTaskFactoryRegistry.h>
 
 #include <U2Core/AppContext.h>
-#include <U2Core/AppResources.h>
 #include <U2Core/Counter.h>
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DNASequenceObject.h>
@@ -44,17 +43,14 @@
 #include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/ExportImageDialog.h>
 #include <U2Gui/GUIUtils.h>
 #include <U2Gui/GraphUtils.h>
 #include <U2Gui/LastUsedDirHelper.h>
-#include <U2Gui/U2FileDialog.h>
 
 #include <U2View/ADVSequenceObjectContext.h>
 #include <U2View/ADVSingleSequenceWidget.h>
 #include <U2View/AnnotatedDNAView.h>
-#include <U2View/PanView.h>
 
 #include "DotPlotDialog.h"
 #include "DotPlotFilterDialog.h"

--- a/src/plugins/enzymes/src/CreateFragmentDialog.cpp
+++ b/src/plugins/enzymes/src/CreateFragmentDialog.cpp
@@ -21,9 +21,7 @@
 
 #include "CreateFragmentDialog.h"
 
-#include <QDir>
 #include <QMessageBox>
-#include <QPushButton>
 
 #include <U2Algorithm/EnzymeModel.h>
 
@@ -34,12 +32,10 @@
 #include <U2Core/GObjectRelationRoles.h>
 #include <U2Core/GObjectTypes.h>
 #include <U2Core/GObjectUtils.h>
-#include <U2Core/Settings.h>
 #include <U2Core/U1AnnotationUtils.h>
 #include <U2Core/U2AlphabetUtils.h>
 
 #include <U2Gui/CreateAnnotationWidgetController.h>
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 
 #include <U2View/ADVSequenceObjectContext.h>

--- a/src/plugins/enzymes/src/EnzymesIO.cpp
+++ b/src/plugins/enzymes/src/EnzymesIO.cpp
@@ -26,6 +26,7 @@
 #include <U2Core/AppContext.h>
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DocumentModel.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/IOAdapter.h>
 #include <U2Core/IOAdapterUtils.h>
 #include <U2Core/L10n.h>
@@ -34,12 +35,10 @@
 #include <U2Core/TextUtils.h>
 #include <U2Core/U2AlphabetUtils.h>
 
-#include <U2Gui/DialogUtils.h>
-
 namespace U2 {
 
 QString EnzymesIO::getFileDialogFilter() {
-    return DialogUtils::prepareFileFilter(tr("Bairoch format"), QStringList("bairoch"));
+    return FileFilters::createFileFilter(tr("Bairoch format"), {"bairoch"});
 }
 
 QList<SEnzymeData> EnzymesIO::readEnzymes(const QString &url, TaskStateInfo &ti) {

--- a/src/plugins/enzymes/src/EnzymesPlugin.cpp
+++ b/src/plugins/enzymes/src/EnzymesPlugin.cpp
@@ -21,20 +21,15 @@
 
 #include "EnzymesPlugin.h"
 
-#include <QDir>
 #include <QMenu>
 #include <QMessageBox>
 
 #include <U2Core/AnnotationSelection.h>
 #include <U2Core/AppContext.h>
-#include <U2Core/AutoAnnotationsSupport.h>
-#include <U2Core/DNAAlphabet.h>
 #include <U2Core/GAutoDeleteList.h>
 #include <U2Core/QObjectScopedPointer.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
-#include <U2Gui/MainWindow.h>
 #include <U2Gui/ToolsMenu.h>
 
 #include <U2Test/GTestFrameworkComponents.h>

--- a/src/plugins/enzymes/src/EnzymesQuery.cpp
+++ b/src/plugins/enzymes/src/EnzymesQuery.cpp
@@ -22,15 +22,10 @@
 #include "EnzymesQuery.h"
 
 #include <QCoreApplication>
-#include <QDir>
 #include <QInputDialog>
 
-#include <U2Core/AppContext.h>
-#include <U2Core/Log.h>
-#include <U2Core/Settings.h>
 #include <U2Core/TaskSignalMapper.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 
 #include <U2Lang/BaseTypes.h>

--- a/src/plugins/enzymes/src/FindEnzymesDialog.cpp
+++ b/src/plugins/enzymes/src/FindEnzymesDialog.cpp
@@ -38,7 +38,6 @@
 #include <U2Core/Settings.h>
 #include <U2Core/Timer.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
@@ -51,7 +50,7 @@
 #include "EnzymesIO.h"
 #include "FindEnzymesTask.h"
 
-// TODO: group by TYPE, ORGANIZM
+// TODO: group by TYPE, ORGANISM
 // TODO: check whole group (tristate mode)
 
 namespace U2 {
@@ -436,7 +435,7 @@ void EnzymesSelectorWidget::initSelection() {
 
 void EnzymesSelectorWidget::sl_loadSelectionFromFile() {
     LastUsedDirHelper dir;
-    dir.url = U2FileDialog::getOpenFileName(this, tr("Select enzymes selection"), dir.dir, DialogUtils::prepareFileFilter(tr("Selection files"), QStringList("*")));
+    dir.url = U2FileDialog::getOpenFileName(this, tr("Select enzymes selection"), dir.dir);
     if (!dir.url.isEmpty()) {
         QFile selectionFile(dir.url);
         if (!selectionFile.open(QIODevice::ReadOnly)) {

--- a/src/plugins/external_tool_support/src/ExternalToolSupportSettingsController.cpp
+++ b/src/plugins/external_tool_support/src/ExternalToolSupportSettingsController.cpp
@@ -27,13 +27,13 @@
 #include <U2Core/AppContext.h>
 #include <U2Core/AppSettings.h>
 #include <U2Core/CustomExternalTool.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/L10n.h>
 #include <U2Core/Settings.h>
 #include <U2Core/Theme.h>
 #include <U2Core/U2SafePoints.h>
 #include <U2Core/UserApplicationsSettings.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/ShowHideSubgroupWidget.h>
@@ -190,7 +190,7 @@ QTreeWidgetItem *ExternalToolSupportSettingsPageWidget::createToolkitItem(QTreeW
     toolkitItem->setIcon(0, icon);
     treeWidget->addTopLevelItem(toolkitItem);
 
-    //draw widget for path select button
+    // draw widget for path select button
     QWidget *widget = new QWidget(treeWidget);
     QToolButton *selectToolKitPathButton = new QToolButton(widget);
     selectToolKitPathButton->setVisible(true);
@@ -222,12 +222,12 @@ void ExternalToolSupportSettingsPageWidget::sl_onClickLink(const QUrl &url) {
 }
 
 void ExternalToolSupportSettingsPageWidget::sl_importCustomToolButtonClicked() {
-    //UGENE-6553 temporary removed
-    //QObjectScopedPointer<ImportExternalToolDialog> dialog = new ImportExternalToolDialog(this);
-    //dialog->exec();
+    // UGENE-6553 temporary removed
+    // QObjectScopedPointer<ImportExternalToolDialog> dialog = new ImportExternalToolDialog(this);
+    // dialog->exec();
 
     LastUsedDirHelper lod("import external tool");
-    const QString filter = DialogUtils::prepareFileFilter("UGENE external tool config file", {"xml"}, true, {});
+    QString filter = FileFilters::createFileFilter(tr("UGENE external tool config file"), {"xml"}, false);
     lod.url = U2FileDialog::getOpenFileName(this, tr("Select configuration file to import"), lod.dir, filter);
     if (!lod.url.isEmpty()) {
         AppContext::getTaskScheduler()->registerTopLevelTask(new ImportCustomToolsTask(QDir::toNativeSeparators(lod.url)));
@@ -607,7 +607,7 @@ void ExternalToolSupportSettingsPageWidget::sl_toolPathChanged() {
     twIntegratedTools->clearSelection();
     foreach (QTreeWidgetItem *item, listOfItems) {
         QWidget *itemWid = item->treeWidget()->itemWidget(item, 1);
-        if (par == itemWid) {    //may be no good method for check QTreeWidgetItem
+        if (par == itemWid) {  // may be no good method for check QTreeWidgetItem
             emit si_setLockState(true);
             QString toolId = item->data(0, Qt::ItemDataRole::UserRole).toString();
             if (path.isEmpty()) {
@@ -674,7 +674,7 @@ void ExternalToolSupportSettingsPageWidget::sl_itemSelectionChanged() {
         }
     }
 
-    //no description or tool custom description
+    // no description or tool custom description
     ExternalTool *tool = AppContext::getExternalToolRegistry()->getById(id);
     setDescription(tool);
 }
@@ -698,7 +698,7 @@ void ExternalToolSupportSettingsPageWidget::sl_onPathEditWidgetClick() {
     }
 }
 
-//looks in selected folder +1 level 1 subfolders
+// looks in selected folder +1 level 1 subfolders
 void ExternalToolSupportSettingsPageWidget::sl_onBrowseToolKitPath() {
     LastUsedDirHelper lod("toolkit path");
     QString dir;
@@ -821,7 +821,7 @@ void ExternalToolSupportSettingsPageWidget::sl_onBrowseToolPackPath() {
 }
 
 ////////////////////////////////////////
-//PathLineEdit
+// PathLineEdit
 void PathLineEdit::sl_onBrowse() {
     LastUsedDirHelper lod(type);
 
@@ -855,4 +855,4 @@ void PathLineEdit::focusInEvent(QFocusEvent * /*event*/) {
     emit si_focusIn();
 }
 
-}    // namespace U2
+}  // namespace U2

--- a/src/plugins/external_tool_support/src/blast/AlignToReferenceBlastDialog.cpp
+++ b/src/plugins/external_tool_support/src/blast/AlignToReferenceBlastDialog.cpp
@@ -32,6 +32,7 @@
 #include <U2Core/Counter.h>
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DocumentUtils.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/IOAdapterUtils.h>
 #include <U2Core/L10n.h>
@@ -42,7 +43,6 @@
 #include <U2Core/U2SafePoints.h>
 #include <U2Core/UserApplicationsSettings.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/SaveDocumentController.h>
@@ -334,7 +334,7 @@ void AlignToReferenceBlastDialog::accept() {
 
 void AlignToReferenceBlastDialog::sl_setReference() {
     LastUsedDirHelper lod;
-    QString filter = DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::SEQUENCE, true);
+    QString filter = FileFilters::createFileFilterByObjectTypes({GObjectTypes::SEQUENCE});
 
     lod.url = U2FileDialog::getOpenFileName(this, tr("Open Reference Sequence"), lod.dir, filter);
     if (lod.url.isEmpty()) {
@@ -345,7 +345,7 @@ void AlignToReferenceBlastDialog::sl_setReference() {
 
 void AlignToReferenceBlastDialog::sl_addRead() {
     LastUsedDirHelper lod;
-    QString filter = DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::SEQUENCE, true);
+    QString filter = FileFilters::createFileFilterByObjectTypes({GObjectTypes::SEQUENCE});
 
     QStringList readFiles = U2FileDialog::getOpenFileNames(this, tr("Select File(s) with Read(s)"), lod.dir, filter);
     CHECK(!readFiles.isEmpty(), );

--- a/src/plugins/external_tool_support/src/blast/AlignToReferenceBlastWorker.cpp
+++ b/src/plugins/external_tool_support/src/blast/AlignToReferenceBlastWorker.cpp
@@ -25,7 +25,7 @@
 #include <U2Core/BaseDocumentFormats.h>
 #include <U2Core/Counter.h>
 #include <U2Core/DNAAlphabet.h>
-#include <U2Core/FormatUtils.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/IOAdapterUtils.h>
 #include <U2Core/L10n.h>
@@ -116,7 +116,7 @@ void AlignToReferenceBlastWorkerFactory::init() {
     QMap<QString, PropertyDelegate *> delegates;
     {
         delegates[REF_ATTR_ID] = new URLDelegate("", "", false, false, false);
-        delegates[RESULT_URL_ATTR_ID] = new URLDelegate(FormatUtils::prepareDocumentsFileFilter(BaseDocumentFormats::UGENEDB, false, QStringList()), "", false, false, true, nullptr, BaseDocumentFormats::UGENEDB);
+        delegates[RESULT_URL_ATTR_ID] = new URLDelegate(FileFilters::createFileFilterByObjectTypes({BaseDocumentFormats::UGENEDB}, true), "", false, false, true, nullptr, BaseDocumentFormats::UGENEDB);
         QVariantMap m;
         m["minimum"] = 0;
         m["maximum"] = 100;

--- a/src/plugins/external_tool_support/src/blast/BlastDBCmdDialog.h
+++ b/src/plugins/external_tool_support/src/blast/BlastDBCmdDialog.h
@@ -24,8 +24,6 @@
 
 #include <QDialog>
 
-#include <U2Gui/DialogUtils.h>
-
 #include "BlastDBCmdTask.h"
 #include "BlastDBSelectorWidgetController.h"
 

--- a/src/plugins/external_tool_support/src/blast/BlastRunCommonDialog.h
+++ b/src/plugins/external_tool_support/src/blast/BlastRunCommonDialog.h
@@ -27,7 +27,6 @@
 #include <U2Core/DNASequenceObject.h>
 
 #include <U2Gui/CreateAnnotationWidgetController.h>
-#include <U2Gui/DialogUtils.h>
 
 #include "BlastDBSelectorWidgetController.h"
 #include "BlastTaskSettings.h"

--- a/src/plugins/external_tool_support/src/blast/BlastRunDialog.cpp
+++ b/src/plugins/external_tool_support/src/blast/BlastRunDialog.cpp
@@ -42,7 +42,6 @@
 #include <U2Core/U2OpStatusUtils.h>
 
 #include <U2Gui/CreateAnnotationWidgetController.h>
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/OpenViewTask.h>
 #include <U2Gui/RegionSelector.h>
 

--- a/src/plugins/external_tool_support/src/blast/MakeBlastDbDialog.h
+++ b/src/plugins/external_tool_support/src/blast/MakeBlastDbDialog.h
@@ -24,8 +24,6 @@
 
 #include <QDialog>
 
-#include <U2Gui/DialogUtils.h>
-
 #include "MakeBlastDbTask.h"
 
 #include <ui_MakeBlastDbDialog.h>

--- a/src/plugins/external_tool_support/src/clustalo/ClustalOSupport.cpp
+++ b/src/plugins/external_tool_support/src/clustalo/ClustalOSupport.cpp
@@ -27,6 +27,7 @@
 #include <U2Core/AppContext.h>
 #include <U2Core/AppSettings.h>
 #include <U2Core/DNAAlphabet.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/MultipleSequenceAlignmentObject.h>
 #include <U2Core/QObjectScopedPointer.h>
 #include <U2Core/U2OpStatusUtils.h>
@@ -179,9 +180,7 @@ void ClustalOSupportContext::sl_addAlignmentToAlignment() {
     MultipleSequenceAlignmentObject *msaObject = msaEditor->getMaObject();
 
     DocumentFormatConstraints c;
-    QString f1 = DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, false);
-    QString f2 = DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::SEQUENCE, true);
-    QString filter = f2 + "\n" + f1;
+    QString filter = FileFilters::createFileFilterByObjectTypes({GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, GObjectTypes::SEQUENCE});
 
     LastUsedDirHelper lod;
     lod.url = U2FileDialog::getOpenFileName(nullptr, tr("Select file with another alignment"), lod, filter);

--- a/src/plugins/external_tool_support/src/clustalo/ClustalOSupportRunDialog.cpp
+++ b/src/plugins/external_tool_support/src/clustalo/ClustalOSupportRunDialog.cpp
@@ -30,9 +30,9 @@
 #include <U2Core/AppSettings.h>
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DocumentUtils.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GUrlUtils.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/SaveDocumentController.h>
@@ -40,7 +40,7 @@
 
 namespace U2 {
 ////////////////////////////////////////
-//ClustalOSupportRunDialog
+// ClustalOSupportRunDialog
 ClustalOSupportRunDialog::ClustalOSupportRunDialog(const MultipleSequenceAlignment &_ma, ClustalOSupportTaskSettings &_settings, QWidget *_parent)
     : QDialog(_parent), ma(_ma->getCopy()), settings(_settings) {
     setupUi(this);
@@ -71,7 +71,7 @@ void ClustalOSupportRunDialog::accept() {
 }
 
 ////////////////////////////////////////
-//ClustalOWithExtFileSpecifySupportRunDialog
+// ClustalOWithExtFileSpecifySupportRunDialog
 ClustalOWithExtFileSpecifySupportRunDialog::ClustalOWithExtFileSpecifySupportRunDialog(ClustalOSupportTaskSettings &_settings, QWidget *_parent)
     : QDialog(_parent),
       settings(_settings),
@@ -91,7 +91,7 @@ ClustalOWithExtFileSpecifySupportRunDialog::ClustalOWithExtFileSpecifySupportRun
 }
 void ClustalOWithExtFileSpecifySupportRunDialog::sl_inputPathButtonClicked() {
     LastUsedDirHelper lod;
-    lod.url = U2FileDialog::getOpenFileName(this, tr("Open an alignment file"), lod.dir, DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, true));
+    lod.url = U2FileDialog::getOpenFileName(this, tr("Open an alignment file"), lod.dir, FileFilters::createFileFilterByObjectTypes({GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT}));
     if (lod.url.isEmpty()) {
         return;
     }
@@ -139,4 +139,4 @@ void ClustalOWithExtFileSpecifySupportRunDialog::accept() {
     }
 }
 
-}    // namespace U2
+}  // namespace U2

--- a/src/plugins/external_tool_support/src/clustalo/ClustalOSupportRunDialog.h
+++ b/src/plugins/external_tool_support/src/clustalo/ClustalOSupportRunDialog.h
@@ -22,13 +22,11 @@
 #ifndef _U2_CLUSTALO_SUPPORT_RUN_DIALOG_H
 #define _U2_CLUSTALO_SUPPORT_RUN_DIALOG_H
 
-#include <ui_ClustalOSupportRunDialog.h>
-
 #include <QDialog>
 
-#include <U2Gui/DialogUtils.h>
-
 #include "ClustalOSupportTask.h"
+
+#include <ui_ClustalOSupportRunDialog.h>
 
 namespace U2 {
 
@@ -63,5 +61,5 @@ private:
     SaveDocumentController *saveController;
 };
 
-}    // namespace U2
-#endif    // _U2_CLUSTALO_SUPPORT_RUN_DIALOG_H
+}  // namespace U2
+#endif  // _U2_CLUSTALO_SUPPORT_RUN_DIALOG_H

--- a/src/plugins/external_tool_support/src/clustalw/ClustalWSupportRunDialog.cpp
+++ b/src/plugins/external_tool_support/src/clustalw/ClustalWSupportRunDialog.cpp
@@ -27,9 +27,9 @@
 
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DocumentUtils.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GUrlUtils.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/SaveDocumentController.h>
@@ -37,7 +37,7 @@
 
 namespace U2 {
 ////////////////////////////////////////
-//ClustalWSupportRunDialog
+// ClustalWSupportRunDialog
 ClustalWSupportRunDialog::ClustalWSupportRunDialog(const MultipleSequenceAlignment &_ma, ClustalWSupportTaskSettings &_settings, QWidget *_parent)
     : QDialog(_parent), ma(_ma->getCopy()), settings(_settings) {
     setupUi(this);
@@ -110,7 +110,7 @@ void ClustalWSupportRunDialog::accept() {
 }
 
 ////////////////////////////////////////
-//ClustalWWithExtFileSpecifySupportRunDialog
+// ClustalWWithExtFileSpecifySupportRunDialog
 ClustalWWithExtFileSpecifySupportRunDialog::ClustalWWithExtFileSpecifySupportRunDialog(ClustalWSupportTaskSettings &_settings, QWidget *_parent)
     : QDialog(_parent),
       settings(_settings),
@@ -135,7 +135,7 @@ ClustalWWithExtFileSpecifySupportRunDialog::ClustalWWithExtFileSpecifySupportRun
 
 void ClustalWWithExtFileSpecifySupportRunDialog::sl_inputPathButtonClicked() {
     LastUsedDirHelper lod;
-    lod.url = U2FileDialog::getOpenFileName(this, tr("Open an alignment file"), lod.dir, DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, true));
+    lod.url = U2FileDialog::getOpenFileName(this, tr("Open an alignment file"), lod.dir, FileFilters::createFileFilterByObjectTypes({GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT}));
     if (lod.url.isEmpty()) {
         return;
     }
@@ -203,4 +203,4 @@ void ClustalWWithExtFileSpecifySupportRunDialog::accept() {
     }
 }
 
-}    // namespace U2
+}  // namespace U2

--- a/src/plugins/external_tool_support/src/clustalw/ClustalWSupportRunDialog.h
+++ b/src/plugins/external_tool_support/src/clustalw/ClustalWSupportRunDialog.h
@@ -22,13 +22,11 @@
 #ifndef _U2_CLUSTALW_SUPPORT_RUN_DIALOG_H
 #define _U2_CLUSTALW_SUPPORT_RUN_DIALOG_H
 
-#include <ui_ClustalWSupportRunDialog.h>
-
 #include <QDialog>
 
-#include <U2Gui/DialogUtils.h>
-
 #include "ClustalWSupportTask.h"
+
+#include <ui_ClustalWSupportRunDialog.h>
 
 namespace U2 {
 
@@ -65,5 +63,5 @@ private:
     SaveDocumentController *saveController;
 };
 
-}    // namespace U2
-#endif    // _U2_CLUSTALW_SUPPORT_RUN_DIALOG_H
+}  // namespace U2
+#endif  // _U2_CLUSTALW_SUPPORT_RUN_DIALOG_H

--- a/src/plugins/external_tool_support/src/cufflinks/CuffdiffWorker.cpp
+++ b/src/plugins/external_tool_support/src/cufflinks/CuffdiffWorker.cpp
@@ -24,13 +24,12 @@
 #include <U2Core/AnnotationTableObject.h>
 #include <U2Core/AppContext.h>
 #include <U2Core/AppSettings.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/L10n.h>
 #include <U2Core/QVariantUtils.h>
 #include <U2Core/UserApplicationsSettings.h>
 
 #include <U2Designer/DelegateEditors.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>
@@ -102,7 +101,7 @@ void CuffdiffWorkerFactory::init() {
                                                      " and the latter lets one see changes in relative promoter use within"
                                                      " a gene."));
 
-    {    // Define parameters of the element
+    {  // Define parameters of the element
         Descriptor outDir(OUT_DIR,
                           CuffdiffWorker::tr("Output folder"),
                           CuffdiffWorker::tr("The base name of output folder. It could be modified with a suffix."));
@@ -201,7 +200,7 @@ void CuffdiffWorkerFactory::init() {
         attributes << new Attribute(tmpDir, BaseTypes::STRING_TYPE(), true, QVariant(L10N::defaultStr()));
     }
 
-    {    // Define ports of the element
+    {  // Define ports of the element
         Descriptor assemblyDesc(BasePorts::IN_ASSEMBLY_PORT_ID(),
                                 CuffdiffWorker::tr("Assembly"),
                                 CuffdiffWorker::tr("RNA-Seq reads assemblies"));
@@ -263,7 +262,7 @@ void CuffdiffWorkerFactory::init() {
 
     delegates[OUT_DIR] = new URLDelegate("", "", false, true /*path*/);
     delegates[FRAG_BIAS_CORRECT] = new URLDelegate("", "", false, false, false);
-    delegates[MASK_FILE] = new URLDelegate(DialogUtils::prepareDocumentsFileFilter(true), "", false, false, false);
+    delegates[MASK_FILE] = new URLDelegate(FileFilters::createAllSupportedFormatsFileFilter(), "", false, false, false);
     delegates[EXT_TOOL_PATH] = new URLDelegate("", "executable", false, false, false);
     delegates[TMP_DIR_PATH] = new URLDelegate("", "TmpDir", false, true);
 
@@ -272,7 +271,7 @@ void CuffdiffWorkerFactory::init() {
     proto->setPrompter(new CuffdiffPrompter());
     proto->setPortValidator(BasePorts::IN_ASSEMBLY_PORT_ID(), new InputSlotValidator());
 
-    {    // external tools
+    {  // external tools
         proto->addExternalTool(CufflinksSupport::ET_CUFFDIFF_ID, EXT_TOOL_PATH);
     }
 
@@ -421,5 +420,5 @@ void CuffdiffWorker::takeAssembly() {
     assemblyUrls[sampleName] << data[BaseSlots::URL_SLOT().getId()].toString();
 }
 
-}    // namespace LocalWorkflow
-}    // namespace U2
+}  // namespace LocalWorkflow
+}  // namespace U2

--- a/src/plugins/external_tool_support/src/cufflinks/CufflinksWorker.cpp
+++ b/src/plugins/external_tool_support/src/cufflinks/CufflinksWorker.cpp
@@ -24,13 +24,12 @@
 #include <U2Core/AnnotationTableObject.h>
 #include <U2Core/AppContext.h>
 #include <U2Core/AppSettings.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/L10n.h>
 #include <U2Core/U2SafePoints.h>
 #include <U2Core/UserApplicationsSettings.h>
 
 #include <U2Designer/DelegateEditors.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>
@@ -253,10 +252,11 @@ void CufflinksWorkerFactory::init() {
     }
 
     delegates[OUT_DIR] = new URLDelegate("", "", false, true /*path*/);
-    delegates[REF_ANNOTATION] = new URLDelegate(DialogUtils::prepareDocumentsFileFilter(true), "", false, false, false);
-    delegates[RABT_ANNOTATION] = new URLDelegate(DialogUtils::prepareDocumentsFileFilter(true), "", false, false, false);
-    delegates[MASK_FILE] = new URLDelegate(DialogUtils::prepareDocumentsFileFilter(true), "", false, false, false);
-    delegates[FRAG_BIAS_CORRECT] = new URLDelegate(DialogUtils::prepareDocumentsFileFilter(true), "", false, false, false);
+    QString allFormatsFilter = FileFilters::createAllSupportedFormatsFileFilter();
+    delegates[REF_ANNOTATION] = new URLDelegate(allFormatsFilter, "", false, false, false);
+    delegates[RABT_ANNOTATION] = new URLDelegate(allFormatsFilter, "", false, false, false);
+    delegates[MASK_FILE] = new URLDelegate(allFormatsFilter, "", false, false, false);
+    delegates[FRAG_BIAS_CORRECT] = new URLDelegate(allFormatsFilter, "", false, false, false);
     delegates[EXT_TOOL_PATH] = new URLDelegate("", "executable", false, false, false);
     delegates[TMP_DIR_PATH] = new URLDelegate("", "TmpDir", false, true);
 
@@ -265,7 +265,7 @@ void CufflinksWorkerFactory::init() {
     proto->setPrompter(new CufflinksPrompter());
     proto->setPortValidator(BasePorts::IN_ASSEMBLY_PORT_ID(), new InputSlotValidator());
 
-    {    // external tools
+    {  // external tools
         proto->addExternalTool(CufflinksSupport::ET_CUFFLINKS_ID, EXT_TOOL_PATH);
     }
 
@@ -343,7 +343,7 @@ void CufflinksWorker::init() {
 }
 
 Task *CufflinksWorker::tick() {
-    if (false == settingsAreCorrect) {
+    if (!settingsAreCorrect) {
         return nullptr;
     }
 
@@ -395,5 +395,5 @@ void CufflinksWorker::sl_cufflinksTaskFinished() {
 void CufflinksWorker::cleanup() {
 }
 
-}    // namespace LocalWorkflow
-}    // namespace U2
+}  // namespace LocalWorkflow
+}  // namespace U2

--- a/src/plugins/external_tool_support/src/cufflinks/CuffmergeWorker.cpp
+++ b/src/plugins/external_tool_support/src/cufflinks/CuffmergeWorker.cpp
@@ -22,13 +22,11 @@
 #include "CuffmergeWorker.h"
 
 #include <U2Core/AnnotationTableObject.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/L10n.h>
-#include <U2Core/QVariantUtils.h>
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Designer/DelegateEditors.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>
@@ -140,8 +138,9 @@ void CuffmergeWorkerFactory::init() {
     QMap<QString, PropertyDelegate *> delegates;
     {
         delegates[OUT_DIR] = new URLDelegate("", "", false, true /*path*/);
-        delegates[REF_ANNOTATION] = new URLDelegate(DialogUtils::prepareDocumentsFileFilter(true), "", false, false, false);
-        delegates[REF_SEQ] = new URLDelegate(DialogUtils::prepareDocumentsFileFilter(true), "", false, false, false);
+        QString allFormatsFilter = FileFilters::createAllSupportedFormatsFileFilter();
+        delegates[REF_ANNOTATION] = new URLDelegate(allFormatsFilter, "", false, false, false);
+        delegates[REF_SEQ] = new URLDelegate(allFormatsFilter, "", false, false, false);
         QVariantMap vm;
         vm["minimum"] = 0.0;
         vm["maximum"] = 1.0;

--- a/src/plugins/external_tool_support/src/custom_tools/ImportExternalToolDialog.cpp
+++ b/src/plugins/external_tool_support/src/custom_tools/ImportExternalToolDialog.cpp
@@ -25,8 +25,8 @@
 #include <QPushButton>
 
 #include <U2Core/AppContext.h>
+#include <U2Core/FileFilters.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/U2FileDialog.h>
@@ -49,7 +49,7 @@ ImportExternalToolDialog::ImportExternalToolDialog(QWidget *_parent)
 
 void ImportExternalToolDialog::sl_browse() {
     LastUsedDirHelper lod("import external tool");
-    const QString filter = DialogUtils::prepareFileFilter("UGENE external tool config file", {"xml"}, true, {});
+    QString filter = FileFilters::createFileFilter(tr("UGENE external tool config file"), {"xml"}, false);
     lod.url = U2FileDialog::getOpenFileName(this, tr("Select configuration file to import"), lod.dir, filter);
     if (!lod.url.isEmpty()) {
         lePath->setText(QDir::toNativeSeparators(lod.url));
@@ -65,4 +65,4 @@ void ImportExternalToolDialog::accept() {
     QDialog::accept();
 }
 
-}    // namespace U2
+}  // namespace U2

--- a/src/plugins/external_tool_support/src/fastqc/FastqcWorker.cpp
+++ b/src/plugins/external_tool_support/src/fastqc/FastqcWorker.cpp
@@ -22,27 +22,17 @@
 #include "FastqcWorker.h"
 
 #include <U2Core/AppContext.h>
-#include <U2Core/BaseDocumentFormats.h>
 #include <U2Core/DataPathRegistry.h>
-#include <U2Core/DocumentImport.h>
-#include <U2Core/DocumentModel.h>
-#include <U2Core/DocumentUtils.h>
 #include <U2Core/FailTask.h>
 #include <U2Core/FileAndDirectoryUtils.h>
-#include <U2Core/GObject.h>
-#include <U2Core/GObjectTypes.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/IOAdapter.h>
-#include <U2Core/IOAdapterUtils.h>
 #include <U2Core/TaskSignalMapper.h>
 #include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Designer/DelegateEditors.h>
-
-#include <U2Formats/BAMUtils.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>
@@ -86,7 +76,7 @@ QString FastQCPrompter::composeRichDoc() {
 }
 
 ////////////////////////////////////////
-//FastQCFactory
+// FastQCFactory
 void FastQCFactory::init() {
     Descriptor desc(ACTOR_ID, FastQCWorker::tr("FastQC Quality Control"), FastQCWorker::tr("Builds quality control reports."));
 
@@ -148,7 +138,7 @@ void FastQCFactory::init() {
 
         DelegateTags outputUrlTags;
         outputUrlTags.set(DelegateTags::PLACEHOLDER_TEXT, FastQCWorker::tr("Auto"));
-        outputUrlTags.set(DelegateTags::FILTER, DialogUtils::prepareFileFilter("HTML", QStringList("html"), false, QStringList()));
+        outputUrlTags.set(DelegateTags::FILTER, FileFilters::createFileFilter("HTML", {"html"}, false));
         delegates[FastQCWorker::OUT_FILE] = new URLDelegate(outputUrlTags, "fastqc/output");
     }
 
@@ -165,7 +155,7 @@ void FastQCFactory::init() {
 }
 
 //////////////////////////////////////////////////////////////////////////
-//FastQCWorker
+// FastQCWorker
 FastQCWorker::FastQCWorker(Actor *a)
     : BaseWorker(a), inputUrlPort(nullptr) {
 }
@@ -232,5 +222,5 @@ QString FastQCWorker::getUrlAndSetupScriptValues() {
     return data[BaseSlots::URL_SLOT().getId()].toString();
 }
 
-}    // namespace LocalWorkflow
-}    // namespace U2
+}  // namespace LocalWorkflow
+}  // namespace U2

--- a/src/plugins/external_tool_support/src/hmmer/HmmerBuildDialog.cpp
+++ b/src/plugins/external_tool_support/src/hmmer/HmmerBuildDialog.cpp
@@ -25,9 +25,9 @@
 #include <QPushButton>
 
 #include <U2Core/AppContext.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/MultipleSequenceAlignment.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/SaveDocumentController.h>
@@ -58,7 +58,7 @@ void HmmerBuildDialog::setSignalsAndSlots() {
     connect(eclustESWRadioButton, SIGNAL(toggled(bool)), SLOT(sl_eclustESWRadioButtonChanged(bool)));
     connect(esetESWRadioButton, SIGNAL(toggled(bool)), SLOT(sl_esetESWRadioButtonChanged(bool)));
 
-    //temporary disabling of strange label/spinbox
+    // temporary disabling of strange label/spinbox
     fragThreshDoubleSpinBox->setVisible(false);
     fragthreshLabel->setVisible(false);
 }
@@ -70,7 +70,7 @@ void HmmerBuildDialog::initialize() {
     buttonBox->button(QDialogButtonBox::Cancel)->setText(tr("Cancel"));
 
     initSaveController();
-    setModelValues();    // build settings are default here
+    setModelValues();  // build settings are default here
     setSignalsAndSlots();
 }
 
@@ -122,7 +122,7 @@ void HmmerBuildDialog::setModelValues() {
 
 void HmmerBuildDialog::sl_maOpenFileButtonClicked() {
     LastUsedDirHelper helper(MA_FILES_DIR_ID);
-    helper.url = U2FileDialog::getOpenFileName(this, tr("Select multiple alignment file"), helper, DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, true));
+    helper.url = U2FileDialog::getOpenFileName(this, tr("Select multiple alignment file"), helper, FileFilters::createFileFilterByObjectTypes({GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT}));
     if (!helper.url.isEmpty()) {
         maLoadFromFileEdit->setText(helper.url);
     }
@@ -244,4 +244,4 @@ void HmmerBuildDialog::sl_esetESWRadioButtonChanged(bool checked) {
     esetESWDoubleSpinBox->setEnabled(checked);
 }
 
-}    // namespace U2
+}  // namespace U2

--- a/src/plugins/external_tool_support/src/hmmer/HmmerSearchDialog.cpp
+++ b/src/plugins/external_tool_support/src/hmmer/HmmerSearchDialog.cpp
@@ -28,12 +28,12 @@
 #include <U2Core/AppContext.h>
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DNASequenceObject.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GObjectTypes.h>
 #include <U2Core/L10n.h>
 #include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/U2FileDialog.h>
@@ -76,7 +76,7 @@ void HmmerSearchDialog::init(U2SequenceObject *seqObj) {
     useExplicitScoreTresholdButton->setChecked(true);
 
     model.sequence = QPointer<U2SequenceObject>(seqObj);
-    setModelValues();    // default settings here
+    setModelValues();  // default settings here
 
     // Annotations widget
     CreateAnnotationModel annModel;
@@ -111,8 +111,8 @@ void HmmerSearchDialog::init(U2SequenceObject *seqObj) {
 
 void HmmerSearchDialog::setModelValues() {
     domESpinBox->setValue(1);
-    scoreTresholdDoubleSpin->setValue(0);    // because default is OPTION_NOT_SET
-    domZDoubleSpinBox->setValue(0);    // because default is OPTION_NOT_SET
+    scoreTresholdDoubleSpin->setValue(0);  // because default is OPTION_NOT_SET
+    domZDoubleSpinBox->setValue(0);  // because default is OPTION_NOT_SET
     nobiasCheckBox->setChecked(model.searchSettings.noBiasFilter);
     nonull2CheckBox->setChecked(model.searchSettings.noNull2);
     maxCheckBox->setChecked(model.searchSettings.doMax);
@@ -246,7 +246,7 @@ void HmmerSearchDialog::sl_domESpinBoxChanged(int newVal) {
 
 void HmmerSearchDialog::sl_queryHmmFileToolButtonClicked() {
     LastUsedDirHelper helper(HMM_FILES_DIR_ID);
-    const QString fileFilter = DialogUtils::prepareFileFilter(tr("HMM profile"), QStringList() << "hmm", true, QStringList());
+    QString fileFilter = FileFilters::createFileFilter(tr("HMM profile"), {"hmm"}, false);
 
     helper.url = U2FileDialog::getOpenFileName(this, tr("Select query HMM profile"), helper, fileFilter);
     if (!helper.url.isEmpty()) {
@@ -260,4 +260,4 @@ void HmmerSearchDialog::sl_domZCheckBoxChanged(int state) {
     domZDoubleSpinBox->setEnabled(checked);
 }
 
-}    // namespace U2
+}  // namespace U2

--- a/src/plugins/external_tool_support/src/hmmer/PhmmerSearchDialog.cpp
+++ b/src/plugins/external_tool_support/src/hmmer/PhmmerSearchDialog.cpp
@@ -22,16 +22,15 @@
 #include <math.h>
 
 #include <QMessageBox>
-#include <QPushButton>
 
 #include <U2Core/AppContext.h>
 #include <U2Core/DNAAlphabet.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GObjectTypes.h>
 #include <U2Core/L10n.h>
 #include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/U2FileDialog.h>
@@ -70,7 +69,7 @@ void PhmmerSearchDialog::init(U2SequenceObject *seqObj) {
     U2OpStatusImpl os;
     model.dbSequence = seqObj;
     SAFE_POINT_EXT(!os.hasError(), QMessageBox::critical(QApplication::activeWindow(), L10N::errorTitle(), os.getError()), );
-    setModelValues();    // default model here
+    setModelValues();  // default model here
 
     // Annotations widget
     CreateAnnotationModel annModel;
@@ -119,7 +118,7 @@ void PhmmerSearchDialog::setModelValues() {
 
 void PhmmerSearchDialog::sl_queryToolButtonClicked() {
     LastUsedDirHelper helper(QUERY_FILES_DIR);
-    helper.url = U2FileDialog::getOpenFileName(this, tr("Select query sequence file"), helper, DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::SEQUENCE, true));
+    helper.url = U2FileDialog::getOpenFileName(this, tr("Select query sequence file"), helper, FileFilters::createFileFilterByObjectTypes({GObjectTypes::SEQUENCE}));
     if (!helper.url.isEmpty()) {
         queryLineEdit->setText(helper.url);
     }
@@ -233,4 +232,4 @@ void PhmmerSearchDialog::sl_domESpinBoxChanged(int newVal) {
     domESpinBox->setPrefix(prefix);
 }
 
-}    // namespace U2
+}  // namespace U2

--- a/src/plugins/external_tool_support/src/mafft/MAFFTSupportRunDialog.cpp
+++ b/src/plugins/external_tool_support/src/mafft/MAFFTSupportRunDialog.cpp
@@ -22,13 +22,10 @@
 #include "MAFFTSupportRunDialog.h"
 
 #include <QMessageBox>
-#include <QPushButton>
-#include <QToolButton>
 
 #include <U2Core/DocumentUtils.h>
-#include <U2Core/GUrlUtils.h>
+#include <U2Core/FileFilters.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/SaveDocumentController.h>
@@ -37,7 +34,7 @@
 namespace U2 {
 
 ////////////////////////////////////////
-//MAFFTSupportRunDialog
+// MAFFTSupportRunDialog
 MAFFTSupportRunDialog::MAFFTSupportRunDialog(MAFFTSupportTaskSettings &_settings, QWidget *_parent)
     : QDialog(_parent), settings(_settings) {
     setupUi(this);
@@ -63,7 +60,7 @@ void MAFFTSupportRunDialog::accept() {
 }
 
 ////////////////////////////////////////
-//MAFFTWithExtFileSpecifySupportRunDialog
+// MAFFTWithExtFileSpecifySupportRunDialog
 MAFFTWithExtFileSpecifySupportRunDialog::MAFFTWithExtFileSpecifySupportRunDialog(MAFFTSupportTaskSettings &_settings, QWidget *_parent)
     : QDialog(_parent),
       settings(_settings),
@@ -81,7 +78,7 @@ MAFFTWithExtFileSpecifySupportRunDialog::MAFFTWithExtFileSpecifySupportRunDialog
 
 void MAFFTWithExtFileSpecifySupportRunDialog::sl_inputPathButtonClicked() {
     LastUsedDirHelper lod;
-    lod.url = U2FileDialog::getOpenFileName(this, tr("Open an alignment file"), lod.dir, DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, true));
+    lod.url = U2FileDialog::getOpenFileName(this, tr("Open an alignment file"), lod.dir, FileFilters::createFileFilterByObjectTypes({GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT}));
     if (lod.url.isEmpty()) {
         return;
     }
@@ -123,4 +120,4 @@ void MAFFTWithExtFileSpecifySupportRunDialog::accept() {
     }
 }
 
-}    // namespace U2
+}  // namespace U2

--- a/src/plugins/external_tool_support/src/mafft/MAFFTSupportRunDialog.h
+++ b/src/plugins/external_tool_support/src/mafft/MAFFTSupportRunDialog.h
@@ -22,13 +22,11 @@
 #ifndef _U2_MAFFT_SUPPORT_RUN_DIALOG_H
 #define _U2_MAFFT_SUPPORT_RUN_DIALOG_H
 
-#include <ui_MAFFTSupportRunDialog.h>
-
 #include <QDialog>
 
-#include <U2Gui/DialogUtils.h>
-
 #include "MAFFTSupportTask.h"
+
+#include <ui_MAFFTSupportRunDialog.h>
 
 namespace U2 {
 
@@ -62,5 +60,5 @@ private:
     SaveDocumentController *saveController;
 };
 
-}    // namespace U2
-#endif    // _U2_MAFFT_SUPPORT_RUN_DIALOG_H
+}  // namespace U2
+#endif  // _U2_MAFFT_SUPPORT_RUN_DIALOG_H

--- a/src/plugins/external_tool_support/src/mrbayes/MrBayesDialogWidget.cpp
+++ b/src/plugins/external_tool_support/src/mrbayes/MrBayesDialogWidget.cpp
@@ -33,8 +33,6 @@
 #include <U2Core/U2SafePoints.h>
 #include <U2Core/UserApplicationsSettings.h>
 
-#include <U2Gui/DialogUtils.h>
-#include <U2Gui/GUIUtils.h>
 #include <U2Gui/MainWindow.h>
 
 #include <U2View/MSAEditor.h>
@@ -168,7 +166,7 @@ int MrBayesWidget::getRandomSeed() {
 }
 
 bool MrBayesWidget::checkSettings(QString &message, const CreatePhyTreeSettings &settings) {
-    //Check that MrBayes and temporary folder path defined
+    // Check that MrBayes and temporary folder path defined
     ExternalToolRegistry *reg = AppContext::getExternalToolRegistry();
     ExternalTool *mb = reg->getById(MrBayesSupport::ET_MRBAYES_ID);
     assert(mb);
@@ -222,7 +220,7 @@ QString MrBayesWidget::generateMrBayesSettingsScript() {
         } else if (currentNst == MrBayesModelTypes::GTR) {
             nst = 6;
         } else {
-            nst = 2;    //by default
+            nst = 2;  // by default
         }
 
         script = script.append("Nst=%1 ").arg(nst);
@@ -269,4 +267,4 @@ QString MrBayesWidget::generateMrBayesSettingsScript() {
     return script;
 }
 
-}    // namespace U2
+}  // namespace U2

--- a/src/plugins/external_tool_support/src/mrbayes/MrBayesSupport.cpp
+++ b/src/plugins/external_tool_support/src/mrbayes/MrBayesSupport.cpp
@@ -26,7 +26,6 @@
 #include <U2Core/AppContext.h>
 #include <U2Core/GAutoDeleteList.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
 
 #include <U2Test/GTest.h>
@@ -55,7 +54,7 @@ MrBayesSupport::MrBayesSupport()
     executableFileName = "mb";
 #endif
 
-    validationArguments << "";    // anything to get info and exit with error
+    validationArguments << "";  // anything to get info and exit with error
     validMessage = "MrBayes";
     description = tr("<i>MrBayes</i> is a program for the Bayesian estimation of phylogeny."
                      "Bayesian inference of phylogeny is based upon a quantity called the posterior "
@@ -67,13 +66,13 @@ MrBayesSupport::MrBayesSupport()
     versionRegExp = QRegExp("MrBayes v(\\d+\\.\\d+\\.\\d+)");
     toolKitName = "MrBayes";
 
-    //register the method
+    // register the method
     PhyTreeGeneratorRegistry *registry = AppContext::getPhyTreeGeneratorRegistry();
     registry->registerPhyTreeGenerator(new MrBayesAdapter(), MrBayesSupport::ET_MRBAYES_ALGORITHM_NAME_AND_KEY);
 }
 
 ////////////////////////////////////////
-//MrBayesAdapter
+// MrBayesAdapter
 
 Task *MrBayesAdapter::createCalculatePhyTreeTask(const MultipleSequenceAlignment &ma, const CreatePhyTreeSettings &s) {
     return new MrBayesSupportTask(ma, s);
@@ -84,7 +83,7 @@ CreatePhyTreeWidget *MrBayesAdapter::createPhyTreeSettingsWidget(const MultipleS
 }
 
 ////////////////////////////////////////
-//MrBayesModelTypes
+// MrBayesModelTypes
 
 QString MrBayesModelTypes::poisson("poisson");
 QString MrBayesModelTypes::jones("jones");
@@ -149,4 +148,4 @@ QStringList MrBayesVariationTypes::getVariationTypes() {
     return list;
 }
 
-}    // namespace U2
+}  // namespace U2

--- a/src/plugins/external_tool_support/src/phyml/PhyMLDialogWidget.cpp
+++ b/src/plugins/external_tool_support/src/phyml/PhyMLDialogWidget.cpp
@@ -26,11 +26,11 @@
 #include <U2Core/AppContext.h>
 #include <U2Core/BaseDocumentFormats.h>
 #include <U2Core/DNAAlphabet.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/QObjectScopedPointer.h>
 #include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/U2FileDialog.h>
 
@@ -239,7 +239,7 @@ void PhyMlWidget::sl_checkTreeImprovement(int newIndex) {
 
 void PhyMlWidget::sl_inputPathButtonClicked() {
     LastUsedDirHelper lod;
-    lod.url = U2FileDialog::getOpenFileName(this, tr("Open an alignment file"), lod.dir, DialogUtils::prepareDocumentsFileFilter(BaseDocumentFormats::NEWICK, false));
+    lod.url = U2FileDialog::getOpenFileName(this, tr("Open an alignment file"), lod.dir, FileFilters::createFileFilterByObjectTypes({BaseDocumentFormats::NEWICK}));
     if (lod.url.isEmpty()) {
         return;
     }

--- a/src/plugins/external_tool_support/src/spades/SpadesWorker.cpp
+++ b/src/plugins/external_tool_support/src/spades/SpadesWorker.cpp
@@ -25,19 +25,15 @@
 
 #include <U2Algorithm/GenomeAssemblyMultiTask.h>
 
-#include <U2Core/BaseDocumentFormats.h>
 #include <U2Core/FailTask.h>
 #include <U2Core/FileAndDirectoryUtils.h>
 #include <U2Core/GUrlUtils.h>
-#include <U2Core/QVariantUtils.h>
 #include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Designer/DelegateEditors.h>
 
 #include <U2Formats/GenbankLocationParser.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>
@@ -206,7 +202,7 @@ QVariantMap uniteUniquely(const QVariantMap &first, const QVariantMap &second) {
     return result;
 }
 
-}    // namespace
+}  // namespace
 
 Task *SpadesWorker::tick() {
     U2OpStatus2Log os;
@@ -403,7 +399,7 @@ GenomeAssemblyTaskSettings SpadesWorker::getSettings(U2OpStatus &os) {
 void SpadesWorkerFactory::init() {
     QList<PortDescriptor *> portDescs;
 
-    //in port
+    // in port
     QList<Descriptor> readDescriptors;
     foreach (const QString &readId, QStringList() << IN_PORT_PAIRED_ID_LIST << IN_PORT_ID_LIST) {
         const QString dataName = SpadesWorkerFactory::getPortNameById(readId);
@@ -444,7 +440,7 @@ void SpadesWorkerFactory::init() {
         portDescs << new PortDescriptor(readDescriptors[i], inTypeSet, true);
     }
 
-    //out port
+    // out port
     QMap<Descriptor, DataTypePtr> outTypeMap;
     Descriptor scaffoldOutDesc(SCAFFOLD_OUT_SLOT_ID,
                                SpadesWorker::tr("Scaffolds URL"),
@@ -607,5 +603,5 @@ QString SpadesPrompter::composeRichDoc() {
     return tr("Assemble de novo the input data into contigs and scaffolds.");
 }
 
-}    // namespace LocalWorkflow
-}    // namespace U2
+}  // namespace LocalWorkflow
+}  // namespace U2

--- a/src/plugins/external_tool_support/src/stringtie/StringTieWorker.cpp
+++ b/src/plugins/external_tool_support/src/stringtie/StringTieWorker.cpp
@@ -30,13 +30,12 @@
 #include <U2Core/ExternalToolRegistry.h>
 #include <U2Core/FailTask.h>
 #include <U2Core/FileAndDirectoryUtils.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Designer/DelegateEditors.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/AttributeRelation.h>
@@ -94,7 +93,7 @@ const QString COVERAGE_REF_OUTPUT("covered-transcripts-output");
 const QString COVERAGE_REF_OUTPUT_FILE("covered-transcripts-output-url");
 const QString BALLGOWN_OUTPUT("ballgown-output");
 const QString BALLGOWN_OUTPUT_FOLDER("ballgown-output-url");
-}    // namespace
+}  // namespace
 
 const QString StringTieWorkerFactory::ACTOR_ID("stringtie");
 
@@ -526,11 +525,11 @@ void StringTieWorkerFactory::init() {
 
     DelegateTags outputUrlTags;
     outputUrlTags.set(DelegateTags::PLACEHOLDER_TEXT, "Auto");
-    outputUrlTags.set(DelegateTags::FILTER, DialogUtils::prepareDocumentsFileFilter(BaseDocumentFormats::PLAIN_TEXT, true, QStringList()));
+    outputUrlTags.set(DelegateTags::FILTER, FileFilters::createFileFilterByDocumentFormatId(BaseDocumentFormats::PLAIN_TEXT));
     outputUrlTags.set(DelegateTags::FORMAT, BaseDocumentFormats::PLAIN_TEXT);
     delegates[PRIMARY_OUTPUT] = new URLDelegate(outputUrlTags, "stringtie/primary-output");
     delegates[GENE_ABUDANCE_OUTPUT] = new ComboBoxWithBoolsDelegate();
-    delegates[GENE_ABUDANCE_OUTPUT_FILE] = new URLDelegate(outputUrlTags, "stringtie/gene-abidance-output");
+    delegates[GENE_ABUDANCE_OUTPUT_FILE] = new URLDelegate(outputUrlTags, "stringtie/gene-abundance-output");
 
     delegates[COVERAGE_REF_OUTPUT] = new ComboBoxWithBoolsDelegate();
     delegates[COVERAGE_REF_OUTPUT_FILE] = new URLDelegate(outputUrlTags, "stringtie/coverage-output");
@@ -562,5 +561,5 @@ Worker *StringTieWorkerFactory::createWorker(Actor *a) {
     return new StringTieWorker(a);
 }
 
-}    // namespace LocalWorkflow
-}    // namespace U2
+}  // namespace LocalWorkflow
+}  // namespace U2

--- a/src/plugins/external_tool_support/src/stringtie/StringtieGeneAbundanceReportWorkerFactory.cpp
+++ b/src/plugins/external_tool_support/src/stringtie/StringtieGeneAbundanceReportWorkerFactory.cpp
@@ -22,10 +22,9 @@
 #include "StringtieGeneAbundanceReportWorkerFactory.h"
 
 #include <U2Core/BaseDocumentFormats.h>
+#include <U2Core/FileFilters.h>
 
 #include <U2Designer/DelegateEditors.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>
@@ -88,11 +87,9 @@ void StringtieGeneAbundanceReportWorkerFactory::init() {
         DelegateTags outputFileTags;
         outputFileTags.set(DelegateTags::PLACEHOLDER_TEXT, tr("Auto"));
         outputFileTags.set(DelegateTags::FILTER,
-                           DialogUtils::prepareDocumentsFileFilter(BaseDocumentFormats::PLAIN_TEXT,
-                                                                   true,
-                                                                   QStringList()));
+                           FileFilters::createFileFilterByObjectTypes({BaseDocumentFormats::PLAIN_TEXT}, true));
         outputFileTags.set(DelegateTags::FORMAT, BaseDocumentFormats::PLAIN_TEXT);
-        delegates[OUTPUT_FILE_ATTR_ID] = new URLDelegate(outputFileTags, "stringtie/gene_abudance_report");
+        delegates[OUTPUT_FILE_ATTR_ID] = new URLDelegate(outputFileTags, "stringtie/gene-abundance-report");
     }
 
     const Descriptor desc(ACTOR_ID,
@@ -120,5 +117,5 @@ void StringtieGeneAbundanceReportWorkerFactory::cleanup() {
     delete localDomain->unregisterEntry(ACTOR_ID);
 }
 
-}    // namespace LocalWorkflow
-}    // namespace U2
+}  // namespace LocalWorkflow
+}  // namespace U2

--- a/src/plugins/external_tool_support/src/tcoffee/TCoffeeSupportRunDialog.cpp
+++ b/src/plugins/external_tool_support/src/tcoffee/TCoffeeSupportRunDialog.cpp
@@ -22,11 +22,9 @@
 #include "TCoffeeSupportRunDialog.h"
 
 #include <QMessageBox>
-#include <QPushButton>
-#include <QToolButton>
 
 #include <U2Core/DocumentUtils.h>
-#include <U2Core/GUrlUtils.h>
+#include <U2Core/FileFilters.h>
 
 #include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
@@ -37,7 +35,7 @@
 namespace U2 {
 
 ////////////////////////////////////////
-//TCoffeeSupportRunDialog
+// TCoffeeSupportRunDialog
 TCoffeeSupportRunDialog::TCoffeeSupportRunDialog(TCoffeeSupportTaskSettings &_settings, QWidget *_parent)
     : QDialog(_parent), settings(_settings) {
     setupUi(this);
@@ -63,7 +61,7 @@ void TCoffeeSupportRunDialog::accept() {
     QDialog::accept();
 }
 ////////////////////////////////////////
-//TCoffeeWithExtFileSpecifySupportRunDialog
+// TCoffeeWithExtFileSpecifySupportRunDialog
 TCoffeeWithExtFileSpecifySupportRunDialog::TCoffeeWithExtFileSpecifySupportRunDialog(TCoffeeSupportTaskSettings &_settings, QWidget *_parent)
     : QDialog(_parent),
       settings(_settings),
@@ -81,7 +79,7 @@ TCoffeeWithExtFileSpecifySupportRunDialog::TCoffeeWithExtFileSpecifySupportRunDi
 
 void TCoffeeWithExtFileSpecifySupportRunDialog::sl_inputPathButtonClicked() {
     LastUsedDirHelper lod;
-    lod.url = U2FileDialog::getOpenFileName(this, tr("Open an alignment file"), lod.dir, DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, true));
+    lod.url = U2FileDialog::getOpenFileName(this, tr("Open an alignment file"), lod.dir, FileFilters::createFileFilterByObjectTypes({GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT}));
     if (lod.url.isEmpty()) {
         return;
     }
@@ -123,4 +121,4 @@ void TCoffeeWithExtFileSpecifySupportRunDialog::accept() {
     }
 }
 
-}    // namespace U2
+}  // namespace U2

--- a/src/plugins/external_tool_support/src/tcoffee/TCoffeeSupportRunDialog.h
+++ b/src/plugins/external_tool_support/src/tcoffee/TCoffeeSupportRunDialog.h
@@ -22,13 +22,11 @@
 #ifndef _U2_TCOFFEE_SUPPORT_RUN_DIALOG_H
 #define _U2_TCOFFEE_SUPPORT_RUN_DIALOG_H
 
-#include <ui_TCoffeeSupportRunDialog.h>
-
 #include <QDialog>
 
-#include <U2Gui/DialogUtils.h>
-
 #include "TCoffeeSupportTask.h"
+
+#include <ui_TCoffeeSupportRunDialog.h>
 
 namespace U2 {
 
@@ -62,5 +60,5 @@ private:
     SaveDocumentController *saveController;
 };
 
-}    // namespace U2
-#endif    // _U2_TCOFFEE_SUPPORT_RUN_DIALOG_H
+}  // namespace U2
+#endif  // _U2_TCOFFEE_SUPPORT_RUN_DIALOG_H

--- a/src/plugins/external_tool_support/src/tophat/TopHatWorker.cpp
+++ b/src/plugins/external_tool_support/src/tophat/TopHatWorker.cpp
@@ -23,6 +23,7 @@
 
 #include <U2Core/AppContext.h>
 #include <U2Core/AppSettings.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/L10n.h>
 #include <U2Core/U2OpStatusUtils.h>
@@ -31,8 +32,6 @@
 #include <U2Core/Version.h>
 
 #include <U2Designer/DelegateEditors.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>
@@ -496,7 +495,7 @@ void TopHatWorkerFactory::init() {
     delegates[BOWTIE_INDEX_DIR] = new URLDelegate("", "", false, true, false, nullptr, "", true);
     delegates[BOWTIE_TOOL_PATH] = new URLDelegate("", "executable", false, false, false);
     delegates[SAMTOOLS_TOOL_PATH] = new URLDelegate("", "executable", false, false, false);
-    delegates[REF_SEQ] = new URLDelegate(DialogUtils::prepareDocumentsFileFilter(true), "", false, false, false);
+    delegates[REF_SEQ] = new URLDelegate(FileFilters::createAllSupportedFormatsFileFilter(), "", false, false, false);
     delegates[EXT_TOOL_PATH] = new URLDelegate("", "executable", false, false, false);
     delegates[TMP_DIR_PATH] = new URLDelegate("", "TmpDir", false, true);
     delegates[RAW_JUNCTIONS] = new URLDelegate("", "", false, false, false);
@@ -508,7 +507,7 @@ void TopHatWorkerFactory::init() {
     proto->setPortValidator(BasePorts::IN_SEQ_PORT_ID(), new InputSlotsValidator());
     proto->setValidator(new BowtieToolsValidator());
 
-    {    // external tools
+    {  // external tools
         proto->addExternalTool(SamToolsExtToolSupport::ET_SAMTOOLS_EXT_ID, SAMTOOLS_TOOL_PATH);
         proto->addExternalTool(TopHatSupport::ET_TOPHAT_ID, EXT_TOOL_PATH);
     }
@@ -904,5 +903,5 @@ RelationType BowtieVersionRelation::getType() const {
 BowtieVersionRelation *BowtieVersionRelation::clone() const {
     return new BowtieVersionRelation(*this);
 }
-}    // namespace LocalWorkflow
-}    // namespace U2
+}  // namespace LocalWorkflow
+}  // namespace U2

--- a/src/plugins/external_tool_support/src/trimmomatic/TrimmomaticWorkerFactory.cpp
+++ b/src/plugins/external_tool_support/src/trimmomatic/TrimmomaticWorkerFactory.cpp
@@ -27,10 +27,9 @@
 #include <U2Core/AppResources.h>
 #include <U2Core/AppSettings.h>
 #include <U2Core/BaseDocumentFormats.h>
+#include <U2Core/FileFilters.h>
 
 #include <U2Designer/DelegateEditors.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>
@@ -231,7 +230,7 @@ void TrimmomaticWorkerFactory::init() {
         {
             DelegateTags outputUrlTags;
             outputUrlTags.set(DelegateTags::PLACEHOLDER_TEXT, "Auto");
-            outputUrlTags.set(DelegateTags::FILTER, DialogUtils::prepareDocumentsFileFilter(BaseDocumentFormats::FASTQ, true, QStringList()));
+            outputUrlTags.set(DelegateTags::FILTER, FileFilters::createFileFilterByObjectTypes({BaseDocumentFormats::FASTQ}, true));
             outputUrlTags.set(DelegateTags::FORMAT, BaseDocumentFormats::FASTQ);
             delegates[OUTPUT_URL_ATTR_ID] = new URLDelegate(outputUrlTags, "trimmomatic/output");
             delegates[PAIRED_URL_1_ATTR_ID] = new URLDelegate(outputUrlTags, "trimmomatic/output");
@@ -246,7 +245,7 @@ void TrimmomaticWorkerFactory::init() {
         {
             DelegateTags outputUrlTags;
             outputUrlTags.set(DelegateTags::PLACEHOLDER_TEXT, "Auto");
-            outputUrlTags.set(DelegateTags::FILTER, DialogUtils::prepareDocumentsFileFilter(BaseDocumentFormats::PLAIN_TEXT, true, QStringList()));
+            outputUrlTags.set(DelegateTags::FILTER, FileFilters::createFileFilterByObjectTypes({BaseDocumentFormats::PLAIN_TEXT}, true));
             outputUrlTags.set(DelegateTags::FORMAT, BaseDocumentFormats::PLAIN_TEXT);
             delegates[LOG_URL_ATTR_ID] = new URLDelegate(outputUrlTags, "trimmomatic/output");
         }
@@ -259,7 +258,7 @@ void TrimmomaticWorkerFactory::init() {
 
     const Descriptor desc(ACTOR_ID,
                           TrimmomaticPrompter::tr("Improve Reads with Trimmomatic"),
-                          TrimmomaticPrompter::tr("Trimmomatic is a fast, multithreaded command line tool that can be used"
+                          TrimmomaticPrompter::tr("Trimmomatic is a fast, multi-threaded command line tool that can be used"
                                                   " to trim and crop Illumina (FASTQ) data as well as to remove adapters."));
 
     ActorPrototype *proto = new IntegralBusActorPrototype(desc, ports, attributes);
@@ -281,5 +280,5 @@ void TrimmomaticWorkerFactory::cleanup() {
     delete localDomain->unregisterEntry(ACTOR_ID);
 }
 
-}    // namespace LocalWorkflow
-}    // namespace U2
+}  // namespace LocalWorkflow
+}  // namespace U2

--- a/src/plugins/external_tool_support/src/trimmomatic/steps/IlluminaClipStep.cpp
+++ b/src/plugins/external_tool_support/src/trimmomatic/steps/IlluminaClipStep.cpp
@@ -25,10 +25,10 @@
 
 #include <U2Core/AppContext.h>
 #include <U2Core/BaseDocumentFormats.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/QObjectScopedPointer.h>
 #include <U2Core/U2SafePoints.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/MainWindow.h>
@@ -171,7 +171,7 @@ const QString IlluminaClipSettingsWidget::DEFAULT_PE_ADAPTERS = "TruSeq3-PE-2.fa
 IlluminaClipSettingsWidget::IlluminaClipSettingsWidget() {
     setupUi(this);
 
-    fileName->setText(QDir::toNativeSeparators(QDir("data:").path() + "/adapters/illumina/" + DEFAULT_SE_ADAPTERS));    // The default adapters should be set depending on another attribute value
+    fileName->setText(QDir::toNativeSeparators(QDir("data:").path() + "/adapters/illumina/" + DEFAULT_SE_ADAPTERS));  // The default adapters should be set depending on another attribute value
     new LineEditHighlighter(fileName);
 
     connect(fileName, SIGNAL(textChanged(QString)), SIGNAL(si_valueChanged()));
@@ -237,8 +237,8 @@ void IlluminaClipSettingsWidget::sl_browseButtonClicked() {
     QString defaultDir = QDir::searchPaths(PATH_PREFIX_DATA).first() + "/adapters/illumina";
     LastUsedDirHelper dirHelper("trimmomatic/adapters", defaultDir);
 
-    const QString filter = DialogUtils::prepareDocumentsFileFilter(BaseDocumentFormats::FASTA, true, QStringList());
-    QString defaultFilter = DialogUtils::prepareDocumentsFileFilter(BaseDocumentFormats::FASTA, false);
+    QString filter = FileFilters::createFileFilterByObjectTypes({BaseDocumentFormats::FASTA});
+    QString defaultFilter = FileFilters::createSingleFileFilterByDocumentFormatId(BaseDocumentFormats::FASTA);
     const QString adaptersFilePath = U2FileDialog::getOpenFileName(this, tr("Open FASTA with adapters"), dirHelper.dir, filter, &defaultFilter);
     if (!adaptersFilePath.isEmpty()) {
         dirHelper.url = adaptersFilePath;
@@ -299,5 +299,5 @@ IlluminaClipStep *IlluminaClipStepFactory::createStep() const {
     return new IlluminaClipStep();
 }
 
-}    // namespace LocalWorkflow
-}    // namespace U2
+}  // namespace LocalWorkflow
+}  // namespace U2

--- a/src/plugins/genome_aligner/src/BuildSArraySettingsWidget.cpp
+++ b/src/plugins/genome_aligner/src/BuildSArraySettingsWidget.cpp
@@ -27,8 +27,6 @@
 #include <U2Core/GUrl.h>
 #include <U2Core/UserApplicationsSettings.h>
 
-#include <U2Gui/DialogUtils.h>
-
 #include "GenomeAlignerTask.h"
 
 static const int MIN_PART_SIZE = 1;

--- a/src/plugins/genome_aligner/src/GenomeAlignerIndexWorker.cpp
+++ b/src/plugins/genome_aligner/src/GenomeAlignerIndexWorker.cpp
@@ -21,11 +21,10 @@
 
 #include "GenomeAlignerIndexWorker.h"
 
+#include <U2Core/FileFilters.h>
 #include <U2Core/Log.h>
 
 #include <U2Designer/DelegateEditors.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>
@@ -78,8 +77,9 @@ void GenomeAlignerBuildWorkerFactory::init() {
 
     QMap<QString, PropertyDelegate *> delegates;
 
-    delegates[REFSEQ_URL_ATTR] = new URLDelegate(DialogUtils::prepareDocumentsFileFilter(true), QString(), true);
-    delegates[INDEX_URL_ATTR] = new URLDelegate(DialogUtils::prepareDocumentsFileFilter(true), QString(), false);
+    QString allFormatsFilter = FileFilters::createAllSupportedFormatsFileFilter();
+    delegates[REFSEQ_URL_ATTR] = new URLDelegate(allFormatsFilter, QString(), true);
+    delegates[INDEX_URL_ATTR] = new URLDelegate(allFormatsFilter, QString(), false);
 
     proto->setEditor(new DelegateEditor(delegates));
     proto->setPrompter(new GenomeAlignerBuildPrompter());
@@ -170,7 +170,8 @@ void GenomeAlignerIndexReaderWorkerFactory::init() {
 
     QMap<QString, PropertyDelegate *> delegates;
 
-    delegates[INDEX_URL_ATTR] = new URLDelegate(DialogUtils::prepareDocumentsFileFilter(true), QString(), false, false, false);
+    QString allFormatsFilter = FileFilters::createAllSupportedFormatsFileFilter();
+    delegates[INDEX_URL_ATTR] = new URLDelegate(allFormatsFilter, QString(), false, false, false);
 
     proto->setEditor(new DelegateEditor(delegates));
     proto->setPrompter(new GenomeAlignerIndexReaderPrompter());

--- a/src/plugins/genome_aligner/src/GenomeAlignerWorker.cpp
+++ b/src/plugins/genome_aligner/src/GenomeAlignerWorker.cpp
@@ -21,7 +21,9 @@
 
 #include "GenomeAlignerWorker.h"
 
-#include <U2Algorithm/OpenCLGpuRegistry.h>
+#ifdef OPENCL_SUPPORT
+#    include <U2Algorithm/OpenCLGpuRegistry.h>
+#endif
 
 #include <U2Core/AppContext.h>
 #include <U2Core/FailTask.h>
@@ -30,20 +32,14 @@
 
 #include <U2Designer/DelegateEditors.h>
 
-#include <U2Gui/DialogUtils.h>
-
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>
 #include <U2Lang/BaseAttributes.h>
-#include <U2Lang/BasePorts.h>
-#include <U2Lang/BaseSlots.h>
 #include <U2Lang/BaseTypes.h>
 #include <U2Lang/CoreLibConstants.h>
 #include <U2Lang/IntegralBusModel.h>
 #include <U2Lang/WorkflowEnv.h>
 #include <U2Lang/WorkflowMonitor.h>
-
-#include "GenomeAlignerPlugin.h"
 
 namespace U2 {
 namespace LocalWorkflow {

--- a/src/plugins/pcr/src/FindPrimerPairsWorker.cpp
+++ b/src/plugins/pcr/src/FindPrimerPairsWorker.cpp
@@ -23,6 +23,7 @@
 
 #include <U2Core/AppContext.h>
 #include <U2Core/FailTask.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/IOAdapter.h>
 #include <U2Core/IOAdapterUtils.h>
 #include <U2Core/L10n.h>
@@ -31,8 +32,6 @@
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Designer/DelegateEditors.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>
@@ -140,7 +139,7 @@ void FindPrimerPairsWorkerFactory::init() {
     ActorPrototype *proto = new IntegralBusActorPrototype(desc, p, attrs);
 
     QMap<QString, PropertyDelegate *> delegates;
-    QString filter = DialogUtils::prepareFileFilter(FindPrimerPairsWorker::tr("Report file"), QStringList("html"), true);
+    QString filter = FileFilters::createFileFilter(FindPrimerPairsWorker::tr("Report file"), {"html"});
     DelegateTags tags;
     tags.set("filter", filter);
     tags.set("extensions", QStringList() << "html");

--- a/src/plugins/pcr/src/PrimersGrouperWorker.cpp
+++ b/src/plugins/pcr/src/PrimersGrouperWorker.cpp
@@ -23,6 +23,7 @@
 
 #include <U2Core/AppContext.h>
 #include <U2Core/FailTask.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/IOAdapter.h>
 #include <U2Core/IOAdapterUtils.h>
 #include <U2Core/L10n.h>
@@ -31,8 +32,6 @@
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Designer/DelegateEditors.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>
@@ -148,7 +147,7 @@ void PrimersGrouperWorkerFactory::init() {
     ActorPrototype *proto = new IntegralBusActorPrototype(desc, p, attrs);
 
     QMap<QString, PropertyDelegate *> delegates;
-    QString filter = DialogUtils::prepareFileFilter(PrimersGrouperWorker::tr("Report file"), QStringList("html"), true);
+    QString filter = FileFilters::createFileFilter(PrimersGrouperWorker::tr("Report file"), {"html"}, false);
     DelegateTags tags;
     tags.set("filter", filter);
     tags.set("extensions", QStringList() << "html");

--- a/src/plugins/pcr/src/export/ExportPrimersDialog.cpp
+++ b/src/plugins/pcr/src/export/ExportPrimersDialog.cpp
@@ -27,11 +27,7 @@
 #include <U2Core/AppSettings.h>
 #include <U2Core/BaseDocumentFormats.h>
 #include <U2Core/DocumentModel.h>
-#include <U2Core/DocumentUtils.h>
-#include <U2Core/FormatUtils.h>
 #include <U2Core/GUrlUtils.h>
-#include <U2Core/L10n.h>
-#include <U2Core/Log.h>
 #include <U2Core/ProjectModel.h>
 #include <U2Core/ProjectService.h>
 #include <U2Core/QObjectScopedPointer.h>
@@ -42,12 +38,10 @@
 
 #include <U2Gui/GUIUtils.h>
 #include <U2Gui/HelpButton.h>
-#include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/ProjectTreeItemSelectorDialog.h>
 #include <U2Gui/ProjectUtils.h>
 #include <U2Gui/SaveDocumentController.h>
 #include <U2Gui/SharedConnectionsDialog.h>
-#include <U2Gui/U2FileDialog.h>
 
 #include "ExportPrimersToDatabaseTask.h"
 #include "ExportPrimersToLocalFileTask.h"

--- a/src/plugins/pcr/src/import/ImportPrimersDialog.cpp
+++ b/src/plugins/pcr/src/import/ImportPrimersDialog.cpp
@@ -22,7 +22,7 @@
 #include "ImportPrimersDialog.h"
 
 #include <U2Core/AppContext.h>
-#include <U2Core/FormatUtils.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/ProjectModel.h>
 #include <U2Core/QObjectScopedPointer.h>
 #include <U2Core/Task.h>
@@ -75,7 +75,7 @@ void ImportPrimersDialog::sl_connectClicked() {
 
 void ImportPrimersDialog::sl_addFileClicked() {
     LastUsedDirHelper dirHelper("ImportPrimersDialog");
-    const QString filter = FormatUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::SEQUENCE, true);
+    const QString filter = FileFilters::createFileFilterByObjectTypes({GObjectTypes::SEQUENCE});
 
     QFileDialog::Options additionalOptions;
     Q_UNUSED(additionalOptions);

--- a/src/plugins/query_designer/src/QDRunDialog.cpp
+++ b/src/plugins/query_designer/src/QDRunDialog.cpp
@@ -32,8 +32,8 @@
 #include <U2Core/DNASequenceSelection.h>
 #include <U2Core/DocumentModel.h>
 #include <U2Core/DocumentUtils.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GObjectRelationRoles.h>
-#include <U2Core/GObjectTypes.h>
 #include <U2Core/GObjectUtils.h>
 #include <U2Core/IOAdapter.h>
 #include <U2Core/IOAdapterUtils.h>
@@ -41,14 +41,12 @@
 #include <U2Core/LoadDocumentTask.h>
 #include <U2Core/ProjectModel.h>
 #include <U2Core/SaveDocumentTask.h>
-#include <U2Core/TaskSignalMapper.h>
 #include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Designer/QDScheduler.h>
 
 #include <U2Gui/CreateAnnotationWidgetController.h>
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/OpenViewTask.h>
@@ -57,7 +55,6 @@
 
 #include <U2View/ADVSequenceObjectContext.h>
 #include <U2View/AnnotatedDNAView.h>
-#include <U2View/AnnotatedDNAViewTasks.h>
 
 #include "QDSceneIOTasks.h"
 #include "QueryViewController.h"
@@ -102,7 +99,7 @@ void QDRunDialog::sl_selectInputFile() {
         dir.dir = fi.absolutePath();
     }
 
-    QString fileFilter = DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::SEQUENCE, true);
+    QString fileFilter = FileFilters::createFileFilterByObjectTypes({GObjectTypes::SEQUENCE});
     dir.url = U2FileDialog::getOpenFileName(this, tr("Select input file"), dir, fileFilter);
 
     if (!dir.url.isEmpty()) {

--- a/src/plugins/query_designer/src/QDWorker.cpp
+++ b/src/plugins/query_designer/src/QDWorker.cpp
@@ -27,7 +27,7 @@
 #include <U2Core/AnnotationTableObject.h>
 #include <U2Core/DNASequenceObject.h>
 #include <U2Core/FailTask.h>
-#include <U2Core/GObjectTypes.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GenbankFeatures.h>
 #include <U2Core/L10n.h>
 #include <U2Core/MultiTask.h>
@@ -38,15 +38,12 @@
 #include <U2Designer/DelegateEditors.h>
 #include <U2Designer/QDScheduler.h>
 
-#include <U2Gui/DialogUtils.h>
-
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>
 #include <U2Lang/BaseAttributes.h>
 #include <U2Lang/BasePorts.h>
 #include <U2Lang/BaseSlots.h>
 #include <U2Lang/BaseTypes.h>
-#include <U2Lang/CoreLibConstants.h>
 #include <U2Lang/IntegralBusModel.h>
 #include <U2Lang/QDScheme.h>
 #include <U2Lang/WorkflowEnv.h>
@@ -106,7 +103,7 @@ void QDWorkerFactory::init() {
     QMap<QString, PropertyDelegate *> delegates;
     {
         delegates[SCHEMA_ATTR] = new URLDelegate(
-            DialogUtils::prepareFileFilter(QDWorker::tr("Query schemes"), QStringList(QUERY_SCHEME_EXTENSION), true),
+            FileFilters::createFileFilter(QDWorker::tr("Query schemes"), {QUERY_SCHEME_EXTENSION}, false),
             QUERY_DESIGNER_ID,
             false,
             false,

--- a/src/plugins/smith_waterman/src/SWWorker.cpp
+++ b/src/plugins/smith_waterman/src/SWWorker.cpp
@@ -26,21 +26,14 @@
 #include <U2Algorithm/SubstMatrixRegistry.h>
 
 #include <U2Core/AppContext.h>
-#include <U2Core/DNAAlphabet.h>
-#include <U2Core/DNAInfo.h>
 #include <U2Core/DNASequence.h>
 #include <U2Core/DNASequenceObject.h>
 #include <U2Core/DNATranslation.h>
-#include <U2Core/DocumentUtils.h>
 #include <U2Core/FailTask.h>
-#include <U2Core/GObjectTypes.h>
 #include <U2Core/GenbankFeatures.h>
 #include <U2Core/IOAdapterUtils.h>
-#include <U2Core/L10n.h>
 #include <U2Core/Log.h>
-#include <U2Core/MSAUtils.h>
 #include <U2Core/MultiTask.h>
-#include <U2Core/MultipleSequenceAlignmentObject.h>
 #include <U2Core/PluginModel.h>
 #include <U2Core/SequenceWalkerTask.h>
 #include <U2Core/TaskSignalMapper.h>
@@ -48,8 +41,6 @@
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Designer/DelegateEditors.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>

--- a/src/plugins/weight_matrix/src/PWMSearchDialogController.cpp
+++ b/src/plugins/weight_matrix/src/PWMSearchDialogController.cpp
@@ -211,7 +211,10 @@ bool PWMSearchDialogController::eventFilter(QObject *obj, QEvent *ev) {
 
 void PWMSearchDialogController::sl_selectModelFile() {
     LastUsedDirHelper lod(WeightMatrixIO::WEIGHT_MATRIX_ID);
-    lod.url = U2FileDialog::getOpenFileName(this, tr("Select file with frequency or weight matrix"), lod, WeightMatrixIO::getAllMatrixFileFilter(false) + ";;" + WeightMatrixIO::getPFMFileFilter(false) + ";;" + WeightMatrixIO::getPWMFileFilter(true));
+    QString fileFilter = WeightMatrixIO::getAllMatrixFileFilter(true) + ";;" +
+                         WeightMatrixIO::getPFMFileFilter(true) + ";;" +
+                         WeightMatrixIO::getPWMFileFilter();
+    lod.url = U2FileDialog::getOpenFileName(this, tr("Select file with frequency or weight matrix"), lod, fileFilter);
     if (lod.url.isEmpty()) {
         return;
     }

--- a/src/plugins/weight_matrix/src/WMQuery.cpp
+++ b/src/plugins/weight_matrix/src/WMQuery.cpp
@@ -27,14 +27,9 @@
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DNASequenceObject.h>
 #include <U2Core/FailTask.h>
-#include <U2Core/L10n.h>
-#include <U2Core/Log.h>
-#include <U2Core/MultiTask.h>
 #include <U2Core/TaskSignalMapper.h>
 
 #include <U2Designer/DelegateEditors.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include <U2Lang/BaseTypes.h>
 

--- a/src/plugins/weight_matrix/src/WeightMatrixIO.cpp
+++ b/src/plugins/weight_matrix/src/WeightMatrixIO.cpp
@@ -28,6 +28,7 @@
 
 #include <U2Core/AppContext.h>
 #include <U2Core/DIProperties.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/IOAdapter.h>
 #include <U2Core/IOAdapterUtils.h>
@@ -35,11 +36,7 @@
 #include <U2Core/SaveDocumentTask.h>
 #include <U2Core/TextUtils.h>
 
-#include <U2Gui/DialogUtils.h>
-
 #include "WeightMatrixPlugin.h"
-
-/* TRANSLATOR U2::IOAdapter */
 
 namespace U2 {
 
@@ -48,16 +45,22 @@ const QString WeightMatrixIO::FREQUENCY_MATRIX_ID("frequency_matrix");
 const QString WeightMatrixIO::WEIGHT_MATRIX_EXT("pwm");
 const QString WeightMatrixIO::FREQUENCY_MATRIX_EXT("pfm");
 
-QString WeightMatrixIO::getAllMatrixFileFilter(bool includeAll) {
-    return DialogUtils::prepareFileFilter(tr("Frequency and weight matrices"), QStringList() << FREQUENCY_MATRIX_EXT << WEIGHT_MATRIX_EXT, includeAll);
+QString WeightMatrixIO::getAllMatrixFileFilter(bool isSingleFileFilterMode) {
+    QString name = tr("Frequency and weight matrices");
+    QStringList extensions({FREQUENCY_MATRIX_EXT, WEIGHT_MATRIX_EXT});
+    return isSingleFileFilterMode ? FileFilters::createSingleFileFilter(name, extensions, false)
+                                  : FileFilters::createFileFilter(name, extensions);
 }
 
-QString WeightMatrixIO::getPFMFileFilter(bool includeAll) {
-    return DialogUtils::prepareFileFilter(tr("Frequency matrices"), QStringList(FREQUENCY_MATRIX_EXT), includeAll);
+QString WeightMatrixIO::getPFMFileFilter(bool isSingleFileFilterMode) {
+    QString name = tr("Frequency matrices");
+    QStringList extensions({FREQUENCY_MATRIX_EXT});
+    return isSingleFileFilterMode ? FileFilters::createSingleFileFilter(name, extensions, false)
+                                  : FileFilters::createFileFilter(name, extensions);
 }
 
-QString WeightMatrixIO::getPWMFileFilter(bool includeAll) {
-    return DialogUtils::prepareFileFilter(tr("Weight matrices"), QStringList(WEIGHT_MATRIX_EXT), includeAll);
+QString WeightMatrixIO::getPWMFileFilter() {
+    return FileFilters::createFileFilter(tr("Weight matrices"), {WEIGHT_MATRIX_EXT});
 }
 
 #define BUFF_SIZE 4096

--- a/src/plugins/weight_matrix/src/WeightMatrixIO.h
+++ b/src/plugins/weight_matrix/src/WeightMatrixIO.h
@@ -44,9 +44,9 @@ public:
     static const QString WEIGHT_MATRIX_EXT;
     static const QString FREQUENCY_MATRIX_EXT;
 
-    static QString getAllMatrixFileFilter(bool includeAll = true);
-    static QString getPFMFileFilter(bool includeAll = true);
-    static QString getPWMFileFilter(bool includeAll = true);
+    static QString getAllMatrixFileFilter(bool isSingleFileFilterMode = false);
+    static QString getPFMFileFilter(bool isSingleFileFilterMode = false);
+    static QString getPWMFileFilter();
     static PFMatrix readPFMatrix(IOAdapterFactory *iof, const QString &url, TaskStateInfo &si);
     static PWMatrix readPWMatrix(IOAdapterFactory *iof, const QString &url, TaskStateInfo &si);
     static void writePFMatrix(IOAdapterFactory *iof, const QString &url, TaskStateInfo &si, const PFMatrix &model);

--- a/src/plugins/workflow_designer/src/WorkflowViewController.cpp
+++ b/src/plugins/workflow_designer/src/WorkflowViewController.cpp
@@ -35,6 +35,7 @@
 
 #include <U2Core/AppContext.h>
 #include <U2Core/Counter.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/IOAdapterUtils.h>
 #include <U2Core/Log.h>
@@ -52,7 +53,6 @@
 #include <U2Designer/RemoveDashboardsTask.h>
 #include <U2Designer/WizardController.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/ExportImageDialog.h>
 #include <U2Gui/ScriptEditorDialog.h>
 #include <U2Gui/U2FileDialog.h>
@@ -853,7 +853,7 @@ QString copyIntoUgene(const QString &url, U2OpStatus &os) {
 }  // namespace
 
 void WorkflowView::sl_appendExternalToolWorker() {
-    QString filter = DialogUtils::prepareFileFilter(WorkflowUtils::tr("UGENE workflow element"), QStringList() << "etc", true);
+    QString filter = FileFilters::createFileFilter(WorkflowUtils::tr("UGENE workflow element"), {"etc"});
     QString url = U2FileDialog::getOpenFileName(this, tr("Add element"), QString(), filter);
     if (!url.isEmpty()) {
         IOAdapter *io = AppContext::getIOAdapterRegistry()->getIOAdapterFactoryById(IOAdapterUtils::url2io(GUrl(url)))->createIOAdapter();
@@ -2151,7 +2151,7 @@ void WorkflowView::sl_loadScene() {
     }
 
     QString dir = AppContext::getSettings()->getValue(LAST_DIR, QString("")).toString();
-    QString filter = DesignerUtils::getSchemaFileFilter(true, true);
+    QString filter = DesignerUtils::getSchemaFileFilter();
     QString url;
 #ifdef Q_OS_DARWIN
     if (qgetenv(ENV_GUI_TEST).toInt() == 1 && qgetenv(ENV_USE_NATIVE_DIALOGS).toInt() == 0) {

--- a/src/plugins/workflow_designer/src/library/BaseDocWriter.cpp
+++ b/src/plugins/workflow_designer/src/library/BaseDocWriter.cpp
@@ -25,7 +25,6 @@
 #include <U2Core/DeleteObjectsTask.h>
 #include <U2Core/DocumentModel.h>
 #include <U2Core/DocumentUtils.h>
-#include <U2Core/FailTask.h>
 #include <U2Core/GHints.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/IOAdapter.h>
@@ -35,21 +34,15 @@
 #include <U2Core/MultiTask.h>
 #include <U2Core/ProjectModel.h>
 #include <U2Core/TaskSignalMapper.h>
-#include <U2Core/U2DbiRegistry.h>
 #include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
 
-#include <U2Gui/DialogUtils.h>
-
 #include <U2Lang/BaseAttributes.h>
 #include <U2Lang/BaseSlots.h>
-#include <U2Lang/CoreLibConstants.h>
 #include <U2Lang/SharedDbUrlUtils.h>
 #include <U2Lang/WorkflowEnv.h>
 #include <U2Lang/WorkflowMonitor.h>
 #include <U2Lang/WorkflowUtils.h>
-
-#include "CoreLib.h"
 
 namespace U2 {
 namespace LocalWorkflow {

--- a/src/plugins/workflow_designer/src/library/CoreLib.cpp
+++ b/src/plugins/workflow_designer/src/library/CoreLib.cpp
@@ -24,14 +24,12 @@
 #include <U2Core/AppContext.h>
 #include <U2Core/BaseDocumentFormats.h>
 #include <U2Core/DocumentModel.h>
-#include <U2Core/GObjectTypes.h>
 #include <U2Core/Log.h>
 #include <U2Core/Settings.h>
 #include <U2Core/global.h>
 
 #include <U2Designer/DelegateEditors.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
@@ -52,7 +50,6 @@
 
 #include "AminoTranslationWorker.h"
 #include "AssemblyToSequenceWorker.h"
-#include "BaseDocWriter.h"
 #include "CDSearchWorker.h"
 #include "ConvertFilesFormatWorker.h"
 #include "ConvertSnpeffVariationsToAnnotationsWorker.h"

--- a/src/plugins/workflow_designer/src/library/DocActors.cpp
+++ b/src/plugins/workflow_designer/src/library/DocActors.cpp
@@ -24,6 +24,7 @@
 #include <QApplication>
 
 #include <U2Core/DocumentModel.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/FormatUtils.h>
 #include <U2Core/SaveDocumentTask.h>
 #include <U2Core/U2SafePoints.h>
@@ -33,12 +34,10 @@
 #include <U2Lang/BaseAttributes.h>
 #include <U2Lang/BaseSlots.h>
 #include <U2Lang/BaseTypes.h>
-#include <U2Lang/CoreLibConstants.h>
 #include <U2Lang/SharedDbUrlUtils.h>
 #include <U2Lang/URLAttribute.h>
 
 #include "../util/DatasetValidator.h"
-#include "CoreLib.h"
 
 namespace U2 {
 namespace Workflow {
@@ -70,10 +69,10 @@ bool DocActorProto::isAcceptableDrop(const QMimeData *md, QVariantMap *params, c
 
 QString DocActorProto::prepareDocumentFilter() {
     if (!fid.isEmpty()) {
-        return FormatUtils::prepareDocumentsFileFilter(fid, true);
+        return FileFilters::createFileFilterByDocumentFormatId(fid);
     } else {
-        assert(!type.isEmpty());
-        return FormatUtils::prepareDocumentsFileFilterByObjType(type, true);
+        SAFE_POINT(!type.isEmpty(), "Both format id and type are empty!", "");
+        return FileFilters::createFileFilterByObjectTypes({type});
     }
 }
 

--- a/src/plugins/workflow_designer/src/library/ExtractAssemblyCoverageWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/ExtractAssemblyCoverageWorker.cpp
@@ -23,14 +23,12 @@
 
 #include <U2Core/BaseDocumentFormats.h>
 #include <U2Core/FailTask.h>
-#include <U2Core/FormatUtils.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Designer/DelegateEditors.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>
@@ -198,7 +196,7 @@ void ExtractAssemblyCoverageWorkerFactory::init() {
 
     QMap<QString, PropertyDelegate *> delegates;
     {
-        const QString filter = FormatUtils::prepareFileFilter(ExportCoverageSettings::BEDGRAPH, QStringList() << ExportCoverageSettings::BEDGRAPH_EXTENSION, true);
+        const QString filter = FileFilters::createFileFilter(ExportCoverageSettings::BEDGRAPH, {ExportCoverageSettings::BEDGRAPH_EXTENSION}, false);
         DelegateTags tags;
         tags.set("filter", filter);
         tags.set("extensions", QStringList() << ExportCoverageSettings::BEDGRAPH_EXTENSION << ExportCoverageSettings::BEDGRAPH_EXTENSION + ExportCoverageSettings::COMPRESSED_EXTENSION);
@@ -300,7 +298,7 @@ void ExtractAssemblyCoverageFileExtensionRelation::updateDelegateTags(const QVar
     const ExportCoverageSettings::Format newFormat = static_cast<ExportCoverageSettings::Format>(influencingValue.toInt());
     if (nullptr != dependentTags) {
         dependentTags->set("extensions", QStringList() << ExportCoverageSettings::getFormatExtension(newFormat) << ExportCoverageSettings::getFormatExtension(newFormat) + ExportCoverageSettings::COMPRESSED_EXTENSION);
-        const QString filter = FormatUtils::prepareFileFilter(ExportCoverageSettings::getFormat(newFormat) + " coverage files", QStringList() << ExportCoverageSettings::getFormatExtension(newFormat));
+        QString filter = FileFilters::createFileFilter(ExportCoverageSettings::getFormat(newFormat) + " coverage files", {ExportCoverageSettings::getFormatExtension(newFormat)});
         dependentTags->set("filter", filter);
     }
 }

--- a/src/plugins/workflow_designer/src/library/FilterAnnotationsByQualifierWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/FilterAnnotationsByQualifierWorker.cpp
@@ -26,15 +26,12 @@
 
 #include <U2Designer/DelegateEditors.h>
 
-#include <U2Gui/DialogUtils.h>
-
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>
 #include <U2Lang/BasePorts.h>
 #include <U2Lang/BaseSlots.h>
 #include <U2Lang/BaseTypes.h>
 #include <U2Lang/ConfigurationEditor.h>
-#include <U2Lang/CoreLibConstants.h>
 #include <U2Lang/WorkflowEnv.h>
 
 namespace U2 {

--- a/src/plugins/workflow_designer/src/library/FilterAnnotationsWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/FilterAnnotationsWorker.cpp
@@ -22,12 +22,11 @@
 #include "FilterAnnotationsWorker.h"
 
 #include <U2Core/AnnotationTableObject.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/TaskSignalMapper.h>
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Designer/DelegateEditors.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>
@@ -35,7 +34,6 @@
 #include <U2Lang/BaseSlots.h>
 #include <U2Lang/BaseTypes.h>
 #include <U2Lang/ConfigurationEditor.h>
-#include <U2Lang/CoreLibConstants.h>
 #include <U2Lang/WorkflowEnv.h>
 
 namespace U2 {
@@ -137,7 +135,7 @@ void FilterAnnotationsWorkerFactory::init() {
     proto->setPrompter(new FilterAnnotationsPrompter());
     {
         QMap<QString, PropertyDelegate *> delegateMap;
-        delegateMap[FILTER_NAMES_FILE_ATTR] = new URLDelegate(DialogUtils::prepareDocumentsFileFilter(true), QString(), false, false, false);
+        delegateMap[FILTER_NAMES_FILE_ATTR] = new URLDelegate(FileFilters::createAllSupportedFormatsFileFilter(), "", false, false, false);
         proto->setEditor(new DelegateEditor(delegateMap));
     }
     proto->setValidator(new FilterAnnotationsValidator());

--- a/src/plugins/workflow_designer/src/library/GenericReadActor.cpp
+++ b/src/plugins/workflow_designer/src/library/GenericReadActor.cpp
@@ -25,17 +25,14 @@
 #include <QFileInfo>
 
 #include <U2Core/AppContext.h>
-#include <U2Core/DNAInfo.h>
 #include <U2Core/DNASequenceObject.h>
 #include <U2Core/DocumentModel.h>
 #include <U2Core/GObjectTypes.h>
 
 #include <U2Designer/DelegateEditors.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
 
-#include <U2Lang/BaseActorCategories.h>
 #include <U2Lang/BaseAttributes.h>
 #include <U2Lang/BasePorts.h>
 #include <U2Lang/BaseSlots.h>

--- a/src/plugins/workflow_designer/src/library/ImportAnnotationsWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/ImportAnnotationsWorker.cpp
@@ -24,19 +24,15 @@
 #include <QScopedPointer>
 
 #include <U2Core/AnnotationTableObject.h>
-#include <U2Core/DNASequence.h>
 #include <U2Core/DocumentModel.h>
 #include <U2Core/FailTask.h>
-#include <U2Core/GObjectTypes.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/L10n.h>
 #include <U2Core/LoadDocumentTask.h>
 #include <U2Core/MultiTask.h>
-#include <U2Core/QVariantUtils.h>
 #include <U2Core/TaskSignalMapper.h>
 
 #include <U2Designer/DelegateEditors.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
 #include <U2Lang/BaseActorCategories.h>
@@ -176,7 +172,7 @@ void ImportAnnotationsWorkerFactory::init() {
     QMap<QString, PropertyDelegate *> delegates;
     {
         delegates[BaseAttributes::URL_IN_ATTRIBUTE().getId()] = new URLDelegate(
-            DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::ANNOTATION_TABLE, true), QString(), true, false, false);
+            FileFilters::createFileFilterByObjectTypes({GObjectTypes::ANNOTATION_TABLE}), "", true, false, false);
     }
     proto->setEditor(new DelegateEditor(delegates));
     proto->setPrompter(new ReadDocPrompter(ImportAnnotationsWorker::tr("Merge input annotations with annotations from <u>%1</u>.")));

--- a/src/plugins/workflow_designer/src/library/ReadAnnotationsWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/ReadAnnotationsWorker.cpp
@@ -29,13 +29,11 @@
 #include <U2Core/DocumentUtils.h>
 #include <U2Core/IOAdapter.h>
 #include <U2Core/IOAdapterUtils.h>
-#include <U2Core/L10n.h>
 #include <U2Core/U2SafePoints.h>
 #include <U2Core/ZlibAdapter.h>
 
 #include <U2Designer/DelegateEditors.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>

--- a/src/plugins/workflow_designer/src/library/ReadAssemblyWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/ReadAssemblyWorker.cpp
@@ -26,18 +26,12 @@
 #include <U2Core/DocumentImport.h>
 #include <U2Core/DocumentProviderTask.h>
 #include <U2Core/DocumentUtils.h>
-#include <U2Core/FileStorageUtils.h>
 #include <U2Core/IOAdapter.h>
-#include <U2Core/IOAdapterUtils.h>
 #include <U2Core/U2DbiRegistry.h>
-#include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Designer/DelegateEditors.h>
 
-#include <U2Formats/BAMUtils.h>
-
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>

--- a/src/plugins/workflow_designer/src/library/ReadVariationWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/ReadVariationWorker.cpp
@@ -31,7 +31,6 @@
 
 #include <U2Designer/DelegateEditors.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>

--- a/src/plugins/workflow_designer/src/library/RemoteDBFetcherWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/RemoteDBFetcherWorker.cpp
@@ -27,6 +27,7 @@
 #include <U2Core/DNASequenceObject.h>
 #include <U2Core/DocumentModel.h>
 #include <U2Core/FailTask.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GObjectRelationRoles.h>
 #include <U2Core/GObjectUtils.h>
 #include <U2Core/L10n.h>
@@ -35,7 +36,6 @@
 
 #include <U2Designer/DelegateEditors.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
 
 #include <U2Lang/ActorModel.h>
@@ -351,7 +351,7 @@ void RemoteDBFetcherFactory::init() {
         sourceItems.insert(localFileString, localFileString);
         delegates[SOURCE_CHOOSER_ID] = new ComboBoxDelegate(sourceItems);
 
-        delegates[SOURCE_FILE_ID] = new URLDelegate(DialogUtils::prepareDocumentsFileFilter(true), QString(), true, false, false);
+        delegates[SOURCE_FILE_ID] = new URLDelegate(FileFilters::createAllSupportedFormatsFileFilter(), "", true, false, false);
         delegates[SEQID_ID] = new StringListDelegate();
         delegates[PATH_ID] = new URLDelegate(QString(), QString(), false, true);
     }

--- a/src/plugins/workflow_designer/src/library/WriteAnnotationsWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/WriteAnnotationsWorker.cpp
@@ -29,6 +29,7 @@
 #include <U2Core/DocumentModel.h>
 #include <U2Core/DocumentUtils.h>
 #include <U2Core/FailTask.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/IOAdapter.h>
 #include <U2Core/IOAdapterUtils.h>
@@ -40,7 +41,6 @@
 
 #include <U2Designer/DelegateEditors.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/ExportAnnotations2CSVTask.h>
 
 #include <U2Lang/ActorPrototypeRegistry.h>
@@ -480,7 +480,7 @@ void WriteAnnotationsWorkerFactory::init() {
         formatDelegate->setSortFlag(true);
         delegates[BaseAttributes::DOCUMENT_FORMAT_ATTRIBUTE().getId()] = formatDelegate;
         delegates[BaseAttributes::URL_OUT_ATTRIBUTE().getId()] =
-            new URLDelegate(DialogUtils::prepareDocumentsFileFilter(format, true), QString(), false, false, true, nullptr, format);
+            new URLDelegate(FileFilters::createFileFilterByDocumentFormatId(format), "", false, false, true, nullptr, format);
         delegates[BaseAttributes::FILE_MODE_ATTRIBUTE().getId()] = new FileModeDelegate(attrs.size() > 2);
 
         delegates[BaseAttributes::DATA_STORAGE_ATTRIBUTE().getId()] = new ComboBoxDelegate(BaseAttributes::DATA_STORAGE_ATTRIBUTE_VALUES_MAP());

--- a/src/plugins/workflow_designer/src/library/create_cmdline_based_worker/CreateCmdlineBasedWorkerWizard.cpp
+++ b/src/plugins/workflow_designer/src/library/create_cmdline_based_worker/CreateCmdlineBasedWorkerWizard.cpp
@@ -251,11 +251,11 @@ void CreateCmdlineBasedWorkerWizard::init() {
     setOption(QWizard::HaveHelpButton, true);
     new U2::HelpButton(this, this->button(QWizard::HelpButton), "28967044");
 
-    DialogUtils::setWizardMinimumSize(this, QSize(780, 350));
+    WizardUtils::setWizardMinimumSize(this, QSize(780, 350));
 }
 
 ExternalProcessConfig *CreateCmdlineBasedWorkerWizard::createActualConfig() const {
-    ExternalProcessConfig *config = new ExternalProcessConfig();
+    auto config = new ExternalProcessConfig();
     config->id = field(WORKER_ID_FIELD).toString();
     config->name = field(WORKER_NAME_FIELD).toString();
     config->description = removeEmptyLines(field(WORKER_DESCRIPTION_FIELD).toString());

--- a/src/plugins_3rdparty/hmm2/src/HMMIO.cpp
+++ b/src/plugins_3rdparty/hmm2/src/HMMIO.cpp
@@ -24,6 +24,7 @@
 #include <QFileInfo>
 
 #include <U2Core/AppContext.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/IOAdapter.h>
 #include <U2Core/IOAdapterUtils.h>
@@ -32,8 +33,6 @@
 #include <U2Core/Settings.h>
 #include <U2Core/Task.h>
 #include <U2Core/TextUtils.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include "TaskLocalStorage.h"
 #include "hmmer2/funcs.h"
@@ -654,7 +653,7 @@ plan7_s *HMMIO::cloneHMM(plan7_s *src) {
 }
 
 QString HMMIO::getHMMFileFilter() {
-    return DialogUtils::prepareFileFilter(tr("HMM models"), QStringList(HMM_EXT));
+    return FileFilters::createFileFilter(tr("HMM models"), {HMM_EXT}, false);
 }
 
 DNAAlphabetType HMMIO::convertHMMAlphabet(int atype) {

--- a/src/plugins_3rdparty/hmm2/src/u_build/HMMBuildDialogController.cpp
+++ b/src/plugins_3rdparty/hmm2/src/u_build/HMMBuildDialogController.cpp
@@ -29,13 +29,13 @@
 #include <U2Core/Counter.h>
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DocumentModel.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/IOAdapter.h>
 #include <U2Core/IOAdapterUtils.h>
 #include <U2Core/LoadDocumentTask.h>
 #include <U2Core/MultipleSequenceAlignmentObject.h>
 #include <U2Core/U2OpStatusUtils.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/SaveDocumentController.h>
@@ -75,7 +75,7 @@ HMMBuildDialogController::HMMBuildDialogController(const QString &_pn, const Mul
 
 void HMMBuildDialogController::sl_msaFileClicked() {
     LastUsedDirHelper lod;
-    lod.url = U2FileDialog::getOpenFileName(this, tr("Select file with alignment"), lod, DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, true));
+    lod.url = U2FileDialog::getOpenFileName(this, tr("Select file with alignment"), lod, FileFilters::createFileFilterByObjectTypes({GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT}));
 
     if (lod.url.isEmpty()) {
         return;

--- a/src/plugins_3rdparty/hmm2/src/u_search/HMMSearchQDActor.cpp
+++ b/src/plugins_3rdparty/hmm2/src/u_search/HMMSearchQDActor.cpp
@@ -29,8 +29,6 @@
 
 #include <U2Designer/DelegateEditors.h>
 
-#include <U2Gui/DialogUtils.h>
-
 #include <U2Lang/BaseTypes.h>
 
 #include "HMMIO.h"

--- a/src/plugins_3rdparty/kalign/src/KalignDialogController.cpp
+++ b/src/plugins_3rdparty/kalign/src/KalignDialogController.cpp
@@ -22,17 +22,14 @@
 #include "KalignDialogController.h"
 
 #include <QMessageBox>
-#include <QPushButton>
-#include <QToolButton>
 
 #include <U2Core/AppContext.h>
 #include <U2Core/BaseDocumentFormats.h>
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DNATranslation.h>
 #include <U2Core/DocumentUtils.h>
-#include <U2Core/GUrlUtils.h>
+#include <U2Core/FileFilters.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/SaveDocumentController.h>
@@ -137,7 +134,7 @@ KalignAlignWithExtFileSpecifyDialogController::KalignAlignWithExtFileSpecifyDial
 
 void KalignAlignWithExtFileSpecifyDialogController::sl_inputPathButtonClicked() {
     LastUsedDirHelper lod;
-    lod.url = U2FileDialog::getOpenFileName(this, tr("Open an alignment file"), lod.dir, DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, true));
+    lod.url = U2FileDialog::getOpenFileName(this, tr("Open an alignment file"), lod.dir, FileFilters::createFileFilterByObjectTypes({GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT}));
     if (lod.url.isEmpty()) {
         return;
     }

--- a/src/plugins_3rdparty/kalign/src/KalignDialogController.h
+++ b/src/plugins_3rdparty/kalign/src/KalignDialogController.h
@@ -22,15 +22,13 @@
 #ifndef _U2_KALIGN_ALIGN_DIALOG_CONTROLLER_H_
 #define _U2_KALIGN_ALIGN_DIALOG_CONTROLLER_H_
 
-#include <ui_KalignDialog.h>
-
 #include <QDialog>
 
 #include <U2Core/GAutoDeleteList.h>
 
-#include <U2Gui/DialogUtils.h>
-
 #include "KalignTask.h"
+
+#include <ui_KalignDialog.h>
 
 namespace U2 {
 

--- a/src/plugins_3rdparty/sitecon/src/SiteconBuildDialogController.cpp
+++ b/src/plugins_3rdparty/sitecon/src/SiteconBuildDialogController.cpp
@@ -22,20 +22,18 @@
 #include "SiteconBuildDialogController.h"
 
 #include <QMessageBox>
-#include <QPushButton>
 
 #include <U2Core/AppContext.h>
 #include <U2Core/Counter.h>
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DocumentModel.h>
-#include <U2Core/GObjectTypes.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/IOAdapter.h>
 #include <U2Core/IOAdapterUtils.h>
 #include <U2Core/LoadDocumentTask.h>
 #include <U2Core/MultipleSequenceAlignmentObject.h>
 #include <U2Core/Settings.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/SaveDocumentController.h>
@@ -73,7 +71,7 @@ SiteconBuildDialogController::SiteconBuildDialogController(SiteconPlugin *pl, QW
 
 void SiteconBuildDialogController::sl_inFileButtonClicked() {
     LastUsedDirHelper lod;
-    lod.url = U2FileDialog::getOpenFileName(this, tr("Select file with alignment"), lod, DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, true));
+    lod.url = U2FileDialog::getOpenFileName(this, tr("Select file with alignment"), lod, FileFilters::createFileFilterByObjectTypes({GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT}));
     if (lod.url.isEmpty()) {
         return;
     }

--- a/src/plugins_3rdparty/sitecon/src/SiteconIO.cpp
+++ b/src/plugins_3rdparty/sitecon/src/SiteconIO.cpp
@@ -21,21 +21,19 @@
 
 #include "SiteconIO.h"
 
-#include <QFile>
 #include <QFileInfo>
 #include <QTextStream>
 #include <QVector>
 #include <QtMath>
 
 #include <U2Core/AppContext.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/IOAdapter.h>
 #include <U2Core/IOAdapterUtils.h>
 #include <U2Core/L10n.h>
 #include <U2Core/SaveDocumentTask.h>
 #include <U2Core/TextUtils.h>
-
-#include <U2Gui/DialogUtils.h>
 
 #include "DIPropertiesSitecon.h"
 #include "SiteconMath.h"
@@ -47,8 +45,9 @@ namespace U2 {
 
 const QString SiteconIO::SITECON_ID("sitecon");
 const QString SiteconIO::SITECON_EXT = SiteconIO::SITECON_ID;
-QString SiteconIO::getFileFilter(bool includeAll) {
-    return DialogUtils::prepareFileFilter(tr("Sitecon models"), QStringList(SITECON_EXT), includeAll);
+
+QString SiteconIO::getFileFilter() {
+    return FileFilters::createFileFilter(tr("Sitecon models"), {SITECON_EXT}, false);
 }
 
 #define FILE_HEADER "SITECON MODEL"

--- a/src/plugins_3rdparty/sitecon/src/SiteconIO.cpp
+++ b/src/plugins_3rdparty/sitecon/src/SiteconIO.cpp
@@ -39,15 +39,13 @@
 #include "SiteconMath.h"
 #include "SiteconPlugin.h"
 
-/* TRANSLATOR U2::IOAdapter */
-
 namespace U2 {
 
 const QString SiteconIO::SITECON_ID("sitecon");
 const QString SiteconIO::SITECON_EXT = SiteconIO::SITECON_ID;
 
 QString SiteconIO::getFileFilter() {
-    return FileFilters::createFileFilter(tr("Sitecon models"), {SITECON_EXT}, false);
+    return FileFilters::createFileFilter(tr("Sitecon models"), {SITECON_EXT}, true);
 }
 
 #define FILE_HEADER "SITECON MODEL"

--- a/src/plugins_3rdparty/sitecon/src/SiteconIO.h
+++ b/src/plugins_3rdparty/sitecon/src/SiteconIO.h
@@ -39,7 +39,7 @@ class SiteconIO : public QObject {
 public:
     static const QString SITECON_ID;
     static const QString SITECON_EXT;
-    static QString getFileFilter(bool includeAll = true);
+    static QString getFileFilter();
     static SiteconModel readModel(IOAdapterFactory *iof, const QString &url, TaskStateInfo &si);
     static void writeModel(IOAdapterFactory *iof, const QString &url, TaskStateInfo &si, const SiteconModel &model);
 };

--- a/src/plugins_3rdparty/umuscle/src/MuscleAlignDialogController.cpp
+++ b/src/plugins_3rdparty/umuscle/src/MuscleAlignDialogController.cpp
@@ -30,6 +30,7 @@
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DNATranslation.h>
 #include <U2Core/DocumentUtils.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GUrlUtils.h>
 
 #include <U2Gui/HelpButton.h>
@@ -159,7 +160,7 @@ MuscleAlignWithExtFileSpecifyDialogController::MuscleAlignWithExtFileSpecifyDial
 
 void MuscleAlignWithExtFileSpecifyDialogController::sl_inputPathButtonClicked() {
     LastUsedDirHelper lod;
-    lod.url = U2FileDialog::getOpenFileName(this, tr("Open an alignment file"), lod.dir, DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, true));
+    lod.url = U2FileDialog::getOpenFileName(this, tr("Open an alignment file"), lod.dir, FileFilters::createFileFilterByObjectTypes({GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT}));
     if (lod.url.isEmpty()) {
         return;
     }

--- a/src/plugins_3rdparty/umuscle/src/MuscleAlignDialogController.h
+++ b/src/plugins_3rdparty/umuscle/src/MuscleAlignDialogController.h
@@ -22,15 +22,13 @@
 #ifndef _U2_MUSCLE_ALIGN_DIALOG_CONTROLLER_H_
 #define _U2_MUSCLE_ALIGN_DIALOG_CONTROLLER_H_
 
-#include <ui_MuscleAlignDialog.h>
-
 #include <QDialog>
 
 #include <U2Core/GAutoDeleteList.h>
 
-#include <U2Gui/DialogUtils.h>
-
 #include "MuscleTask.h"
+
+#include <ui_MuscleAlignDialog.h>
 
 namespace U2 {
 

--- a/src/plugins_3rdparty/umuscle/src/MusclePlugin.cpp
+++ b/src/plugins_3rdparty/umuscle/src/MusclePlugin.cpp
@@ -25,10 +25,10 @@
 #include <QMainWindow>
 
 #include <U2Algorithm/AlignmentAlgorithmsRegistry.h>
-#include <U2Algorithm/BaseAlignmentAlgorithmsIds.h>
 
 #include <U2Core/AppContext.h>
 #include <U2Core/DocumentModel.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GAutoDeleteList.h>
 #include <U2Core/MultipleSequenceAlignmentObject.h>
 #include <U2Core/QObjectScopedPointer.h>
@@ -45,7 +45,6 @@
 #include <U2View/MaCollapseModel.h>
 #include <U2View/MaEditorFactory.h>
 #include <U2View/MaEditorSelection.h>
-#include <U2View/RealignSequencesInAlignmentTask.h>
 
 #include "MuscleAlignDialogController.h"
 #include "MuscleTask.h"
@@ -185,7 +184,7 @@ void MuscleMSAEditorContext::sl_align() {
     }
 
     AlignGObjectTask *muscleTask = new MuscleGObjectRunFromSchemaTask(obj, s);
-    Task *alignTask = nullptr;
+    Task *alignTask;
 
     if (dlg->translateToAmino()) {
         QString trId = dlg->getTranslationId();
@@ -208,9 +207,7 @@ void MuscleMSAEditorContext::sl_alignSequencesToProfile() {
     MultipleSequenceAlignmentObject *msaObject = msaEditor->getMaObject();
 
     DocumentFormatConstraints c;
-    QString f1 = DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, false);
-    QString f2 = DialogUtils::prepareDocumentsFileFilterByObjType(GObjectTypes::SEQUENCE, true);
-    QString filter = f2 + "\n" + f1;
+    QString filter = FileFilters::createFileFilterByObjectTypes({GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, GObjectTypes::SEQUENCE});
 
     LastUsedDirHelper lod;
     lod.url = U2FileDialog::getOpenFileName(nullptr, tr("Select file with sequences"), lod, filter);
@@ -231,7 +228,7 @@ void MuscleMSAEditorContext::sl_alignProfileToProfile() {
     MultipleSequenceAlignmentObject *obj = ed->getMaObject();
     assert(!obj->isStateLocked());
 
-    QString filter = DialogUtils::prepareDocumentsFileFilterByObjTypes({GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, GObjectTypes::SEQUENCE}, true);
+    QString filter = FileFilters::createFileFilterByObjectTypes({GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, GObjectTypes::SEQUENCE});
     LastUsedDirHelper lod;
     lod.url = U2FileDialog::getOpenFileName(nullptr, tr("Select file with alignment"), lod, filter);
 

--- a/src/ugeneui/src/project_support/ProjectLoaderImpl.cpp
+++ b/src/ugeneui/src/project_support/ProjectLoaderImpl.cpp
@@ -34,6 +34,7 @@
 #include <U2Core/CMDLineUtils.h>
 #include <U2Core/DocumentImport.h>
 #include <U2Core/DocumentUtils.h>
+#include <U2Core/FileFilters.h>
 #include <U2Core/GHints.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/IOAdapter.h>
@@ -227,12 +228,10 @@ void ProjectLoaderImpl::sl_newProject() {
 
 void ProjectLoaderImpl::sl_openProject() {
     LastUsedDirHelper h;
-    QString filter = DialogUtils::prepareDocumentsFileFilter(true);
-
-    filter.append("\n" + tr("UGENE project file") + " (*" + PROJECTFILE_EXT + ")");
+    QMap<QString, QStringList> extraFormats = {{tr("UGENE project file"), {PROJECTFILE_EXT}}};
+    QString filter = FileFilters::createAllSupportedFormatsFileFilter(extraFormats);
 
     QStringList files;
-
     if (qgetenv(ENV_GUI_TEST).toInt() == 1 && qgetenv(ENV_USE_NATIVE_DIALOGS).toInt() == 0) {
         files = U2FileDialog::getOpenFileNames(QApplication::activeWindow(), tr("Select files to open"), h.dir, filter, 0, QFileDialog::DontUseNativeDialog);
     } else {
@@ -989,7 +988,7 @@ Project *ProjectLoaderImpl::createProject(const QString &name, const QString &ur
 
 void ProjectLoaderImpl::sl_onAddExistingDocument() {
     LastUsedDirHelper h;
-    QString filter = DialogUtils::prepareDocumentsFileFilter(true);
+    QString filter = FileFilters::createAllSupportedFormatsFileFilter();
     QString file = U2FileDialog::getOpenFileName(nullptr, tr("Select files to open"), h.dir, filter);
     if (file.isEmpty()) {
         return;

--- a/src/ugeneui/src/project_support/ProjectServiceImpl.cpp
+++ b/src/ugeneui/src/project_support/ProjectServiceImpl.cpp
@@ -27,12 +27,10 @@
 #include <QToolBar>
 
 #include <U2Core/GUrlUtils.h>
-#include <U2Core/L10n.h>
 #include <U2Core/QObjectScopedPointer.h>
 #include <U2Core/Settings.h>
 #include <U2Core/U2OpStatusUtils.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/GUIUtils.h>
 #include <U2Gui/MainWindow.h>
 

--- a/src/ugeneui/src/project_view/ProjectViewImpl.cpp
+++ b/src/ugeneui/src/project_view/ProjectViewImpl.cpp
@@ -21,29 +21,21 @@
 
 #include <AppContextImpl.h>
 
-#include <QClipboard>
 #include <QDesktopServices>
 #include <QMainWindow>
 #include <QMessageBox>
 #include <QTimer>
 #include <QUrl>
 
-#include <U2Core/AddDocumentTask.h>
 #include <U2Core/AppSettings.h>
-#include <U2Core/CopyDataTask.h>
-#include <U2Core/CopyDocumentTask.h>
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DNASequenceObject.h>
 #include <U2Core/DbiDocumentFormat.h>
 #include <U2Core/DocumentImport.h>
-#include <U2Core/DocumentUtils.h>
 #include <U2Core/GObject.h>
-#include <U2Core/GObjectTypes.h>
 #include <U2Core/GObjectUtils.h>
 #include <U2Core/GUrl.h>
 #include <U2Core/GUrlUtils.h>
-#include <U2Core/IOAdapter.h>
-#include <U2Core/IOAdapterUtils.h>
 #include <U2Core/L10n.h>
 #include <U2Core/LoadDocumentTask.h>
 #include <U2Core/LocalFileAdapter.h>
@@ -52,18 +44,12 @@
 #include <U2Core/ProjectModel.h>
 #include <U2Core/ProjectService.h>
 #include <U2Core/QObjectScopedPointer.h>
-#include <U2Core/RemoveDocumentTask.h>
-#include <U2Core/U2SafePoints.h>
 #include <U2Core/SaveDocumentTask.h>
 #include <U2Core/SelectionUtils.h>
 #include <U2Core/Settings.h>
-#include <U2Core/StringAdapter.h>
-#include <U2Core/TaskSignalMapper.h>
-#include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
 #include <U2Core/UserApplicationsSettings.h>
 
-#include <U2Gui/DialogUtils.h>
 #include <U2Gui/ExportDocumentDialogController.h>
 #include <U2Gui/ExportObjectUtils.h>
 #include <U2Gui/GUIUtils.h>
@@ -72,9 +58,7 @@
 #include <U2Gui/OpenViewTask.h>
 #include <U2Gui/ProjectUtils.h>
 #include <U2Gui/ReloadDocumentsTask.h>
-#include <U2Gui/UnloadDocumentTask.h>
 
-#include <U2View/ADVSequenceWidget.h>
 #include <U2View/ADVSingleSequenceWidget.h>
 #include <U2View/AnnotatedDNAView.h>
 


### PR DESCRIPTION
Please read the discussion in the bug. The main idea of the patch is that all File Open/Save dialogs should have non-restrictive "All files" option.

In this patch I move all filter creation code from 2 different places into a single file: FileFilters utils and make the filters list to always contain "All files" option.