### PR TITLE
Make QTimer::singleShot calls safe

### DIFF
--- a/src/corelibs/U2Gui/src/Notification.cpp
+++ b/src/corelibs/U2Gui/src/Notification.cpp
@@ -440,7 +440,7 @@ QPoint NotificationStack::getStackBottomRightPoint() const {
 bool NotificationStack::eventFilter(QObject *target, QEvent *event) {
     if (target == parentWidget) {
         if (event->type() == QEvent::Resize || event->type() == QEvent::Move) {
-            QTimer::singleShot(100, [=]() { updateOnScreenNotificationPositions(); });
+            QTimer::singleShot(100, this, [this]() { updateOnScreenNotificationPositions(); });
         }
     }
     return false;

--- a/src/corelibs/U2Lang/src/model/wizard/Wizard.h
+++ b/src/corelibs/U2Lang/src/model/wizard/Wizard.h
@@ -32,7 +32,7 @@ namespace U2 {
 
 class WizardPage;
 
-class U2LANG_EXPORT Wizard {
+class U2LANG_EXPORT Wizard : public QObject {
 public:
     Wizard(const QString &name, const QList<WizardPage *> &pages, const QString &helpPageId);
     virtual ~Wizard();

--- a/src/corelibs/U2View/src/ov_msa/phy_tree/MSAEditorTreeManager.cpp
+++ b/src/corelibs/U2View/src/ov_msa/phy_tree/MSAEditorTreeManager.cpp
@@ -282,7 +282,7 @@ void MSAEditorTreeManager::sl_openTreeTaskFinished(Task *task) {
 
     // Once tree is added to the splitter make the tree-view viewport state consistent:
     // scroll to the top-right corner to make sequence names visible.
-    QTimer::singleShot(0, [treeViewer]() {
+    QTimer::singleShot(0, treeViewer, [treeViewer]() {
         QGraphicsView *ui = treeViewer->getTreeViewerUI();
         ui->centerOn(ui->scene()->width(), 0);
     });

--- a/src/plugins/workflow_designer/src/WorkflowViewController.cpp
+++ b/src/plugins/workflow_designer/src/WorkflowViewController.cpp
@@ -1996,13 +1996,12 @@ void WorkflowView::sl_saveSceneAs() {
 }
 
 void WorkflowView::startWizard(Wizard *wizard) {
-    auto viewPointer = new QPointer<WorkflowView>(this);
-    QTimer::singleShot(100, [this, wizard, viewPointer]() {
-        // Check that the view is not closed/destroyed before running the wizard. */
-        if (!viewPointer->isNull()) {
-            runWizardAndHandleResult(wizard);
+    QPointer<Wizard> wizardPointer(wizard);
+    QTimer::singleShot(100, this, [this, wizardPointer]() {
+        // Check that the wizard is not closed/destroyed.
+        if (!wizardPointer.isNull()) {
+            runWizardAndHandleResult(wizardPointer.data());
         }
-        delete viewPointer;
     });
 }
 

--- a/src/ugeneui/src/welcome_page/WelcomePageMdiController.cpp
+++ b/src/ugeneui/src/welcome_page/WelcomePageMdiController.cpp
@@ -75,7 +75,7 @@ void WelcomePageMdiController::sl_onMdiClose(MWMDIWindow *mdi) {
 void WelcomePageMdiController::sl_onRecentChanged() {
     // Update recent list asynchronously: sl_onRecentChanged may be called within 'label->click'
     // event processing and welcomePage->updateRecent deletes the labels for missed files.
-    QTimer::singleShot(0, [this]() {
+    QTimer::singleShot(0, this, [this]() {
         CHECK(welcomePage != nullptr, );
         auto settings = AppContext::getSettings();
         QStringList recentProjects = settings->getValue(SETTINGS_DIR + RECENT_PROJECTS_SETTINGS_NAME).toStringList();


### PR DESCRIPTION
QTimer::singleShot may call the functor object after the 'stack' object is destroyed if no correct 'context' is provided.

I made this error once by myself and decided to check and fix all places like this in UGENE
