### PR TITLE
Reduce usage of GTUtilsTask in GUI tests.

### DIFF
--- a/src/plugins/GUITestBase/src/GTUtilsTask.h
+++ b/src/plugins/GUITestBase/src/GTUtilsTask.h
@@ -19,8 +19,8 @@
  * MA 02110-1301, USA.
  */
 
-#ifndef GTUTILSTASK_H
-#define GTUTILSTASK_H
+#ifndef _U2_GT_UTILS_TASK_H_
+#define _U2_GT_UTILS_TASK_H_
 
 #include "GTGlobals.h"
 
@@ -29,19 +29,21 @@ class Task;
 namespace U2 {
 using namespace HI;
 
+/**
+ * Low level task utilities.
+ * Use GTUtilsTaskTreeView for normal GUI tests (a usual user experience).
+ * Use this class only for low-level checks & waits.
+ */
 class GTUtilsTask {
 public:
-    static QList<Task *> getTopLevelTasks(HI::GUITestOpStatus &os);
-    static Task *getTaskByName(HI::GUITestOpStatus &os, QString taskName, GTGlobals::FindOptions options = GTGlobals::FindOptions(true));
-    static Task *getSubTaskByName(HI::GUITestOpStatus &os, QString taskName, GTGlobals::FindOptions options = GTGlobals::FindOptions(true));
-    static Task *getSubTaskByName(HI::GUITestOpStatus &os, Task *parent, QString taskName, GTGlobals::FindOptions options = GTGlobals::FindOptions(true));
-    static void checkTask(HI::GUITestOpStatus &os, QString taskName);
-    static void checkNoTask(HI::GUITestOpStatus &os, QString taskName);
-    static void cancelTask(HI::GUITestOpStatus &os, QString taskName);
-    static void cancelSubTask(HI::GUITestOpStatus &os, QString taskName);
-    static void waitTaskStart(HI::GUITestOpStatus &os, QString taskName, int timeOut = 180000);
+    static void checkNoTask(HI::GUITestOpStatus &os, const QString &taskName);
+
+    static void waitTaskStart(HI::GUITestOpStatus &os, const QString &taskName, int timeout = 180000);
+
+private:
+    static Task *getTaskByName(HI::GUITestOpStatus &os, const QString &taskName, const GTGlobals::FindOptions &options = {});
 };
 
 }  // namespace U2
 
-#endif  // GTUTILSTASK_H
+#endif  // _U2_GT_UTILS_TASK_H_

--- a/src/plugins/GUITestBase/src/GTUtilsTaskTreeView.h
+++ b/src/plugins/GUITestBase/src/GTUtilsTaskTreeView.h
@@ -62,15 +62,17 @@ public:
     static void cancelTask(HI::GUITestOpStatus &os, const QString &itemName, bool failIfNotFound = true, const QStringList &parentTaskNames = {});
 
     static QTreeWidgetItem *getTreeWidgetItem(HI::GUITestOpStatus &os, const QString &itemName, bool failOnNull = true);
-    static QTreeWidget *getTreeWidget(HI::GUITestOpStatus &os);
+
+    /** Returns instance of the task tree view if found. Asserts if not found and if 'failIfNotFound' is 'true'. */
+    static QTreeWidget *getTreeWidget(HI::GUITestOpStatus &os, bool failIfNotFound = false);
+
     static void moveToOpenedView(HI::GUITestOpStatus &os, const QString &itemName);
     static QPoint getTreeViewItemPosition(HI::GUITestOpStatus &os, const QString &itemName);
     static void moveTo(HI::GUITestOpStatus &os, const QString &itemName);
     static int getTopLevelTasksCount(HI::GUITestOpStatus &os);
-    static bool checkTask(HI::GUITestOpStatus &os, const QString &itemName);
 
-    /** Check that there/there-is-no task with the given name. Wait up to 30 seconds for the condition. */
-    static void checkTopLevelTaskWithWait(HI::GUITestOpStatus &os, const QString &itemNamePart, bool checkIfPresent = true);
+    /** Check that there/there-is-no top-level task with the given name. */
+    static void checkTaskIsPresent(HI::GUITestOpStatus &os, const QString &topLevelTaskName, bool checkIfPresent = true);
 
     static int countTasks(HI::GUITestOpStatus &os, const QString &itemName);
     static QString getTaskStatus(HI::GUITestOpStatus &os, const QString &itemName);

