### PR TITLE
Replace non-main threads ->click(), ->setText(), ->setChecked() with …

### DIFF
--- a/src/corelibs/U2View/src/util_dna_assembly/BuildIndexFromRefDialog.ui
+++ b/src/corelibs/U2View/src/util_dna_assembly/BuildIndexFromRefDialog.ui
@@ -112,9 +112,6 @@
          <property name="toolTip">
           <string>Specify the index to build for the reference sequence. This parameter is &lt;b&gt;required&lt;/b&gt;.</string>
          </property>
-         <property name="readOnly">
-          <bool>true</bool>
-         </property>
         </widget>
        </item>
        <item row="1" column="2">

--- a/src/libs_3rdparty/QSpec/src/primitives/GTCheckBox.cpp
+++ b/src/libs_3rdparty/QSpec/src/primitives/GTCheckBox.cpp
@@ -30,6 +30,9 @@ namespace HI {
 #define GT_METHOD_NAME "setChecked"
 void GTCheckBox::setChecked(GUITestOpStatus &os, QCheckBox *checkBox, bool checked) {
     GT_CHECK(checkBox != nullptr, "QCheckBox == NULL");
+    if (checkBox->isChecked() == checked) {  // TODO: this should not be used this way: setChecked() must not be called on the disabled checkbox.
+        return;
+    }
     GT_CHECK(checkBox->isEnabled(), "QCheckBox is disabled: " + checkBox->objectName());
 
     if (checked != checkBox->isChecked()) {

--- a/src/libs_3rdparty/QSpec/src/primitives/GTCheckBox.cpp
+++ b/src/libs_3rdparty/QSpec/src/primitives/GTCheckBox.cpp
@@ -29,20 +29,19 @@ namespace HI {
 
 #define GT_METHOD_NAME "setChecked"
 void GTCheckBox::setChecked(GUITestOpStatus &os, QCheckBox *checkBox, bool checked) {
-    GT_CHECK(checkBox != NULL, "QCheckBox == NULL");
-    if (checkBox->isChecked() == checked) {
-        return;
-    }
-    GT_CHECK(checkBox->isEnabled(), "QcheckBox is disabled");
+    GT_CHECK(checkBox != nullptr, "QCheckBox == NULL");
+    GT_CHECK(checkBox->isEnabled(), "QCheckBox is disabled: " + checkBox->objectName());
 
-    bool checkBoxState = checkBox->isChecked();
-    if (checked != checkBoxState) {
-        QPoint p = QPoint(5, checkBox->rect().height() / 2);
-        GTWidget::click(os, checkBox, Qt::LeftButton, p);
+    if (checked != checkBox->isChecked()) {
+        GTWidget::click(os, checkBox, Qt::LeftButton, {5, checkBox->rect().height() / 2});
     }
-    GTGlobals::sleep(500);
-
-    GT_CHECK(checked == checkBox->isChecked(), "Can't set checked state");
+    // Wait up to 5 seconds for the checked state to be updated.
+    bool isChecked = checkBox->isChecked();
+    for (int time = 0; time <= 5000 && isChecked != checked; time += 100) {
+        GTGlobals::sleep(100);
+        isChecked = checkBox->isChecked();
+    }
+    GT_CHECK(checked == isChecked, "Can't set checked state: " + checkBox->objectName());
 }
 #undef GT_METHOD_NAME
 
@@ -53,7 +52,7 @@ void GTCheckBox::setChecked(GUITestOpStatus &os, const QString &checkBoxName, bo
 #undef GT_METHOD_NAME
 
 #define GT_METHOD_NAME "setChecked"
-void GTCheckBox::setChecked(GUITestOpStatus &os, const QString &checkBoxName, QWidget  *parent) {
+void GTCheckBox::setChecked(GUITestOpStatus &os, const QString &checkBoxName, QWidget *parent) {
     GTCheckBox::setChecked(os, GTWidget::findExactWidget<QCheckBox *>(os, checkBoxName, parent));
 }
 #undef GT_METHOD_NAME
@@ -82,7 +81,7 @@ void GTCheckBox::checkState(GUITestOpStatus &os, QCheckBox const *const checkBox
 #undef GT_METHOD_NAME
 
 #define GT_METHOD_NAME "checkState"
-void GTCheckBox::checkState(GUITestOpStatus &os, const QString &checkBoxName, bool expectedState, QWidget  *parent) {
+void GTCheckBox::checkState(GUITestOpStatus &os, const QString &checkBoxName, bool expectedState, QWidget *parent) {
     checkState(os, GTWidget::findExactWidget<QCheckBox *>(os, checkBoxName, parent), expectedState);
 }
 #undef GT_METHOD_NAME

--- a/src/libs_3rdparty/QSpec/src/primitives/GTLineEdit.cpp
+++ b/src/libs_3rdparty/QSpec/src/primitives/GTLineEdit.cpp
@@ -31,6 +31,11 @@ namespace HI {
 
 #define GT_METHOD_NAME "setText"
 void GTLineEdit::setText(GUITestOpStatus &os, QLineEdit *lineEdit, const QString &text, bool noCheck /* = false*/, bool useCopyPaste) {
+    GT_CHECK(lineEdit != nullptr, "lineEdit is NULL");
+    GT_CHECK(!lineEdit->isReadOnly(), "lineEdit is read-only: " + lineEdit->objectName());
+    if (lineEdit->text() == text) {
+        return;
+    }
     clear(os, lineEdit);
 
     if (useCopyPaste) {

--- a/src/libs_3rdparty/QSpec/src/primitives/GTLineEdit.cpp
+++ b/src/libs_3rdparty/QSpec/src/primitives/GTLineEdit.cpp
@@ -25,48 +25,36 @@
 #include "primitives/GTWidget.h"
 #include "system/GTClipboard.h"
 #include "utils/GTKeyboardUtils.h"
-#include "utils/GTThread.h"
 
 namespace HI {
 #define GT_CLASS_NAME "GTLineEdit"
 
 #define GT_METHOD_NAME "setText"
-void GTLineEdit::setText(GUITestOpStatus &os, QLineEdit *lineEdit, const QString &str, bool noCheck /* = false*/, bool useCopyPaste) {
-    GT_CHECK(lineEdit != NULL, "lineEdit is NULL");
-    if (lineEdit->text() == str) {
-        return;
-    }
-
-    GTWidget::setFocus(os, lineEdit);
-    if (lineEdit->text() == str) {
-        return;
-    }
-    if (!lineEdit->text().isEmpty()) {
-        clear(os, lineEdit);
-    }
+void GTLineEdit::setText(GUITestOpStatus &os, QLineEdit *lineEdit, const QString &text, bool noCheck /* = false*/, bool useCopyPaste) {
+    clear(os, lineEdit);
 
     if (useCopyPaste) {
-        GTClipboard::setText(os, str);
+        GTClipboard::setText(os, text);
         GTKeyboardDriver::keyClick('v', Qt::ControlModifier);
     } else {
-        GTKeyboardDriver::keySequence(str);
+        GTKeyboardDriver::keySequence(text);
     }
-    GTGlobals::sleep(500);
-
     if (noCheck) {
+        GTGlobals::sleep(500);
         return;
     }
 
-    QString s = lineEdit->text();
-    for (int i = 0; i <= 10 && (s != str); i++) {
-        GTGlobals::sleep(500);
-        s = lineEdit->text();
+    // Wait up to 5 seconds for the text to be updated.
+    QString currentText = lineEdit->text();
+    for (int time = 0; time <= 5000 && currentText != text; time += 100) {
+        GTGlobals::sleep(100);
+        currentText = lineEdit->text();
     }
-    GT_CHECK(s == str, QString("Can't set text, set text differs from a given string in lineEdit '%1'. "
-                               "Expected '%2', got '%3'")
-                           .arg(lineEdit->objectName())
-                           .arg(str)
-                           .arg(s));
+    GT_CHECK(currentText == text, QString("Can't set text, current text is different from a given input in lineEdit '%1'. "
+                                          "Expected '%2', got '%3'")
+                                      .arg(lineEdit->objectName())
+                                      .arg(text)
+                                      .arg(currentText));
 }
 #undef GT_METHOD_NAME
 
@@ -78,39 +66,42 @@ void GTLineEdit::setText(GUITestOpStatus &os, const QString &lineEditName, const
 
 #define GT_METHOD_NAME "getText"
 QString GTLineEdit::getText(GUITestOpStatus &os, QLineEdit *lineEdit) {
-    Q_UNUSED(os);
-    GT_CHECK_RESULT(lineEdit != NULL, "lineEdit is NULL", "");
+    GT_CHECK_RESULT(lineEdit != nullptr, "lineEdit is NULL", "");
     return lineEdit->text();
 }
 #undef GT_METHOD_NAME
 
 #define GT_METHOD_NAME "getText"
 QString GTLineEdit::getText(GUITestOpStatus &os, const QString &lineEditName, QWidget *parent) {
-    return getText(os, GTWidget::findExactWidget<QLineEdit *>(os, lineEditName, parent));
+    return getText(os, GTWidget::findLineEdit(os, lineEditName, parent));
 }
 #undef GT_METHOD_NAME
 
 #define GT_METHOD_NAME "clear"
 void GTLineEdit::clear(GUITestOpStatus &os, QLineEdit *lineEdit) {
-    GT_CHECK(lineEdit != NULL, "lineEdit is NULL");
+    GT_CHECK(lineEdit != nullptr, "lineEdit is NULL");
+    GT_CHECK(!lineEdit->isReadOnly(), "lineEdit is read-only: " + lineEdit->objectName());
 
     GTWidget::setFocus(os, lineEdit);
-
+    if (lineEdit->text().isEmpty()) {
+        return;
+    }
     GTKeyboardUtils::selectAll();
     GTGlobals::sleep(100);
     GTKeyboardDriver::keyClick(Qt::Key_Delete);
-    GTGlobals::sleep(100);
-    GTThread::waitForMainThread();
 
-    QString s = lineEdit->text();
-    GT_CHECK(s.isEmpty() == true, "Can't clear text, lineEdit is not empty");
+    // Wait up to 5 seconds for the text to be cleaned.
+    QString currentText = lineEdit->text();
+    for (int time = 0; time <= 5000 && !currentText.isEmpty(); time += 100) {
+        GTGlobals::sleep(100);
+        currentText = lineEdit->text();
+    }
+    GT_CHECK(currentText.isEmpty(), "Can't clear text, lineEdit is not empty: " + currentText);
 }
 #undef GT_METHOD_NAME
 
 #define GT_METHOD_NAME "pasteClipboard"
 void GTLineEdit::pasteClipboard(GUITestOpStatus &os, QLineEdit *lineEdit, PasteMethod pasteMethod) {
-    GT_CHECK(lineEdit != NULL, "lineEdit is NULL");
-
     clear(os, lineEdit);
     switch (pasteMethod) {
         case Mouse:
@@ -127,57 +118,35 @@ void GTLineEdit::pasteClipboard(GUITestOpStatus &os, QLineEdit *lineEdit, PasteM
 }
 #undef GT_METHOD_NAME
 
-#define GT_METHOD_NAME "checkTextSize"
-void GTLineEdit::checkTextSize(GUITestOpStatus &os, QLineEdit *lineEdit) {
-    GT_CHECK(lineEdit != NULL, "lineEdit is NULL");
-
-    QMargins lineEditMargins = lineEdit->textMargins();
-    QFontMetrics fontMetrics = lineEdit->fontMetrics();
-    int textWidth = lineEditMargins.left() + lineEditMargins.right() + fontMetrics.width(lineEdit->text());
-    int rectWidth = lineEdit->rect().width();
-
-    GT_CHECK(textWidth <= rectWidth, "GTLineEdit::checkTextSize: Text is not inside LineEdit's rect");
-}
-#undef GT_METHOD_NAME
-
 #define GT_METHOD_NAME "checkText"
 void GTLineEdit::checkText(GUITestOpStatus &os, QLineEdit *lineEdit, const QString &expectedText) {
-    Q_UNUSED(os);
-    GT_CHECK(NULL != lineEdit, "Line edit is NULL");
+    GT_CHECK(lineEdit != nullptr, "Line edit is NULL");
     GT_CHECK(expectedText == lineEdit->text(), QString("The text differs: expect '%1', got '%2'").arg(expectedText).arg(lineEdit->text()));
 }
 #undef GT_METHOD_NAME
 
 #define GT_METHOD_NAME "checkText"
 void GTLineEdit::checkText(GUITestOpStatus &os, const QString &lineEditName, QWidget *parent, const QString &expectedText) {
-    checkText(os, GTWidget::findExactWidget<QLineEdit *>(os, lineEditName, parent), expectedText);
+    checkText(os, GTWidget::findLineEdit(os, lineEditName, parent), expectedText);
 }
 #undef GT_METHOD_NAME
 
 #define GT_METHOD_NAME "copyText"
 QString GTLineEdit::copyText(GUITestOpStatus &os, QLineEdit *lineEdit) {
-    GT_CHECK_RESULT(lineEdit != NULL, "lineEdit is NULL", QString());
+    GT_CHECK_RESULT(lineEdit != nullptr, "lineEdit is NULL", QString());
     return lineEdit->text();
 }
 #undef GT_METHOD_NAME
 
 #define GT_METHOD_NAME "tryToSetText"
-bool GTLineEdit::tryToSetText(GUITestOpStatus &os, QLineEdit *lineEdit, const QString &str) {
-    GT_CHECK_RESULT(lineEdit != NULL, "lineEdit is NULL", false);
-    GTWidget::setFocus(os, lineEdit);
-    if (lineEdit->text() == str) {
-        return true;
-    }
+bool GTLineEdit::tryToSetText(GUITestOpStatus &os, QLineEdit *lineEdit, const QString &text) {
+    clear(os, lineEdit);
 
-    if (!lineEdit->text().isEmpty()) {
-        clear(os, lineEdit);
-    }
-
-    GTKeyboardDriver::keySequence(str);
+    GTKeyboardDriver::keySequence(text);
     GTGlobals::sleep(500);
 
-    QString s = lineEdit->text();
-    return s == str;
+    QString currentText = lineEdit->text();
+    return currentText == text;
 }
 #undef GT_METHOD_NAME
 

--- a/src/libs_3rdparty/QSpec/src/primitives/GTLineEdit.h
+++ b/src/libs_3rdparty/QSpec/src/primitives/GTLineEdit.h
@@ -41,7 +41,7 @@ public:
     static void setText(GUITestOpStatus &os, QLineEdit *lineEdit, const QString &str, bool noCheck = false, bool useCopyPaste = true);
     static void setText(GUITestOpStatus &os, const QString &lineEditName, const QString &text, QWidget  *parent, bool noCheck = false, bool useCopyPaste = true);
 #else
-    static void setText(GUITestOpStatus &os, QLineEdit *lineEdit, const QString &str, bool noCheck = false, bool useCopyPaste = false);
+    static void setText(GUITestOpStatus &os, QLineEdit *lineEdit, const QString &text, bool noCheck = false, bool useCopyPaste = false);
     static void setText(GUITestOpStatus &os, const QString &lineEditName, const QString &text, QWidget  *parent, bool noCheck = false, bool useCopyPaste = false);
 #endif
     static QString getText(GUITestOpStatus &os, QLineEdit *lineEdit);
@@ -55,7 +55,6 @@ public:
 
     // fails if lineEdit is NULL or lineEdit text is not in lineEdit's rect
     // considering lineEdit's fontMetrics and textMargins
-    static void checkTextSize(GUITestOpStatus &os, QLineEdit *lineEdit);
     static void checkText(GUITestOpStatus &os, QLineEdit *lineEdit, const QString &expectedText);
     static void checkText(GUITestOpStatus &os, const QString &lineEditName, QWidget  *parent, const QString &expectedText);
 
@@ -63,7 +62,7 @@ public:
 
     // fails if lineEdit is NULL
     // checks if str can be pasted in lineEdit
-    static bool tryToSetText(GUITestOpStatus &os, QLineEdit *lineEdit, const QString &str);
+    static bool tryToSetText(GUITestOpStatus &os, QLineEdit *lineEdit, const QString &text);
 };
 
 }  // namespace HI

--- a/src/libs_3rdparty/QSpec/src/primitives/GTRadioButton.cpp
+++ b/src/libs_3rdparty/QSpec/src/primitives/GTRadioButton.cpp
@@ -53,7 +53,7 @@ void GTRadioButton::click(GUITestOpStatus &os, QRadioButton *radioButton) {
 
 #define GT_METHOD_NAME "click"
 void GTRadioButton::click(GUITestOpStatus &os, const QString &radioButtonName, QWidget *parent) {
-    click(os, GTWidget::findExactWidget<QRadioButton *>(os, radioButtonName, parent));
+    click(os, GTWidget::findRadioButton(os, radioButtonName, parent));
 }
 #undef GT_METHOD_NAME
 

--- a/src/libs_3rdparty/QSpec/src/primitives/GTWidget.cpp
+++ b/src/libs_3rdparty/QSpec/src/primitives/GTWidget.cpp
@@ -116,6 +116,10 @@ QRadioButton *GTWidget::findRadioButton(GUITestOpStatus &os, const QString &widg
     return findExactWidget<QRadioButton *>(os, widgetName, parentWidget, options);
 }
 
+QGroupBox *GTWidget::findGroupBox(GUITestOpStatus &os, const QString &widgetName, QWidget *parentWidget, const GTGlobals::FindOptions &options) {
+    return findExactWidget<QGroupBox *>(os, widgetName, parentWidget, options);
+}
+
 QLineEdit *GTWidget::findLineEdit(GUITestOpStatus &os, const QString &widgetName, QWidget *parentWidget, const GTGlobals::FindOptions &options) {
     return findExactWidget<QLineEdit *>(os, widgetName, parentWidget, options);
 }
@@ -126,6 +130,10 @@ QTextEdit *GTWidget::findTextEdit(GUITestOpStatus &os, const QString &widgetName
 
 QTableWidget *GTWidget::findTableWidget(GUITestOpStatus &os, const QString &widgetName, QWidget *parentWidget, const GTGlobals::FindOptions &options) {
     return findExactWidget<QTableWidget *>(os, widgetName, parentWidget, options);
+}
+
+QTabWidget *GTWidget::findTabWidget(GUITestOpStatus &os, const QString &widgetName, QWidget *parentWidget, const GTGlobals::FindOptions &options) {
+    return findExactWidget<QTabWidget *>(os, widgetName, parentWidget, options);
 }
 
 QPlainTextEdit *GTWidget::findPlainTextEdit(GUITestOpStatus &os, const QString &widgetName, QWidget *parentWidget, const GTGlobals::FindOptions &options) {

--- a/src/libs_3rdparty/QSpec/src/primitives/GTWidget.h
+++ b/src/libs_3rdparty/QSpec/src/primitives/GTWidget.h
@@ -32,6 +32,7 @@
 #include <QComboBox>
 #include <QCoreApplication>
 #include <QGraphicsView>
+#include <QGroupBox>
 #include <QLabel>
 #include <QLineEdit>
 #include <QMenu>
@@ -134,6 +135,9 @@ public:
     /** Calls findExactWidget with QRadioButton type. Shortcut method. */
     static QRadioButton *findRadioButton(GUITestOpStatus &os, const QString &widgetName, QWidget *parentWidget = nullptr, const GTGlobals::FindOptions &options = {});
 
+    /** Calls findExactWidget with QGroupBox type. Shortcut method. */
+    static QGroupBox *findGroupBox(GUITestOpStatus &os, const QString &widgetName, QWidget *parentWidget = nullptr, const GTGlobals::FindOptions &options = {});
+
     /** Calls findExactWidget with QLineEdit type. Shortcut method. */
     static QLineEdit *findLineEdit(GUITestOpStatus &os, const QString &widgetName, QWidget *parentWidget = nullptr, const GTGlobals::FindOptions &options = {});
 
@@ -142,6 +146,9 @@ public:
 
     /** Calls findExactWidget with QTableWidget type. Shortcut method. */
     static QTableWidget *findTableWidget(GUITestOpStatus &os, const QString &widgetName, QWidget *parentWidget = nullptr, const GTGlobals::FindOptions &options = {});
+
+    /** Calls findExactWidget with QTabWidget type. Shortcut method. */
+    static QTabWidget *findTabWidget(GUITestOpStatus &os, const QString &widgetName, QWidget *parentWidget = nullptr, const GTGlobals::FindOptions &options = {});
 
     /** Calls findExactWidget with QPlainTextEdit type. Shortcut method. */
     static QPlainTextEdit *findPlainTextEdit(GUITestOpStatus &os, const QString &widgetName, QWidget *parentWidget = nullptr, const GTGlobals::FindOptions &options = {});

--- a/src/plugins/GUITestBase/src/GTUtilsAssemblyBrowser.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsAssemblyBrowser.cpp
@@ -325,14 +325,13 @@ void GTUtilsAssemblyBrowser::scrollToStart(GUITestOpStatus &os, Qt::Orientation 
     QScrollBar *scrollBar = getScrollBar(os, orientation);
     class MainThreadAction : public CustomScenario {
     public:
-        MainThreadAction(QScrollBar *scrollbar)
-            : CustomScenario(), scrollbar(scrollbar) {
+        MainThreadAction(QScrollBar *_scrollbar)
+            : scrollbar(_scrollbar) {
         }
-        void run(HI::GUITestOpStatus &os) {
-            Q_UNUSED(os);
+        void run(HI::GUITestOpStatus &) override {
             scrollbar->setValue(0);
         }
-        QScrollBar *scrollbar;
+        QScrollBar *scrollbar = nullptr;
     };
     GTThread::runInMainThread(os, new MainThreadAction(scrollBar));
     GTThread::waitForMainThread();

--- a/src/plugins/GUITestBase/src/GTUtilsOptionPanelMca.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsOptionPanelMca.cpp
@@ -30,7 +30,6 @@
 #include <QApplication>
 #include <QComboBox>
 #include <QLabel>
-#include <QToolButton>
 
 #include "GTUtilsMcaEditor.h"
 #include "GTUtilsOptionPanelMca.h"
@@ -170,16 +169,14 @@ void GTUtilsOptionPanelMca::setFileFormat(HI::GUITestOpStatus &os, FileFormat fi
 #define GT_METHOD_NAME "pushResetButton"
 void GTUtilsOptionPanelMca::pushResetButton(HI::GUITestOpStatus &os) {
     openTab(os, Consensus);
-    QToolButton *result = GTWidget::findExactWidget<QToolButton *>(os, "thresholdResetButton");
-    result->click();
+    GTWidget::click(os, GTWidget::findToolButton(os, "thresholdResetButton"));
 }
 #undef GT_METHOD_NAME
 
 #define GT_METHOD_NAME "pushExportButton"
 void GTUtilsOptionPanelMca::pushExportButton(HI::GUITestOpStatus &os) {
     openTab(os, Consensus);
-    QToolButton *result = GTWidget::findExactWidget<QToolButton *>(os, "exportBtn");
-    result->click();
+    GTWidget::click(os, GTWidget::findToolButton(os, "exportBtn"));
 }
 #undef GT_METHOD_NAME
 

--- a/src/plugins/GUITestBase/src/GTUtilsProjectTreeView.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsProjectTreeView.cpp
@@ -192,14 +192,13 @@ void GTUtilsProjectTreeView::scrollToIndexAndMakeExpanded(HI::GUITestOpStatus &o
 
     class MainThreadActionExpand : public CustomScenario {
     public:
-        MainThreadActionExpand(QTreeView *treeView, const QModelIndex &index)
-            : CustomScenario(), treeView(treeView), index(index) {
+        MainThreadActionExpand(QTreeView *_treeView, const QModelIndex &_index)
+            : treeView(_treeView), index(_index) {
         }
-        void run(HI::GUITestOpStatus &os) {
-            Q_UNUSED(os);
+        void run(HI::GUITestOpStatus &) override {
             treeView->setExpanded(index, true);
         }
-        QTreeView *treeView;
+        QTreeView *treeView = nullptr;
         QModelIndex index;
     };
 

--- a/src/plugins/GUITestBase/src/base_dialogs/GTFileDialog.cpp
+++ b/src/plugins/GUITestBase/src/base_dialogs/GTFileDialog.cpp
@@ -47,7 +47,7 @@
 namespace HI {
 #define GT_CLASS_NAME "GTFileDialogUtils"
 
-GTFileDialogUtils::GTFileDialogUtils(GUITestOpStatus &_os, const QString &_path, const QString &_fileName, Button _button, GTGlobals::UseMethod _method, TextInput textInput, const QString& _filter)
+GTFileDialogUtils::GTFileDialogUtils(GUITestOpStatus &_os, const QString &_path, const QString &_fileName, Button _button, GTGlobals::UseMethod _method, TextInput textInput, const QString &_filter)
     : Filler(_os, "QFileDialog"),
       fileName(_fileName),
       button(_button),
@@ -57,7 +57,7 @@ GTFileDialogUtils::GTFileDialogUtils(GUITestOpStatus &_os, const QString &_path,
     init(_path + "/" + fileName);
 }
 
-GTFileDialogUtils::GTFileDialogUtils(GUITestOpStatus &os, const QString &filePath, GTGlobals::UseMethod method, Button b, TextInput textInput, const QString& _filter)
+GTFileDialogUtils::GTFileDialogUtils(GUITestOpStatus &os, const QString &filePath, GTGlobals::UseMethod method, Button b, TextInput textInput, const QString &_filter)
     : Filler(os, "QFileDialog"),
       button(b),
       method(method),
@@ -335,7 +335,7 @@ void GTFileDialogUtils::applyFilter() {
     }
 
     GTGlobals::sleep(300);
-    QComboBox* comboBox = GTWidget::findComboBox(os, FILE_TYPE_COMBO_BOX, fileDialog);
+    QComboBox *comboBox = GTWidget::findComboBox(os, FILE_TYPE_COMBO_BOX, fileDialog);
     GTComboBox::selectItemByText(os, comboBox, filter, GTGlobals::UseMouse);
 }
 #undef GT_METHOD_NAME

--- a/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/BuildIndexDialogFiller.cpp
+++ b/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/BuildIndexDialogFiller.cpp
@@ -26,34 +26,27 @@
 #include <primitives/GTWidget.h>
 
 #include <QApplication>
-#include <QComboBox>
 #include <QDialogButtonBox>
-#include <QLineEdit>
-#include <QPushButton>
 
 namespace U2 {
 
 #define GT_CLASS_NAME "GTUtilsDialog::BuildIndexDialogFiller"
 #define GT_METHOD_NAME "commonScenario"
 void BuildIndexDialogFiller::commonScenario() {
-    QWidget *dialog = QApplication::activeModalWidget();
-    GT_CHECK(dialog, "activeModalWidget is NULL");
+    auto dialog = GTWidget::getActiveModalWidget(os);
 
-    QComboBox *methodNamesBox = dialog->findChild<QComboBox *>("methodNamesBox");
+    auto methodNamesBox = GTWidget::findComboBox(os, "methodNamesBox", dialog);
     for (int i = 0; i < methodNamesBox->count(); i++) {
         if (methodNamesBox->itemText(i) == method) {
             GTComboBox::selectItemByIndex(os, methodNamesBox, i);
         }
     }
 
-    GTFileDialogUtils *ob = new GTFileDialogUtils(os, refPath, refFileName);
-    GTUtilsDialog::waitForDialog(os, ob);
+    GTUtilsDialog::waitForDialog(os, new GTFileDialogUtils(os, refPath, refFileName));
     GTWidget::click(os, GTWidget::findWidget(os, "addRefButton", dialog));
 
     if (!useDefaultIndexName) {
-        QLineEdit *indexFileNameEdit = dialog->findChild<QLineEdit *>("indexFileNameEdit");
-        indexFileNameEdit->clear();
-        indexFileNameEdit->setText(indPath + indFileName);
+        GTLineEdit::setText(os, "indexFileNameEdit", indPath + indFileName, dialog);
     }
 
     GTUtilsDialog::clickButtonBox(os, dialog, QDialogButtonBox::Ok);

--- a/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/CreateDocumentFromTextDialogFiller.cpp
+++ b/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/CreateDocumentFromTextDialogFiller.cpp
@@ -25,15 +25,14 @@
 #include <primitives/GTGroupBox.h>
 #include <primitives/GTLineEdit.h>
 #include <primitives/GTPlainTextEdit.h>
+#include <primitives/GTRadioButton.h>
 #include <primitives/GTWidget.h>
 #include <utils/GTThread.h>
 
 #include <QApplication>
 #include <QDialogButtonBox>
 #include <QDir>
-#include <QGroupBox>
 #include <QPushButton>
-#include <QRadioButton>
 
 #include <U2Core/Log.h>
 
@@ -98,26 +97,17 @@ void CreateDocumentFiller::commonScenario() {
     GTGlobals::sleep();
 
     if (customSettings) {
-        QGroupBox *customSettingsCheckBox = qobject_cast<QGroupBox *>(GTWidget::findWidget(os, "groupBox", dialog));
-        GTGroupBox::setChecked(os, customSettingsCheckBox, true);
-
-        QComboBox *alphabetComboBox = qobject_cast<QComboBox *>(GTWidget::findWidget(os, "alphabetBox", dialog));
-        GT_CHECK(alphabetComboBox != nullptr, "ComboBox not found");
-
+        GTGroupBox::setChecked(os, GTWidget::findGroupBox(os, "groupBox", dialog), true);
         if (skipUnknownSymbols) {
-            QRadioButton *skipUnknownSymbols = qobject_cast<QRadioButton *>(GTWidget::findWidget(os, "skipRB", dialog));
-            skipUnknownSymbols->setChecked(true);
+            GTRadioButton::click(os, "skipRB", dialog);
         } else if (replaceUnknownSymbols) {
-            QRadioButton *replaceUnknownSymbols = qobject_cast<QRadioButton *>(GTWidget::findWidget(os, "replaceRB", dialog));
-            replaceUnknownSymbols->setChecked(true);
-
-            QLineEdit *lineEdit = dialog->findChild<QLineEdit *>("symbolToReplaceEdit");
-            GT_CHECK(lineEdit != nullptr, "line edit not found");
-            GTLineEdit::setText(os, lineEdit, symbol);
+            GTRadioButton::click(os, "replaceRB", dialog);
+            GTLineEdit::setText(os, GTWidget::findLineEdit(os, "symbolToReplaceEdit", dialog), symbol);
         } else {
-            assert(false);  // replase skipUnknownSymbols and replaceUnknownSymbols variables with enum
+            GT_FAIL("Unsupported state", );  // replace skipUnknownSymbols and replaceUnknownSymbols variables with enum
         }
 
+        auto alphabetComboBox = GTWidget::findComboBox(os, "alphabetBox", dialog);
         int alphabetIndex = alphabetComboBox->findText(comboBoxAlphabetItems[alphabet]);
         GT_CHECK(alphabetIndex != -1, QString("item \"%1\" in combobox not found").arg(comboBoxAlphabetItems[alphabet]));
 
@@ -179,26 +169,18 @@ void CancelCreateDocumentFiller::commonScenario() {
     GTPlainTextEdit::setPlainText(os, plainText, pasteDataHere);
 
     if (customSettings) {
-        QGroupBox *customSettingsCheckBox = qobject_cast<QGroupBox *>(GTWidget::findWidget(os, "groupBox", dialog));
-        customSettingsCheckBox->setChecked(true);
-
-        QComboBox *alphabetComboBox = qobject_cast<QComboBox *>(GTWidget::findWidget(os, "alphabetBox", dialog));
-        GT_CHECK(alphabetComboBox != nullptr, "ComboBox not found");
+        GTGroupBox::setChecked(os, GTWidget::findGroupBox(os, "groupBox", dialog), true);
 
         if (skipUnknownSymbols) {
-            QRadioButton *skipUnknownSymbols = qobject_cast<QRadioButton *>(GTWidget::findWidget(os, "skipRB", dialog));
-            skipUnknownSymbols->setChecked(true);
+            GTRadioButton::click(os, "skipRB", dialog);
         } else if (replaceUnknownSymbols) {
-            QRadioButton *replaceUnknownSymbols = qobject_cast<QRadioButton *>(GTWidget::findWidget(os, "replaceRB", dialog));
-            replaceUnknownSymbols->setChecked(true);
-
-            QLineEdit *lineEdit = dialog->findChild<QLineEdit *>("symbolToReplaceEdit");
-            GT_CHECK(lineEdit != nullptr, "line edit not found");
-            GTLineEdit::setText(os, lineEdit, symbol);
+            GTRadioButton::click(os, "replaceRB", dialog);
+            GTLineEdit::setText(os, GTWidget::findLineEdit(os, "symbolToReplaceEdit", dialog), symbol);
         } else {
-            assert(false);  // replase skipUnknownSymbols and replaceUnknownSymbols variables with enum
+            GT_FAIL("Unsupported state", );
         }
 
+        auto alphabetComboBox = GTWidget::findComboBox(os, "alphabetBox", dialog);
         int alphabetIndex = alphabetComboBox->findText(comboBoxAlphabetItems[alphabet]);
         GT_CHECK(alphabetIndex != -1, QString("item \"%1\" in combobox not found").arg(comboBoxAlphabetItems[alphabet]));
 

--- a/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/ExportImageDialogFiller.cpp
+++ b/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/ExportImageDialogFiller.cpp
@@ -241,20 +241,16 @@ void SelectSubalignmentFiller::commonScenario() {
     GTMouseDriver::moveTo(p);
     GTMouseDriver::click();
     for (int i = 0; i < table->rowCount(); i++) {
-        foreach (QString s, msaRegion.sequences) {
-            QCheckBox *box = qobject_cast<QCheckBox *>(table->cellWidget(i, 0));
-            if (s == box->text()) {
+        for (const QString &sequence : qAsConst(msaRegion.sequences)) {
+            auto box = qobject_cast<QCheckBox *>(table->cellWidget(i, 0));
+            GT_CHECK(box != nullptr, "Not a QCheckBox cell");
+            if (sequence == box->text()) {
                 GT_CHECK(box->isEnabled(), QString("%1 box is disabled").arg(box->text()));
-                box->setChecked(true);
+                GTCheckBox::setChecked(os, box, true);
             }
         }
     }
-
-    QDialogButtonBox *box = dialog->findChild<QDialogButtonBox *>("buttonBox");
-    GT_CHECK(box != nullptr, "buttonBox is NULL");
-    QPushButton *ok = box->button(QDialogButtonBox::Ok);
-    GT_CHECK(ok != nullptr, "ok button is NULL");
-    GTWidget::click(os, ok);
+    GTUtilsDialog::clickButtonBox(os, dialog, QDialogButtonBox::Ok);
 }
 #undef GT_METHOD_NAME
 #undef GT_CLASS_NAME

--- a/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/ExportImageDialogFiller.cpp
+++ b/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/ExportImageDialogFiller.cpp
@@ -27,13 +27,10 @@
 #include <primitives/GTSpinBox.h>
 #include <primitives/GTWidget.h>
 
-#include <QApplication>
 #include <QCheckBox>
 #include <QComboBox>
 #include <QDialogButtonBox>
 #include <QDir>
-#include <QPushButton>
-#include <QRadioButton>
 #include <QTableWidget>
 
 #include "ExportImageDialogFiller.h"
@@ -57,20 +54,15 @@ ExportImage::ExportImage(HI::GUITestOpStatus &os, CustomScenario *scenario)
 
 #define GT_METHOD_NAME "commonScenario"
 void ExportImage::commonScenario() {
-    QWidget *dialog = QApplication::activeModalWidget();
-    GT_CHECK(dialog, "activeModalWidget is NULL");
-
-    QLineEdit *fileEdit = dialog->findChild<QLineEdit *>("fileNameEdit");
-    GTLineEdit::setText(os, fileEdit, filePath);
+    QWidget *dialog = GTWidget::getActiveModalWidget(os);
+    GTLineEdit::setText(os, "fileNameEdit", filePath, dialog);
 
     if (comboValue != "") {
-        QComboBox *formatsBox = dialog->findChild<QComboBox *>("formatsBox");
-        GTComboBox::selectItemByText(os, formatsBox, comboValue);
+        GTComboBox::selectItemByText(os, "formatsBox", dialog, comboValue);
     }
 
     if (spinValue) {
-        QSpinBox *spin = dialog->findChild<QSpinBox *>("qualitySpinBox");
-        GTSpinBox::setValue(os, spin, spinValue, GTGlobals::UseKeyBoard);
+        GTSpinBox::setValue(os, "qualitySpinBox", spinValue, GTGlobals::UseKeyBoard, dialog);
     }
 
     GTUtilsDialog::clickButtonBox(os, dialog, QDialogButtonBox::Ok);
@@ -81,32 +73,21 @@ void ExportImage::commonScenario() {
 #define GT_CLASS_NAME "GTUtilsDialog::CircularViewExportImage"
 #define GT_METHOD_NAME "commonScenario"
 void CircularViewExportImage::commonScenario() {
-    QWidget *dialog = QApplication::activeModalWidget();
-    GT_CHECK(dialog, "activeModalWidget is NULL");
+    QWidget *dialog = GTWidget::getActiveModalWidget(os);
+    GTLineEdit::setText(os, "fileNameEdit", filePath, dialog);
 
-    QLineEdit *fileEdit = dialog->findChild<QLineEdit *>("fileNameEdit");
-    GTLineEdit::setText(os, fileEdit, filePath);
-
-    if (comboValue != "") {
-        QComboBox *formatsBox = dialog->findChild<QComboBox *>("formatsBox");
-        GTComboBox::selectItemByText(os, formatsBox, comboValue);
+    if (!comboValue.isEmpty()) {
+        GTComboBox::selectItemByText(os, "formatsBox", dialog, comboValue);
     }
 
     if (spinValue) {
-        QSpinBox *spin = dialog->findChild<QSpinBox *>("qualitySpinBox");
-        GTSpinBox::setValue(os, spin, spinValue, GTGlobals::UseKeyBoard);
+        GTSpinBox::setValue(os, "qualitySpinBox", spinValue, GTGlobals::UseKeyBoard, dialog);
     }
 
     if (!exportedSequenceName.isEmpty()) {
-        QComboBox *seqsCombo = dialog->findChild<QComboBox *>("Exported_sequence_combo");
-        GTComboBox::selectItemByText(os, seqsCombo, exportedSequenceName);
+        GTComboBox::selectItemByText(os, "Exported_sequence_combo", dialog, exportedSequenceName);
     }
-
-    QDialogButtonBox *box = qobject_cast<QDialogButtonBox *>(GTWidget::findWidget(os, "buttonBox", dialog));
-    GT_CHECK(box != nullptr, "buttonBox is NULL");
-    QPushButton *button = box->button(QDialogButtonBox::Ok);
-    GT_CHECK(button != nullptr, "Ok button is NULL");
-    GTWidget::click(os, button);
+    GTUtilsDialog::clickButtonBox(os, dialog, QDialogButtonBox::Ok);
 }
 #undef GT_METHOD_NAME
 #undef GT_CLASS_NAME
@@ -116,44 +97,28 @@ void CircularViewExportImage::commonScenario() {
 void ExportMsaImage::commonScenario() {
     GT_CHECK((exportWholeAlignment && exportCurrentSelection) != true, "Wrong filler parameters");
 
-    QWidget *dialog = QApplication::activeModalWidget();
-    GT_CHECK(dialog, "activeModalWidget is NULL");
+    QWidget *dialog = GTWidget::getActiveModalWidget(os);
 
     if (!exportWholeAlignment) {
         if (!exportCurrentSelection) {
             GTUtilsDialog::waitForDialog(os, new SelectSubalignmentFiller(os, region));
         }
-        QComboBox *exportType = dialog->findChild<QComboBox *>("comboBox");
-        GTComboBox::selectItemByText(os, exportType, "Custom region");
+        GTComboBox::selectItemByText(os, "comboBox", dialog, "Custom region");
     }
 
-    QCheckBox *namesCB = dialog->findChild<QCheckBox *>("exportSeqNames");
-    GTCheckBox::setChecked(os, namesCB, settings.includeNames);
+    GTCheckBox::setChecked(os, "exportSeqNames", settings.includeNames, dialog);
+    GTCheckBox::setChecked(os, "exportConsensus", settings.includeConsensus, dialog);
+    GTCheckBox::setChecked(os, "exportRuler", settings.includeRuler, dialog);
+    GTLineEdit::setText(os, "fileNameEdit", filePath, dialog);
 
-    QCheckBox *consensusCB = dialog->findChild<QCheckBox *>("exportConsensus");
-    GTCheckBox::setChecked(os, consensusCB, settings.includeConsensus);
-
-    QCheckBox *rulerCB = dialog->findChild<QCheckBox *>("exportRuler");
-    GTCheckBox::setChecked(os, rulerCB, settings.includeRuler);
-
-    QLineEdit *fileEdit = dialog->findChild<QLineEdit *>("fileNameEdit");
-    GTLineEdit::setText(os, fileEdit, filePath);
-
-    if (comboValue != "") {
-        QComboBox *formatsBox = dialog->findChild<QComboBox *>("formatsBox");
-        GTComboBox::selectItemByText(os, formatsBox, comboValue);
+    if (!comboValue.isEmpty()) {
+        GTComboBox::selectItemByText(os, "formatsBox", dialog, comboValue);
     }
 
     if (spinValue) {
-        QSpinBox *spin = dialog->findChild<QSpinBox *>("qualitySpinBox");
-        GTSpinBox::setValue(os, spin, spinValue, GTGlobals::UseKeyBoard);
+        GTSpinBox::setValue(os, "qualitySpinBox", spinValue, GTGlobals::UseKeyBoard, dialog);
     }
-
-    QDialogButtonBox *box = qobject_cast<QDialogButtonBox *>(GTWidget::findWidget(os, "buttonBox", dialog));
-    GT_CHECK(box != nullptr, "buttonBox is NULL");
-    QPushButton *button = box->button(QDialogButtonBox::Ok);
-    GT_CHECK(button != nullptr, "ok button is NULL");
-    GTWidget::click(os, button);
+    GTUtilsDialog::clickButtonBox(os, QDialogButtonBox::Ok);
 }
 #undef GT_METHOD_NAME
 #undef GT_CLASS_NAME
@@ -161,9 +126,7 @@ void ExportMsaImage::commonScenario() {
 #define GT_CLASS_NAME "GTUtilsDialog::ExportSequenceImage"
 #define GT_METHOD_NAME "commonScenario"
 void ExportSequenceImage::commonScenario() {
-    GTGlobals::sleep(500);
-    QWidget *dialog = QApplication::activeModalWidget();
-    GT_CHECK(dialog, "activeModalWidget is NULL");
+    QWidget *dialog = GTWidget::getActiveModalWidget(os);
 
     QString radioButtonName;
     switch (settings.type) {
@@ -178,36 +141,25 @@ void ExportSequenceImage::commonScenario() {
             break;
     }
 
-    QRadioButton *radioButton = dialog->findChild<QRadioButton *>(radioButtonName);
-    GTRadioButton::click(os, radioButton);
+    GTRadioButton::click(os, radioButtonName, dialog);
 
     if (settings.type != CurrentView) {
-        // set region
-        QLineEdit *start = dialog->findChild<QLineEdit *>("start_edit_line");
-        GTLineEdit::setText(os, start, QString::number(settings.region.startPos));
-
-        QLineEdit *end = dialog->findChild<QLineEdit *>("end_edit_line");
-        GTLineEdit::setText(os, end, QString::number(settings.region.endPos()));
+        // Set region.
+        GTLineEdit::setText(os, "start_edit_line", QString::number(settings.region.startPos), dialog);
+        GTLineEdit::setText(os, "end_edit_line", QString::number(settings.region.endPos()), dialog);
     }
 
-    QLineEdit *fileEdit = dialog->findChild<QLineEdit *>("fileNameEdit");
-    GTLineEdit::setText(os, fileEdit, filePath);
+    GTLineEdit::setText(os, "fileNameEdit", filePath, dialog);
 
     if (comboValue != "") {
-        QComboBox *formatsBox = dialog->findChild<QComboBox *>("formatsBox");
-        GTComboBox::selectItemByText(os, formatsBox, comboValue);
+        GTComboBox::selectItemByText(os, "formatsBox", dialog, comboValue);
     }
 
     if (spinValue) {
-        QSpinBox *spin = dialog->findChild<QSpinBox *>("qualitySpinBox");
-        GTSpinBox::setValue(os, spin, spinValue, GTGlobals::UseKeyBoard);
+        GTSpinBox::setValue(os, "qualitySpinBox", spinValue, GTGlobals::UseKeyBoard, dialog);
     }
 
-    QDialogButtonBox *box = qobject_cast<QDialogButtonBox *>(GTWidget::findWidget(os, "buttonBox", dialog));
-    GT_CHECK(box != nullptr, "buttonBox is NULL");
-    QPushButton *button = box->button(QDialogButtonBox::Ok);
-    GT_CHECK(button != nullptr, "ok button is NULL");
-    GTWidget::click(os, button);
+    GTUtilsDialog::clickButtonBox(os, QDialogButtonBox::Ok);
 }
 #undef GT_METHOD_NAME
 #undef GT_CLASS_NAME
@@ -215,23 +167,13 @@ void ExportSequenceImage::commonScenario() {
 #define GT_CLASS_NAME "GTUtilsDialog::SelectSubalignmentFiller"
 #define GT_METHOD_NAME "commonScenario"
 void SelectSubalignmentFiller::commonScenario() {
-    QWidget *dialog = QApplication::activeModalWidget();
-    GT_CHECK(dialog, "activeModalWidget is NULL");
+    QWidget *dialog = GTWidget::getActiveModalWidget(os);
+    GTSpinBox::setValue(os, "startLineEdit", msaRegion.region.startPos, GTGlobals::UseKeyBoard, dialog);
+    GTSpinBox::setValue(os, "endLineEdit", msaRegion.region.endPos(), GTGlobals::UseKeyBoard, dialog);
 
-    QSpinBox *startLineEdit = dialog->findChild<QSpinBox *>("startLineEdit");
-    GT_CHECK(startLineEdit != nullptr, "startLineEdit is NULL");
-    GTSpinBox::setValue(os, startLineEdit, msaRegion.region.startPos, GTGlobals::UseKeyBoard);
+    GTWidget::click(os, GTWidget::findWidget(os, "noneButton", dialog));
 
-    QSpinBox *endLineEdit = dialog->findChild<QSpinBox *>("endLineEdit");
-    GT_CHECK(endLineEdit != nullptr, "endPoxBox is NULL");
-    GTSpinBox::setValue(os, endLineEdit, msaRegion.region.endPos(), GTGlobals::UseKeyBoard);
-
-    QWidget *noneButton = dialog->findChild<QWidget *>("noneButton");
-    GT_CHECK(noneButton != nullptr, "noneButton is NULL");
-    GTWidget::click(os, noneButton);
-
-    QTableWidget *table = dialog->findChild<QTableWidget *>("sequencesTableWidget");
-    GT_CHECK(table != nullptr, "tableWidget is NULL");
+    QTableWidget *table = GTWidget::findTableWidget(os, "sequencesTableWidget", dialog);
 
     QPoint p = table->geometry().topRight();
     p.setX(p.x() - 2);
@@ -245,6 +187,7 @@ void SelectSubalignmentFiller::commonScenario() {
             auto box = qobject_cast<QCheckBox *>(table->cellWidget(i, 0));
             GT_CHECK(box != nullptr, "Not a QCheckBox cell");
             if (sequence == box->text()) {
+                GTWidget::scrollToIndex(os, table, table->model()->index(i, 0));
                 GT_CHECK(box->isEnabled(), QString("%1 box is disabled").arg(box->text()));
                 GTCheckBox::setChecked(os, box, true);
             }
@@ -263,22 +206,14 @@ ImageExportFormFiller::ImageExportFormFiller(HI::GUITestOpStatus &os, const Para
 #define GT_METHOD_NAME "commonScenario"
 
 void ImageExportFormFiller::commonScenario() {
-    QWidget *dialog = QApplication::activeModalWidget();
-    GT_CHECK(dialog, "activeModalWidget is NULL");
-
-    QLineEdit *fileNameEdit = qobject_cast<QLineEdit *>(GTWidget::findWidget(os, "fileNameEdit", dialog));
-    GT_CHECK(fileNameEdit, "fileNameEdit is NULL");
-    GTLineEdit::setText(os, fileNameEdit, QDir::toNativeSeparators(parameters.fileName));
+    QWidget *dialog = GTWidget::getActiveModalWidget(os);
+    GTLineEdit::setText(os, "fileNameEdit", QDir::toNativeSeparators(parameters.fileName), dialog);
 
     QComboBox *formatsBox = qobject_cast<QComboBox *>(GTWidget::findWidget(os, "formatsBox", dialog));
     GT_CHECK(formatsBox, "formatsBox is NULL");
     GTComboBox::selectItemByText(os, formatsBox, parameters.format);
 
-    QDialogButtonBox *box = dialog->findChild<QDialogButtonBox *>("buttonBox");
-    GT_CHECK(box != nullptr, "buttonBox is NULL");
-    QPushButton *ok = box->button(QDialogButtonBox::Ok);
-    GT_CHECK(ok != nullptr, "ok button is NULL");
-    GTWidget::click(os, ok);
+    GTUtilsDialog::clickButtonBox(os, QDialogButtonBox::Ok);
 }
 
 #undef GT_METHOD_NAME

--- a/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/ExportImageDialogFiller.h
+++ b/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/ExportImageDialogFiller.h
@@ -91,9 +91,7 @@ public:
 
     // default
     ExportMsaImage(HI::GUITestOpStatus &os, QString filePath, QString comboValue = "", int spinValue = 0)
-        : ExportImage(os, filePath, comboValue, spinValue),
-          exportWholeAlignment(true),
-          exportCurrentSelection(false) {
+        : ExportImage(os, filePath, comboValue, spinValue) {
     }
 
     //  exportWholeAlignment = false,   exportCurrentSelection = false  : export of specified msa region, there should be no any selection on msa
@@ -108,12 +106,12 @@ public:
           region(region) {
     }
 
-    void commonScenario();
+    void commonScenario() override;
 
 private:
     Settings settings;
-    bool exportWholeAlignment;
-    bool exportCurrentSelection;
+    bool exportWholeAlignment = true;
+    bool exportCurrentSelection = false;
     RegionMsa region;
 };
 

--- a/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/FindRepeatsDialogFiller.cpp
+++ b/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/FindRepeatsDialogFiller.cpp
@@ -20,15 +20,14 @@
  */
 
 #include "FindRepeatsDialogFiller.h"
+#include <primitives/GTLineEdit.h>
 #include <primitives/GTSpinBox.h>
 #include <primitives/GTTabWidget.h>
 #include <primitives/GTWidget.h>
 
 #include <QAbstractButton>
 #include <QApplication>
-#include <QCheckBox>
 #include <QDialogButtonBox>
-#include <QPushButton>
 #include <QSpinBox>
 
 namespace U2 {
@@ -77,13 +76,11 @@ void FindRepeatsDialogFiller::commonScenario() {
         GTSpinBox::setValue(os, minDistBox, minDistance);
     }
 
-    QLineEdit *resultLocationEdit = qobject_cast<QLineEdit *>(GTWidget::findWidget(os, "leNewTablePath", dialog));
-    resultLocationEdit->setText(resultAnnotationFilesPath);
+    GTLineEdit::setText(os, "leNewTablePath", resultAnnotationFilesPath, dialog);
 
     GTTabWidget::setCurrentIndex(os, tabWidget, 1);
 
-    QCheckBox *invertedRepeatsIndicator = qobject_cast<QCheckBox *>(GTWidget::findWidget(os, "invertCheck", dialog));
-    invertedRepeatsIndicator->setChecked(searchInverted);
+    GTWidget::findCheckBox(os, "invertCheck", dialog);
 
     GTUtilsDialog::clickButtonBox(os, dialog, QDialogButtonBox::Ok);
 }

--- a/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/FindRepeatsDialogFiller.cpp
+++ b/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/FindRepeatsDialogFiller.cpp
@@ -20,25 +20,28 @@
  */
 
 #include "FindRepeatsDialogFiller.h"
+#include <primitives/GTCheckBox.h>
 #include <primitives/GTLineEdit.h>
 #include <primitives/GTSpinBox.h>
 #include <primitives/GTTabWidget.h>
 #include <primitives/GTWidget.h>
 
-#include <QAbstractButton>
 #include <QApplication>
 #include <QDialogButtonBox>
-#include <QSpinBox>
 
 namespace U2 {
 
 #define GT_CLASS_NAME "GTUtilsDialog::FindRepeatsDialogFiller"
 #define GT_METHOD_NAME "run"
 
-FindRepeatsDialogFiller::FindRepeatsDialogFiller(HI::GUITestOpStatus &_os, const QString &_resultFilesPath, bool _searchInverted, int minRepeatLength, int repeatsIdentity, int minDistance)
-    : Filler(_os, "FindRepeatsDialog"), button(Start), resultAnnotationFilesPath(_resultFilesPath),
-      searchInverted(_searchInverted), minRepeatLength(minRepeatLength), repeatsIdentity(repeatsIdentity), minDistance(minDistance) {
-    GTGlobals::sleep(10);
+FindRepeatsDialogFiller::FindRepeatsDialogFiller(HI::GUITestOpStatus &os,
+                                                 const QString &_resultFilesPath,
+                                                 bool _searchInverted,
+                                                 int _minRepeatLength,
+                                                 int _repeatsIdentity,
+                                                 int _minDistance)
+    : Filler(os, "FindRepeatsDialog"), button(Start), resultAnnotationFilesPath(_resultFilesPath),
+      searchInverted(_searchInverted), minRepeatLength(_minRepeatLength), repeatsIdentity(_repeatsIdentity), minDistance(_minDistance) {
 }
 
 FindRepeatsDialogFiller::FindRepeatsDialogFiller(HI::GUITestOpStatus &os, CustomScenario *scenario)
@@ -53,34 +56,30 @@ FindRepeatsDialogFiller::FindRepeatsDialogFiller(HI::GUITestOpStatus &os, Custom
 void FindRepeatsDialogFiller::commonScenario() {
     QWidget *dialog = GTWidget::getActiveModalWidget(os);
     if (button == Cancel) {
-        QAbstractButton *cancelButton = qobject_cast<QAbstractButton *>(GTWidget::findWidget(os, "cancelButton", dialog));
-        GTWidget::click(os, cancelButton);
+        GTWidget::click(os, GTWidget::findWidget(os, "cancelButton", dialog));
         return;
     }
 
-    QTabWidget *tabWidget = qobject_cast<QTabWidget *>(GTWidget::findWidget(os, "tabWidget", dialog));
+    auto tabWidget = GTWidget::findTabWidget(os, "tabWidget", dialog);
     GTTabWidget::setCurrentIndex(os, tabWidget, 0);
 
     if (minRepeatLength != -1) {
-        QSpinBox *minLenBox = qobject_cast<QSpinBox *>(GTWidget::findWidget(os, "minLenBox", dialog));
-        GTSpinBox::setValue(os, minLenBox, minRepeatLength);
+        GTSpinBox::setValue(os, "minLenBox", minRepeatLength, dialog);
     }
 
     if (repeatsIdentity != -1) {
-        QSpinBox *identityBox = qobject_cast<QSpinBox *>(GTWidget::findWidget(os, "identityBox", dialog));
-        GTSpinBox::setValue(os, identityBox, repeatsIdentity);
+        GTSpinBox::setValue(os, "identityBox", repeatsIdentity, dialog);
     }
 
     if (minDistance != -1) {
-        QSpinBox *minDistBox = qobject_cast<QSpinBox *>(GTWidget::findWidget(os, "minDistBox", dialog));
-        GTSpinBox::setValue(os, minDistBox, minDistance);
+        GTSpinBox::setValue(os, "minDistBox", minDistance, dialog);
     }
 
     GTLineEdit::setText(os, "leNewTablePath", resultAnnotationFilesPath, dialog);
 
     GTTabWidget::setCurrentIndex(os, tabWidget, 1);
 
-    GTWidget::findCheckBox(os, "invertCheck", dialog);
+    GTCheckBox::setChecked(os, "invertCheck", searchInverted, dialog);
 
     GTUtilsDialog::clickButtonBox(os, dialog, QDialogButtonBox::Ok);
 }

--- a/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2View/ov_msa/ExtractSelectedAsMSADialogFiller.cpp
+++ b/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2View/ov_msa/ExtractSelectedAsMSADialogFiller.cpp
@@ -25,15 +25,12 @@
 #include <primitives/GTCheckBox.h>
 #include <primitives/GTComboBox.h>
 #include <primitives/GTLineEdit.h>
-#include <primitives/GTSpinBox.h>
 #include <primitives/GTWidget.h>
 
 #include <QApplication>
 #include <QCheckBox>
 #include <QComboBox>
 #include <QDialogButtonBox>
-#include <QPushButton>
-#include <QSpinBox>
 #include <QTableWidget>
 
 namespace U2 {
@@ -152,11 +149,12 @@ void ExtractSelectedAsMSADialogFiller::commonScenario() {
         GTMouseDriver::moveTo(p);
         GTMouseDriver::click();
         for (int i = 0; i < table->rowCount(); i++) {
-            foreach (QString s, sequenceNameList) {
+            for (const QString &sequenceName : qAsConst(sequenceNameList)) {
                 QCheckBox *box = qobject_cast<QCheckBox *>(table->cellWidget(i, 0));
-                if (s == box->text()) {
+                GT_CHECK(box != nullptr, "Not a QCheckBox cell");
+                if (sequenceName == box->text()) {
                     GT_CHECK(box->isEnabled(), QString("%1 box is disabled").arg(box->text()));
-                    box->setChecked(true);
+                    GTCheckBox::setChecked(os, box, true);
                 }
             }
         }

--- a/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2View/ov_msa/ExtractSelectedAsMSADialogFiller.cpp
+++ b/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2View/ov_msa/ExtractSelectedAsMSADialogFiller.cpp
@@ -27,9 +27,7 @@
 #include <primitives/GTLineEdit.h>
 #include <primitives/GTWidget.h>
 
-#include <QApplication>
 #include <QCheckBox>
-#include <QComboBox>
 #include <QDialogButtonBox>
 #include <QTableWidget>
 
@@ -77,70 +75,44 @@ ExtractSelectedAsMSADialogFiller::ExtractSelectedAsMSADialogFiller(GUITestOpStat
 }
 
 void ExtractSelectedAsMSADialogFiller::commonScenario() {
-    QWidget *dialog = QApplication::activeModalWidget();
-    GT_CHECK(dialog, "activeModalWidget is NULL");
+    QWidget *dialog = GTWidget::getActiveModalWidget(os);
 
     if (from) {
-        QLineEdit *fromSpin = dialog->findChild<QLineEdit *>("startLineEdit");
-        GT_CHECK(fromSpin != nullptr, "fromSpin is NULL")
-        GTLineEdit::setText(os, fromSpin, QString::number(from));
+        GTLineEdit::setText(os, "startLineEdit", QString::number(from), dialog);
     }
 
     if (to) {
-        QLineEdit *toSpin = dialog->findChild<QLineEdit *>("endLineEdit");
-        GT_CHECK(toSpin != nullptr, "toSpin is NULL")
-        GTLineEdit::setText(os, toSpin, QString::number(to));
+        GTLineEdit::setText(os, "endLineEdit", QString::number(to), dialog);
     }
 
-    QLineEdit *filepathEdit = dialog->findChild<QLineEdit *>("filepathEdit");
-    GT_CHECK(filepathEdit != nullptr, "filepathEdit is NULL");
-    GTLineEdit::setText(os, filepathEdit, filepath, dontCheckFilepath);
-    GTGlobals::sleep(300);
+    GTLineEdit::setText(os, "filepathEdit", filepath, dialog, dontCheckFilepath);
 
     if (!useDefaultSequenceSelection) {
-        QWidget *noneButton = dialog->findChild<QWidget *>("noneButton");
-        GT_CHECK(noneButton != nullptr, "noneButton is NULL");
-        GTWidget::click(os, noneButton);
+        GTWidget::click(os, GTWidget::findWidget(os, "noneButton", dialog));
     }
 
     if (invertButtonPress) {
-        GTGlobals::sleep(300);
-        QWidget *invertButton = dialog->findChild<QWidget *>("invertButton");
-        GT_CHECK(invertButton != nullptr, "invertButton is NULL");
-        GTWidget::click(os, invertButton);
+        GTWidget::click(os, GTWidget::findWidget(os, "invertButton", dialog));
     }
 
     if (allButtonPress) {
-        GTGlobals::sleep(300);
-        QWidget *allButton = dialog->findChild<QWidget *>("allButton");
-        GT_CHECK(allButton != nullptr, "allButton is NULL");
-        GTWidget::click(os, allButton);
+        GTWidget::click(os, GTWidget::findWidget(os, "allButton", dialog));
     }
 
     if (noneButtonPress) {
-        GTGlobals::sleep(300);
-        QWidget *noneButton = dialog->findChild<QWidget *>("noneButton");
-        GT_CHECK(noneButton != nullptr, "noneButton is NULL");
-        GTWidget::click(os, noneButton);
+        GTWidget::click(os, GTWidget::findWidget(os, "noneButton", dialog));
     }
 
     if (addToProj) {
-        GTGlobals::sleep(300);
-        QCheckBox *addToProjCheck = dialog->findChild<QCheckBox *>("addToProjBox");
-        GT_CHECK(addToProjCheck != nullptr, "addToProjBox is NULL");
-        GTCheckBox::setChecked(os, addToProjCheck, addToProj);
+        GTCheckBox::setChecked(os, "addToProjBox", addToProj, dialog);
     }
 
     if (!format.isEmpty()) {
-        GTGlobals::sleep(300);
-        QComboBox *formatCombo = dialog->findChild<QComboBox *>("formatCombo");
-        GT_CHECK(formatCombo != nullptr, "formatCombo is null");
-        GTComboBox::selectItemByText(os, formatCombo, format);
+        GTComboBox::selectItemByText(os, "formatCombo", dialog, format);
     }
 
     if (!useDefaultSequenceSelection) {
-        QTableWidget *table = dialog->findChild<QTableWidget *>("sequencesTableWidget");
-        GT_CHECK(table != nullptr, "tableWidget is NULL");
+        auto table = GTWidget::findTableWidget(os, "sequencesTableWidget", dialog);
         QPoint p = table->geometry().topRight();
         p.setX(p.x() - 2);
         p.setY(p.y() + 2);
@@ -150,15 +122,15 @@ void ExtractSelectedAsMSADialogFiller::commonScenario() {
         GTMouseDriver::click();
         for (int i = 0; i < table->rowCount(); i++) {
             for (const QString &sequenceName : qAsConst(sequenceNameList)) {
-                QCheckBox *box = qobject_cast<QCheckBox *>(table->cellWidget(i, 0));
+                auto box = qobject_cast<QCheckBox *>(table->cellWidget(i, 0));
                 GT_CHECK(box != nullptr, "Not a QCheckBox cell");
                 if (sequenceName == box->text()) {
                     GT_CHECK(box->isEnabled(), QString("%1 box is disabled").arg(box->text()));
+                    GTWidget::scrollToIndex(os, table, table->model()->index(i, 0));
                     GTCheckBox::setChecked(os, box, true);
                 }
             }
         }
-        GTGlobals::sleep();
     }
 
     GTUtilsDialog::clickButtonBox(os, dialog, QDialogButtonBox::Ok);
@@ -167,8 +139,7 @@ void ExtractSelectedAsMSADialogFiller::commonScenario() {
 
 #define GT_METHOD_NAME "getSelectedSequences"
 QStringList ExtractSelectedAsMSADialogFiller::getSequences(HI::GUITestOpStatus &os, bool selected) {
-    QWidget *dialog = QApplication::activeModalWidget();
-    GT_CHECK_RESULT(dialog, "activeModalWidget is NULL", QStringList());
+    QWidget *dialog = GTWidget::getActiveModalWidget(os);
     QStringList result;
 
     QTableWidget *sequencesTableWidget = GTWidget::findExactWidget<QTableWidget *>(os, "sequencesTableWidget", dialog);

--- a/src/plugins/GUITestBase/src/runnables/ugene/plugins/dna_export/ExportMSA2SequencesDialogFiller.cpp
+++ b/src/plugins/GUITestBase/src/runnables/ugene/plugins/dna_export/ExportMSA2SequencesDialogFiller.cpp
@@ -48,13 +48,6 @@ ExportToSequenceFormatFiller::ExportToSequenceFormatFiller(HI::GUITestOpStatus &
     comboBoxItems[Swiss_Prot] = "Swiss_Prot";
 }
 
-ExportToSequenceFormatFiller::ExportToSequenceFormatFiller(HI::GUITestOpStatus &_os, CustomScenario *scenario)
-    : Filler(_os, "U2__ExportMSA2SequencesDialog", scenario),
-      format(EMBL),
-      saveFile(false),
-      keepCharacters(false) {
-}
-
 #define GT_METHOD_NAME "commonScenario"
 void ExportToSequenceFormatFiller::commonScenario() {
     QWidget *dialog = QApplication::activeModalWidget();
@@ -79,14 +72,7 @@ void ExportToSequenceFormatFiller::commonScenario() {
         GTCheckBox::setChecked(os, saveFileCheckBox);
     }
 
-    if (keepCharacters) {
-        QRadioButton *keepButton = qobject_cast<QRadioButton *>(GTWidget::findWidget(os, "keepGapsRB", dialog));
-        keepButton->setChecked(true);
-    } else {
-        QRadioButton *trimButton = qobject_cast<QRadioButton *>(GTWidget::findWidget(os, "trimGapsRB", dialog));
-        trimButton->setChecked(true);
-    }
-
+    GTRadioButton::click(os, keepCharacters ? "keepGapsRB" : "trimGapsRB", dialog);
     GTGlobals::sleep(100);
 
     GTUtilsDialog::clickButtonBox(os, dialog, QDialogButtonBox::Ok);

--- a/src/plugins/GUITestBase/src/runnables/ugene/plugins/dna_export/ExportMSA2SequencesDialogFiller.h
+++ b/src/plugins/GUITestBase/src/runnables/ugene/plugins/dna_export/ExportMSA2SequencesDialogFiller.h
@@ -36,9 +36,8 @@ public:
                           Genbank,
                           Swiss_Prot };
     ExportToSequenceFormatFiller(HI::GUITestOpStatus &os, const QString &path, const QString &name, documentFormat format, bool saveFile, bool keepCharacters, GTGlobals::UseMethod method = GTGlobals::UseMouse);
-    ExportToSequenceFormatFiller(HI::GUITestOpStatus &os, CustomScenario *scenario);
 
-    void commonScenario();
+    void commonScenario() override;
 
 private:
     QString path, name;

--- a/src/plugins/GUITestBase/src/runnables/ugene/plugins/dna_export/ImportAnnotationsToCsvFiller.cpp
+++ b/src/plugins/GUITestBase/src/runnables/ugene/plugins/dna_export/ImportAnnotationsToCsvFiller.cpp
@@ -207,8 +207,7 @@ void ImportAnnotationsToCsvFiller::commonScenario() {
         //        GTWidget::click(os, separatorEdit);
         //        GTKeyboardDriver::keyClick(os, 'v', GTKeyboardDriver::key["ctrl"]);
     } else {
-        QRadioButton *scriptRadioButton = qobject_cast<QRadioButton *>(GTWidget::findWidget(os, "scriptRadioButton", dialog));
-        scriptRadioButton->setChecked(true);
+        GTRadioButton::click(os, "scriptRadioButton", dialog);
     }
 
     QLineEdit *firstLinesLineEdit = dialog->findChild<QLineEdit *>(QString::fromUtf8("prefixToSkipEdit"));

--- a/src/plugins/GUITestBase/src/runnables/ugene/plugins/dotplot/BuildDotPlotDialogFiller.cpp
+++ b/src/plugins/GUITestBase/src/runnables/ugene/plugins/dotplot/BuildDotPlotDialogFiller.cpp
@@ -40,11 +40,11 @@ BuildDotPlotFiller::BuildDotPlotFiller(HI::GUITestOpStatus &_os,
                                        bool _mergeSecondBoxChecked,
                                        int _gapFirstValue,
                                        int _gapSecondValue,
-                                       bool cancel)
+                                       bool _cancel)
     : Filler(_os, "DotPlotFilesDialog"), mergeFirstBoxChecked(_mergeFirstBoxChecked),
       oneSequenceBoxChecked(_oneSequenceBoxChecked), mergeSecondBoxChecked(_mergeSecondBoxChecked),
       firstFileName(_firstFileName), secondFileName(_secondFileName), firstGapSize(_gapFirstValue),
-      secondGapSize(_gapSecondValue), cancel(cancel) {
+      secondGapSize(_gapSecondValue), cancel(_cancel) {
 }
 
 #define GT_CLASS_NAME "GTUtilsDialog::DotPlotFiller"
@@ -52,24 +52,23 @@ BuildDotPlotFiller::BuildDotPlotFiller(HI::GUITestOpStatus &_os,
 void BuildDotPlotFiller::commonScenario() {
     QWidget *dialog = GTWidget::getActiveModalWidget(os);
 
-    GTCheckBox::setChecked(os, GTWidget::findCheckBox(os, "oneSequenceCheckBox", dialog), oneSequenceBoxChecked);
-    GTLineEdit::setText(os, GTWidget::findLineEdit(os, "firstFileEdit", dialog), firstFileName);
+    GTCheckBox::setChecked(os, "oneSequenceCheckBox", oneSequenceBoxChecked, dialog);
+    GTLineEdit::setText(os, "firstFileEdit", firstFileName, dialog);
 
-    GTCheckBox::setChecked(os, GTWidget::findCheckBox(os, "mergeFirstCheckBox", dialog), mergeFirstBoxChecked);
+    GTCheckBox::setChecked(os, "mergeFirstCheckBox", mergeFirstBoxChecked, dialog);
     if (mergeFirstBoxChecked) {
-        GTSpinBox::setValue(os, GTWidget::findSpinBox(os, "gapFirst", dialog), firstGapSize);
+        GTSpinBox::setValue(os, "gapFirst", firstGapSize, dialog);
     }
 
     if (!oneSequenceBoxChecked) {
-        GTLineEdit::setText(os, GTWidget::findLineEdit(os, "secondFileEdit", dialog), secondFileName);
-        GTCheckBox::setChecked(os, GTWidget::findCheckBox(os, "mergeSecondCheckBox", dialog), mergeSecondBoxChecked);
+        GTLineEdit::setText(os, "secondFileEdit", secondFileName, dialog);
+        GTCheckBox::setChecked(os, "mergeSecondCheckBox", mergeSecondBoxChecked, dialog);
         if (mergeSecondBoxChecked) {
-            GTSpinBox::setValue(os, GTWidget::findSpinBox(os, "gapSecond", dialog), secondGapSize);
+            GTSpinBox::setValue(os, "gapSecond", secondGapSize, dialog);
         }
     }
     GTUtilsDialog::clickButtonBox(os, dialog, QDialogButtonBox::Ok);
     if (cancel) {
-        dialog = GTWidget::getActiveModalWidget(os);
         GTUtilsDialog::clickButtonBox(os, dialog, QDialogButtonBox::Cancel);
     }
 }

--- a/src/plugins/GUITestBase/src/runnables/ugene/plugins_3rdparty/hmm3/UHMM3PhmmerDialogFiller.cpp
+++ b/src/plugins/GUITestBase/src/runnables/ugene/plugins_3rdparty/hmm3/UHMM3PhmmerDialogFiller.cpp
@@ -21,11 +21,8 @@
 
 #include "UHMM3PhmmerDialogFiller.h"
 #include <primitives/GTLineEdit.h>
-#include <primitives/GTTabBar.h>
+#include <primitives/GTTabWidget.h>
 #include <primitives/GTWidget.h>
-
-#include <QApplication>
-#include <QTabWidget>
 
 namespace U2 {
 
@@ -33,15 +30,11 @@ namespace U2 {
 #define GT_METHOD_NAME "commonScenario"
 
 void UHMM3PhmmerDialogFiller::commonScenario() {
-    QWidget *dialog = QApplication::activeModalWidget();
-    GT_CHECK(dialog != nullptr, "dialog not found");
+    auto dialog = GTWidget::getActiveModalWidget(os);
 
-    GTGlobals::sleep(1000);
-    QTabWidget *tabWidget = GTWidget::findExactWidget<QTabWidget *>(os, "mainTabWidget", dialog);
+    GTTabWidget::setCurrentIndex(os, GTWidget::findTabWidget(os, "mainTabWidget", dialog), 0);
 
-    tabWidget->setCurrentIndex(0);
-    QLineEdit *queryLineEdit = GTWidget::findExactWidget<QLineEdit *>(os, "queryLineEdit", dialog);
-    GTLineEdit::setText(os, queryLineEdit, input);
+    GTLineEdit::setText(os, "queryLineEdit", input, dialog);
 
     GTUtilsDialog::clickButtonBox(os, dialog, QDialogButtonBox::Ok);
 }

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/Assembling/extract_consensus/GTTestsAssemblyExtractConsensus.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/Assembling/extract_consensus/GTTestsAssemblyExtractConsensus.cpp
@@ -60,12 +60,9 @@ public:
     }
 
     void run(HI::GUITestOpStatus &os) override {
-        QWidget *const dialog = GTWidget::getActiveModalWidget(os);
-
-        // Dialog filling
-        GTLineEdit::setText(os, GTWidget::findExactWidget<QLineEdit *>(os, "Assembly widget", dialog), inputPaths.join(';'));
-
-        GTLineEdit::setText(os, GTWidget::findExactWidget<QLineEdit *>(os, "Output file widget", dialog), outFile);
+        QWidget *dialog = GTWidget::getActiveModalWidget(os);
+        GTLineEdit::setText(os, "Assembly widget", inputPaths.join(';'), dialog);
+        GTLineEdit::setText(os, "Output file widget", outFile, dialog);
 
         GTUtilsWizard::clickButton(os, GTUtilsWizard::Run);
     }

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/Assembling/extract_consensus/GTTestsAssemblyExtractConsensus.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/Assembling/extract_consensus/GTTestsAssemblyExtractConsensus.cpp
@@ -130,7 +130,7 @@ GUI_TEST_CLASS_DEFINITION(test_0002_multiple_input) {
             // Dialog filling
             GTLineEdit::setText(os, GTWidget::findExactWidget<QLineEdit *>(os, "Assembly widget", dialog), inputPaths.join(';'));
 
-            GTWidget::findButtonByText(os, "Add", dialog)->click();
+            GTWidget::click(os, GTWidget::findButtonByText(os, "Add", dialog));
             GTUtilsDialog::waitForDialog(os,
                                          new GTFileDialogUtils(os, testDir + "_common_data/bam/small.bam.sorted.bam"));
 

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/GTTestsMsaEditor.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/GTTestsMsaEditor.cpp
@@ -1271,7 +1271,7 @@ GUI_TEST_CLASS_DEFINITION(test_0016) {
     GTUtilsDialog::waitForDialog(os, new MessageBoxDialogFiller(os, QMessageBox::Yes));
     GTFile::copy(os, sandBoxDir + "ma2_gapped.aln", sandBoxDir + "ma2_gapped_old.aln");
     GTFile::copy(os, sandBoxDir + "ma2_gapped_edited.aln", sandBoxDir + "ma2_gapped.aln");
-    GTGlobals::sleep(10000); // Wait up to 10 seconds so UGENE will find the changes.
+    GTGlobals::sleep(10000);  // Wait up to 10 seconds so UGENE will find the changes.
 
     //    Expected state: document was reloaded, view activated.
     //    'Phaneroptera_falcata' starts with CTT.
@@ -2673,14 +2673,18 @@ GUI_TEST_CLASS_DEFINITION(test_0043) {
     // select a few sequences
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
+    GTUtils::checkExportServiceIsEnabled(os);
 
-    QStringList sequences;
-    sequences << "Montana_montana"
-              << "Conocephalus_percaudata"
-              << "Podisma_sapporensis";
+    QStringList sequences = {"Montana_montana", "Conocephalus_percaudata", "Podisma_sapporensis"};
 
     GTUtilsDialog::waitForDialog(os, new PopupChooser(os, {MSAE_MENU_EXPORT, "export_msa_as_image_action"}));
-    GTUtilsDialog::waitForDialog(os, new ExportMsaImage(os, testDir + "_common_data/scenarios/sandbox/test_0043.png", ExportMsaImage::Settings(), false, false, RegionMsa(U2Region(1, 594), sequences)));
+    GTUtilsDialog::waitForDialog(os,
+                                 new ExportMsaImage(os,
+                                                    testDir + "_common_data/scenarios/sandbox/test_0043.png",
+                                                    ExportMsaImage::Settings(),
+                                                    false,
+                                                    false,
+                                                    RegionMsa(U2Region(1, 594), sequences)));
 
     GTMenu::showContextMenu(os, GTWidget::findWidget(os, "msa_editor_sequence_area"));
 }
@@ -4109,7 +4113,6 @@ GUI_TEST_CLASS_DEFINITION(test_0082) {
 
     GTMouseDriver::click(Qt::RightButton);
     GTUtilsTaskTreeView::waitTaskFinished(os);
-
 
     QStringList sequencesNameList = GTUtilsMSAEditorSequenceArea::getNameList(os);
 

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_1_1000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_1_1000.cpp
@@ -2791,7 +2791,7 @@ GUI_TEST_CLASS_DEFINITION(test_0940) {
     GTFileDialog::openFile(os, sandBoxDir, "test_0940.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    GTUtilsDialog::waitForDialog(os, new PopupChooser(os, QStringList() << MSAE_MENU_EXPORT << "Save subalignment"));
+    GTUtilsDialog::waitForDialog(os, new PopupChooser(os, {MSAE_MENU_EXPORT, "Save subalignment"}));
     GTUtilsDialog::waitForDialog(os, new ExtractSelectedAsMSADialogFiller(os, sandBoxDir + "test_0940.aln", GTUtilsMSAEditorSequenceArea::getNameList(os)));
     GTMenu::showContextMenu(os, GTWidget::findWidget(os, "msa_editor_sequence_area"));
 }

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_2001_3000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_2001_3000.cpp
@@ -1905,22 +1905,22 @@ GUI_TEST_CLASS_DEFINITION(test_2351) {
 
         void run() override {
             auto dialog = GTWidget::getActiveModalWidget(os);
-            GTLineEdit::setText(os, projectName, "projectNameEdit", dialog);
-            GTLineEdit::setText(os, projectFolder + "/" + projectFile, "projectFilePathEdit", dialog);
+            GTLineEdit::setText(os, "projectNameEdit", projectName, dialog);
+            GTLineEdit::setText(os, "projectFilePathEdit", projectFolder + "/" + projectFile, dialog);
             GTUtilsDialog::clickButtonBox(os, dialog, QDialogButtonBox::Ok);
         }
 
     private:
-        const QString projectName;
-        const QString projectFolder;
-        const QString projectFile;
+        QString projectName;
+        QString projectFolder;
+        QString projectFile;
     };
 
-    const QString projectName = "test_2351";
-    const QString projectFolder = testDir + "_common_data/scenarios/sandbox";
-    const QString projectFile = "test_2351";
+    QString projectName = "test_2351";
+    QString projectFolder = testDir + "_common_data/scenarios/sandbox";
+    QString projectFile = "test_2351";
 
-    for (int i = 0; i < 15; ++i) {
+    for (int i = 0; i < 10; ++i) {
         GTUtilsDialog::waitForDialog(os, new RapidProjectCreator(os, projectName, projectFolder, projectFile));
         GTWidget::click(os,
                         GTToolbar::getWidgetForActionObjectName(os,
@@ -2142,7 +2142,7 @@ GUI_TEST_CLASS_DEFINITION(test_2379) {
     class CreateProjectFiller : public Filler {
         // It is a local support class, it is the same as SaveProjectAsDialogFiller,
         // but it clicks the final button with keyboard.
-        // I know that it is bad practice to create so useless classes, but I don't need to extend the original class.
+        // I know that it is bad practice creating so useless classes, but I don't need to extend the original class.
         // Do not move it to another place: if you need the same filler than extend the original class.
     public:
         CreateProjectFiller(HI::GUITestOpStatus &_os,

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_2001_3000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_2001_3000.cpp
@@ -615,7 +615,7 @@ GUI_TEST_CLASS_DEFINITION(test_2049) {
     GTWidget::click(os, GTToolbar::getWidgetForActionObjectName(os, GTToolbar::getToolbar(os, MWTOOLBAR_ACTIVEMDI), "Codon table"));
     auto codonTableWidget = GTWidget::findWidget(os, "Codon table widget");
     auto labelBefore = GTWidget::findLabel(os, "row_6_column_2", codonTableWidget);
-    CHECK_SET_ERR(labelBefore->text().contains("Leucine (Leu, L)"), "1. Invalid cell text: "+ labelBefore->text());
+    CHECK_SET_ERR(labelBefore->text().contains("Leucine (Leu, L)"), "1. Invalid cell text: " + labelBefore->text());
     int heightBefore = labelBefore->geometry().height();
 
     GTUtilsDialog::waitForDialog(os, new PopupChooser(os, {"3. The Yeast Mitochondrial Code"}));
@@ -1903,28 +1903,11 @@ GUI_TEST_CLASS_DEFINITION(test_2351) {
               projectFile(_projectFile) {
         }
 
-        virtual void run() {
-            QWidget *dialog = GTWidget::getActiveModalWidget(os);
-
-            QLineEdit *projectNameEdit = qobject_cast<QLineEdit *>(GTWidget::findWidget(os, "projectNameEdit", dialog));
-            if (nullptr == projectNameEdit) {
-                os.setError("projectNameEdit not found");
-                return;
-            }
-            projectNameEdit->setText(projectName);
-
-            QLineEdit *projectFileEdit = qobject_cast<QLineEdit *>(GTWidget::findWidget(os, "projectFilePathEdit", dialog));
-            if (nullptr == projectFileEdit) {
-                os.setError("projectFileEdit not found");
-                return;
-            }
-            projectFileEdit->setText(projectFolder + "/" + projectFile);
-
-            QDialogButtonBox *box = qobject_cast<QDialogButtonBox *>(GTWidget::findWidget(os, "buttonBox", dialog));
-            CHECK_SET_ERR(box != nullptr, "buttonBox is NULL");
-            QPushButton *button = box->button(QDialogButtonBox::Ok);
-            CHECK_SET_ERR(button != nullptr, "ok button is NULL");
-            GTWidget::click(os, button);
+        void run() override {
+            auto dialog = GTWidget::getActiveModalWidget(os);
+            GTLineEdit::setText(os, projectName, "projectNameEdit", dialog);
+            GTLineEdit::setText(os, projectFolder + "/" + projectFile, "projectFilePathEdit", dialog);
+            GTUtilsDialog::clickButtonBox(os, dialog, QDialogButtonBox::Ok);
         }
 
     private:

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_3001_4000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_3001_4000.cpp
@@ -2261,28 +2261,20 @@ GUI_TEST_CLASS_DEFINITION(test_3346) {
 GUI_TEST_CLASS_DEFINITION(test_3348) {
     GTFileDialog::openFile(os, testDir + "_common_data/cmdline/", "DNA.fa");
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    GTUtilsDocument::checkDocument(os, "DNA.fa");
 
-    Runnable *findDialog = new FindRepeatsDialogFiller(os, testDir + "_common_data/scenarios/sandbox/", true, 10, 75, 100);
-    GTUtilsDialog::waitForDialog(os, findDialog);
-
-    GTMenu::clickMainMenuItem(os, QStringList() << "Actions"
-                                                << "Analyze"
-                                                << "Find repeats...",
-                              GTGlobals::UseMouse);
+    GTUtilsDialog::waitForDialog(os, new FindRepeatsDialogFiller(os, testDir + "_common_data/scenarios/sandbox/", true, 10, 75, 100));
+    GTMenu::clickMainMenuItem(os, {"Actions", "Analyze", "Find repeats..."}, GTGlobals::UseMouse);
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    GTUtilsAnnotationsTreeView::getTreeWidget(os);
-    QTreeWidgetItem *annotationGroup = GTUtilsAnnotationsTreeView::findItem(os, "repeat_unit  (0, 39)");
+    auto treeWidget = GTUtilsAnnotationsTreeView::getTreeWidget(os);
+    QTreeWidgetItem *annotationGroup = GTUtilsAnnotationsTreeView::findItem(os, "repeat_unit  (0, 39)", treeWidget);
     QTreeWidgetItem *generalItem = annotationGroup->child(36);
     CHECK_SET_ERR(generalItem != nullptr, "Invalid annotation tree item");
 
-    AVAnnotationItem *annotation = dynamic_cast<AVAnnotationItem *>(generalItem);
-    CHECK_SET_ERR(nullptr != annotation, "Annotation tree item not found");
-    CHECK_SET_ERR("76" == annotation->annotation->findFirstQualifierValue("repeat_identity"), "Annotation qualifier not found");
-
-    GTUtilsMdi::click(os, GTGlobals::Close);
-    GTMouseDriver::click();
+    auto annotation = dynamic_cast<AVAnnotationItem *>(generalItem);
+    CHECK_SET_ERR(annotation != nullptr, "Annotation tree item not found");
+    QString identityQualifierValue = annotation->annotation->findFirstQualifierValue("repeat_identity");
+    CHECK_SET_ERR(identityQualifierValue == "76", "Annotation qualifier has invalid value: " + identityQualifierValue);
 }
 
 GUI_TEST_CLASS_DEFINITION(test_3357) {

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_4001_5000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_4001_5000.cpp
@@ -303,7 +303,7 @@ GUI_TEST_CLASS_DEFINITION(test_4022) {
     // Expected: UGENE shows warning & does not crash.
 
     // 10Mb (40 * 250_000)
-    QApplication::clipboard()->setText(QString("AAAAAAAAAACCCCCCCCCCGGGGGGGGGGTTTTTTTTTT").repeated(250000));
+    GTClipboard::setText(os, QString("AAAAAAAAAACCCCCCCCCCGGGGGGGGGGTTTTTTTTTT").repeated(250000));
 
     class Scenario : public CustomScenario {
     public:
@@ -1757,13 +1757,10 @@ GUI_TEST_CLASS_DEFINITION(test_4170) {
 
     GTUtilsOptionPanelSequenceView::openAnnotationParametersShowHideWidget(os);
 
-    QLineEdit *annotationNameEdit = qobject_cast<QLineEdit *>(GTWidget::findWidget(os, "leAnnotationName"));
-    CHECK_SET_ERR(annotationNameEdit != nullptr, "chbUsePatternNames not found!");
-    annotationNameEdit->setText("pat");
+    auto annotationNameEdit = GTWidget::findLineEdit(os, "leAnnotationName");
+    GTLineEdit::setText(os, annotationNameEdit, "pat");
 
-    QCheckBox *check = qobject_cast<QCheckBox *>(GTWidget::findWidget(os, "chbUsePatternNames"));
-    CHECK_SET_ERR(check != nullptr, "chbUsePatternNames not found!");
-    GTCheckBox::setChecked(os, check, 1);
+    GTCheckBox::setChecked(os, GTWidget::findCheckBox(os, "chbUsePatternNames"), 1);
 
     CHECK_SET_ERR(annotationNameEdit->isEnabled() != true, "annotationNameEdit is enabled!");
 


### PR DESCRIPTION
…correct gui tests API calls

What is in the patch: I reviewed all places with direct  "->click()", "->setChecked", "->setText" calls on QT widgets from non-GUI threads and moved these calls into GUI threads.

I also cleaned up a little code style around such code.