### PR TITLE
UGENE-7458. Crash in NGS workflow sample "Variation annotation with

### DIFF
--- a/src/corelibs/U2Core/src/util/StrPackUtils.cpp
+++ b/src/corelibs/U2Core/src/util/StrPackUtils.cpp
@@ -92,7 +92,9 @@ StrStrMap StrPackUtils::unpackMap(const QString &string, Options options) {
         QRegExp keyValueSeparator = options == SingleQuotes ? pairSingleQuoteSeparatorRegExp : pairDoubleQuoteSeparatorRegExp;
         QStringList splitPair = pair.split(keyValueSeparator, QString::SkipEmptyParts);
         Q_ASSERT(splitPair.size() <= 2);
-        map.insert(splitPair.first(), splitPair.size() > 1 ? splitPair[1] : "");
+        if (!splitPair.empty()) {  // splitPair can be empty if both key and value are empty strings.
+            map.insert(splitPair.first(), splitPair.size() > 1 ? splitPair[1] : "");
+        }
     }
     return map;
 }

--- a/tests/regression/7458/test_0001.xml
+++ b/tests/regression/7458/test_0001.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE UGENE_TEST_FRAMEWORK_TEST> 
+<multi-test>
+    <run-cmdline
+        task="!common_data_dir!cmdline/ngs-variant-annotate/ngs_variant_annotation.uwl"
+        in="!common_data_dir!vcf/chr_copy1.vcf"
+        genome="129S1_SvImJ_v1.86"
+    />
+</multi-test>


### PR DESCRIPTION
SnpEff" for custom input file.

Fixed calling `first()` on an empty list.
Added XML test.