--- a/src/plugins/GUITestBase/src/GTUtilsTaskTreeView.h
+++ b/src/plugins/GUITestBase/src/GTUtilsTaskTreeView.h
@@ -54,7 +54,13 @@ public:
     static QTreeWidget *openView(HI::GUITestOpStatus &os);
 
     static void toggleView(HI::GUITestOpStatus &os);
-    static void cancelTask(HI::GUITestOpStatus &os, const QString &itemName, bool failIfNotFound = true);
+
+    /**
+     * Cancels tasks with the given name.
+     * If "parentTaskNames" is provided first expands the top-level tasks so the task tree is populated.
+     */
+    static void cancelTask(HI::GUITestOpStatus &os, const QString &itemName, bool failIfNotFound = true, const QStringList &parentTaskNames = {});
+
     static QTreeWidgetItem *getTreeWidgetItem(HI::GUITestOpStatus &os, const QString &itemName, bool failOnNull = true);
     static QTreeWidget *getTreeWidget(HI::GUITestOpStatus &os);
     static void moveToOpenedView(HI::GUITestOpStatus &os, const QString &itemName);

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_1001_2000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_1001_2000.cpp
@@ -1297,7 +1297,7 @@ GUI_TEST_CLASS_DEFINITION(test_1080) {
     GTUtilsWorkflowDesigner::runWorkflow(os);
     // Allow task to start and check there are no errors
     QString taskName = "Execute workflow";
-    GTUtilsTaskTreeView::checkTask(os, taskName);
+    GTUtilsTaskTreeView::checkTaskIsPresent(os, taskName);
     QString taskStatus = GTUtilsTaskTreeView::getTaskStatus(os, taskName);
     CHECK_SET_ERR(taskStatus == "Running", "The task status is incorrect: " + taskStatus);
     GTUtilsTaskTreeView::cancelTask(os, taskName);  // Cancel task because we don't need the result

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_1001_2000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_1001_2000.cpp
@@ -6750,7 +6750,7 @@ GUI_TEST_CLASS_DEFINITION(test_1693) {
     QWidget *samplesWidget = GTWidget::findWidget(os, "samples");
     CHECK_SET_ERR(samplesWidget != nullptr, "Samples widget is NULL");
     CHECK_SET_ERR(!samplesWidget->isEnabled(), "Samples widget is unexpectedly enabled");
-    GTUtilsTask::cancelTask(os, "Execute workflow");
+    GTUtilsTaskTreeView::cancelTask(os, "Execute workflow");
 }
 
 GUI_TEST_CLASS_DEFINITION(test_1700) {

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_1001_2000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_1001_2000.cpp
@@ -100,7 +100,6 @@
 #include "GTUtilsProject.h"
 #include "GTUtilsProjectTreeView.h"
 #include "GTUtilsSequenceView.h"
-#include "GTUtilsTask.h"
 #include "GTUtilsTaskTreeView.h"
 #include "GTUtilsWizard.h"
 #include "GTUtilsWorkflowDesigner.h"
@@ -7899,7 +7898,7 @@ GUI_TEST_CLASS_DEFINITION(test_1984) {
 
 GUI_TEST_CLASS_DEFINITION(test_1986) {
     // Download a sequence from NCBI. Use "limit" for results.
-    GTUtilsDialog::waitForDialog(os, new NCBISearchDialogSimpleFiller(os, "rat", false, 10, "Organism"));
+    GTUtilsDialog::waitForDialog(os, new NCBISearchDialogSimpleFiller(os, "rabbit", false, 10, "Organism"));
     GTMenu::clickMainMenuItem(os, {"File", "Search NCBI GenBank..."});
 
     // Expected state: the chosen sequence has been downloaded, saved in FASTA format and displayed in sequence view

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_1_1000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_1_1000.cpp
@@ -636,7 +636,8 @@ GUI_TEST_CLASS_DEFINITION(test_0598) {
     GTUtilsDialog::waitForDialog(os, new PopupChooser(os, {"Graph", "visual_properties_action"}));
     QWidget *graphView = GTUtilsSequenceView::getGraphView(os);
     GTWidget::click(os, graphView, Qt::RightButton);
-    GTUtilsTaskTreeView::checkTask(os, "Calculate graph points");
+    GTUtilsTaskTreeView::checkTaskIsPresent(os, "Calculate graph points");
+    GTUtilsTaskTreeView::waitTaskFinished(os);
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0605) {

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_2001_3000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_2001_3000.cpp
@@ -4410,7 +4410,7 @@ GUI_TEST_CLASS_DEFINITION(test_2801) {
 
     // 3. Cancel the align task.
     GTUtilsTaskTreeView::openView(os);
-    GTUtilsTaskTreeView::checkTask(os, "Run MAFFT alignment task");
+    GTUtilsTaskTreeView::checkTaskIsPresent(os, "Run MAFFT alignment task");
     GTUtilsTaskTreeView::cancelTask(os, "Run MAFFT alignment task");
     // Expected state: the task is cancelled, there is no MAFFT processes with its subprocesses (check for the "disttbfast" process)
     GTUtilsTaskTreeView::waitTaskFinished(os);
@@ -4429,7 +4429,7 @@ GUI_TEST_CLASS_DEFINITION(test_2801_1) {
 
     // 3. Cancel the "align" task.
     GTUtilsTaskTreeView::openView(os);
-    GTUtilsTaskTreeView::checkTask(os, "Run MAFFT alignment task");
+    GTUtilsTaskTreeView::checkTaskIsPresent(os, "Run MAFFT alignment task");
     GTUtilsTaskTreeView::cancelTask(os, "Run MAFFT alignment task");
     // Expected state: the task is cancelled, there is no MAFFT processes with its subprocesses (check for the "disttbfast" process)
     GTUtilsTaskTreeView::waitTaskFinished(os);
@@ -4826,7 +4826,7 @@ GUI_TEST_CLASS_DEFINITION(test_2903) {
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
     class Scenario : public CustomScenario {
-        void run(HI::GUITestOpStatus &os) {
+        void run(HI::GUITestOpStatus &os) override {
             GTWidget::getActiveModalWidget(os);
             GTKeyboardDriver::keyClick(Qt::Key_Enter);
         }
@@ -4841,14 +4841,11 @@ GUI_TEST_CLASS_DEFINITION(test_2903) {
     GTMenu::showContextMenu(os, GTWidget::findWidget(os, "ren"
                                                          "der_area_virus_X"));
     QString blastTaskName = "RemoteBLASTTask";
-    GTUtilsTaskTreeView::checkTask(os, blastTaskName);
+    GTUtilsTaskTreeView::checkTaskIsPresent(os, blastTaskName);
     GTGlobals::sleep(10000);  // Give a task some time to run.
 
     // Cancel the task. If not cancelled the run may last too long to trigger timeout in nightly tests.
-    bool isTaskRunning = GTUtilsTaskTreeView::checkTask(os, blastTaskName);
-    if (isTaskRunning) {
-        GTUtilsTaskTreeView::cancelTask(os, blastTaskName);
-    }
+    GTUtilsTaskTreeView::cancelTask(os, blastTaskName, false);
 
     GTUtilsLog::check(os, logTracer);
 }

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_3001_4000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_3001_4000.cpp
@@ -2497,7 +2497,7 @@ GUI_TEST_CLASS_DEFINITION(test_3414) {
     GTGlobals::sleep(3000);  // Wait for label to change.
     QString timeAfter = timeLabel->text();
     CHECK_SET_ERR(timeBefore != timeAfter, "timer is not changed, timeBefore: " + timeBefore + ", timeAfter: " + timeAfter);
-    GTUtilsTask::cancelTask(os, "Execute workflow");
+    GTUtilsTaskTreeView::cancelTask(os, "Execute workflow");
 }
 
 GUI_TEST_CLASS_DEFINITION(test_3428) {
@@ -4584,7 +4584,7 @@ GUI_TEST_CLASS_DEFINITION(test_3770) {
     //    Current state: the task doesn't cancel.
 
     GTUtilsDialog::waitForDialog(os, new RemoteDBDialogFillerDeprecated(os, "NW_003943623", 0, true, true, false, sandBoxDir));
-    GTMenu::clickMainMenuItem(os, {"File", "Access remote database..."},  GTGlobals::UseKey);
+    GTMenu::clickMainMenuItem(os, {"File", "Access remote database..."}, GTGlobals::UseKey);
     GTUtilsTaskTreeView::cancelTask(os, "Download remote documents");
 
     CHECK_SET_ERR(GTUtilsTaskTreeView::countTasks(os, "Download remote documents") == 0, "Task was not canceled");

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_3001_4000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_3001_4000.cpp
@@ -3144,7 +3144,7 @@ GUI_TEST_CLASS_DEFINITION(test_3519_2) {
     GTUtilsDialog::waitForDialog(os, new SiteconCustomFiller(os));
     GTMenu::clickMainMenuItem(os, {"Actions", "Analyze", "Find TFBS with SITECON..."});
 
-    CHECK_SET_ERR(GTUtilsTaskTreeView::checkTask(os, "SITECON search") == false, "SITECON task is still running");
+    GTUtilsTaskTreeView::checkTaskIsPresent(os, "SITECON search", false);
     GTUtilsTaskTreeView::cancelTask(os, "Auto-annotations update task");
     GTUtilsTaskTreeView::waitTaskFinished(os, 60000);
 }
@@ -4005,12 +4005,12 @@ GUI_TEST_CLASS_DEFINITION(test_3656) {
     GTUtils::checkExportServiceIsEnabled(os);
 
     GTMouseDriver::moveTo(GTUtilsProjectTreeView::getItemCenter(os, idx));
-    GTUtilsDialog::waitForDialog(os, new PopupChooser(os, QStringList() << ACTION_PROJECT__EXPORT_IMPORT_MENU_ACTION << ACTION_EXPORT_SEQUENCE));
+    GTUtilsDialog::waitForDialog(os, new PopupChooser(os, {ACTION_PROJECT__EXPORT_IMPORT_MENU_ACTION, ACTION_EXPORT_SEQUENCE}));
     GTUtilsDialog::waitForDialog(os, new ExportSelectedRegionFiller(os, testDir + "_common_data/scenarios/sandbox/", "test_3656.fa"));
     GTMouseDriver::click(Qt::RightButton);
 
     QString exportTaskName = "Opening view for document: test_3656.fa";
-    CHECK_SET_ERR(GTUtilsTaskTreeView::checkTask(os, exportTaskName), "Task is not running: " + exportTaskName);
+    GTUtilsTaskTreeView::checkTaskIsPresent(os, exportTaskName);
 
     GTUtilsTaskTreeView::cancelTask(os, exportTaskName);
 }

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_4001_5000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_4001_5000.cpp
@@ -778,13 +778,11 @@ GUI_TEST_CLASS_DEFINITION(test_4091) {
                            << "NC_004718 features";
 
     GTUtilsDialog::waitForDialog(os, new ProjectTreeItemSelectorDialogFiller(os, doc2Objects, acceptableTypes, ProjectTreeItemSelectorDialogFiller::Separate));
-    GTUtilsDialog::waitForDialog(os, new PopupChooser(os, QStringList() << ACTION_PROJECT__ADD_MENU << ACTION_PROJECT__ADD_OBJECT));
+    GTUtilsDialog::waitForDialog(os, new PopupChooser(os, {ACTION_PROJECT__ADD_MENU, ACTION_PROJECT__ADD_OBJECT}));
     GTUtilsProjectTreeView::click(os, "CVU55762.gb", Qt::RightButton);
-
-    GTUtilsTaskTreeView::checkTaskIsPresent(os, "Add objects to document");
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    const QModelIndex docIndex = GTUtilsProjectTreeView::findIndex(os, "CVU55762.gb");
+    QModelIndex docIndex = GTUtilsProjectTreeView::findIndex(os, "CVU55762.gb");
     GTUtilsProjectTreeView::checkItem(os, "CVU55762", docIndex);
     GTUtilsProjectTreeView::checkItem(os, "CVU55762 features", docIndex);
     GTUtilsProjectTreeView::checkItem(os, "human_T1 (UCSC April 2002 chr7:115977709-117855134)", docIndex);

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_4001_5000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_4001_5000.cpp
@@ -781,7 +781,7 @@ GUI_TEST_CLASS_DEFINITION(test_4091) {
     GTUtilsDialog::waitForDialog(os, new PopupChooser(os, QStringList() << ACTION_PROJECT__ADD_MENU << ACTION_PROJECT__ADD_OBJECT));
     GTUtilsProjectTreeView::click(os, "CVU55762.gb", Qt::RightButton);
 
-    GTUtilsTaskTreeView::checkTask(os, "Add objects to document");
+    GTUtilsTaskTreeView::checkTaskIsPresent(os, "Add objects to document");
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
     const QModelIndex docIndex = GTUtilsProjectTreeView::findIndex(os, "CVU55762.gb");
@@ -2390,16 +2390,14 @@ GUI_TEST_CLASS_DEFINITION(test_4276) {
     // 3. Select file "_common_data/fasta/PF07724_full_family.fa"
     // 4. Press "Open"
     GTUtilsDialog::waitForDialog(os, new GTFileDialogUtils(os, testDir + "_common_data/fasta/PF07724_full_family.fa"));
-    GTUtilsDialog::waitForDialog(os, new PopupChooser(os, QStringList() << MSAE_MENU_LOAD << "Sequence from file"));
+    GTUtilsDialog::waitForDialog(os, new PopupChooser(os, {MSAE_MENU_LOAD, "Sequence from file"}));
     GTWidget::click(os, GTUtilsMdi::activeWindow(os), Qt::RightButton);
 
-    // 5. Delete the alignment object
+    // 5. Delete the alignment object: current state: UGENE crashes.
     GTUtilsProjectTreeView::click(os, "COI");
     GTKeyboardDriver::keyClick(Qt::Key_Delete);
 
-    bool executed = GTUtilsTaskTreeView::checkTask(os, "Add sequences to alignment task");
-    CHECK_SET_ERR(false == executed, "The task is not cancelled");
-    // Current state: UGENE crashes
+    GTUtilsTaskTreeView::checkTaskIsPresent(os, "Add sequences to alignment task", false);
 }
 
 GUI_TEST_CLASS_DEFINITION(test_4284) {
@@ -4964,7 +4962,7 @@ GUI_TEST_CLASS_DEFINITION(test_4785_1) {
     GTUtilsDialog::waitForDialog(os, new PopupChooser(os, {MSAE_MENU_ALIGN, "Align profile to profile with MUSCLE"}));
     GTUtilsDialog::waitForDialog(os, new GTFileDialogUtils(os, dataDir + "samples/CLUSTALW", "COI.aln"));
     GTUtilsMSAEditorSequenceArea::callContextMenu(os);
-    GTUtilsTaskTreeView::checkTopLevelTaskWithWait(os, "MUSCLE");
+    GTUtilsTaskTreeView::checkTaskIsPresent(os, "MUSCLE");
 
     // 4. Delete "test_4785.aln"
     // Expected result : An error notification appears :
@@ -5601,7 +5599,7 @@ GUI_TEST_CLASS_DEFINITION(test_4913) {
     RemoteBLASTDialogFiller *filler = new RemoteBLASTDialogFiller(os, scenario);
 
     GTUtilsDialog::waitForDialog(os, filler);
-    GTUtilsDialog::waitForDialog(os, new PopupChooser(os, {"ADV_MENU_ANALYSE","Query NCBI BLAST database"}));
+    GTUtilsDialog::waitForDialog(os, new PopupChooser(os, {"ADV_MENU_ANALYSE", "Query NCBI BLAST database"}));
     GTMenu::showContextMenu(os, GTUtilsSequenceView::getSeqWidgetByNumber(os));
 }
 


### PR DESCRIPTION
Reason for the fix:
1. GTUtilsTask called "main thread" methods to cancel task from non-main thread.
2. GUI tests should check current state via UI state (like a user) and avoid access internal UGENE state via API.