### PR TITLE
UGENE-7552. UGENE hangs on Linux/GTK when file dialog is opened from …

### DIFF
--- a/src/corelibs/U2Core/src/globals/Task.h
+++ b/src/corelibs/U2Core/src/globals/Task.h
@@ -569,10 +569,6 @@ public:
 
     virtual const QList<Task *> &getTopLevelTasks() const = 0;
 
-    virtual Task *getTopLevelTaskById(qint64 id) const = 0;
-
-    virtual QDateTime estimatedFinishTime(Task *) const = 0;
-
     virtual void cancelAllTasks() = 0;
 
     virtual QString getStateName(Task *t) const = 0;
@@ -581,11 +577,15 @@ public:
 
     virtual void removeThreadId(qint64 taskId) = 0;
 
-    virtual qint64 getNameByThreadId(Qt::HANDLE id) const = 0;
-
     virtual void pauseThreadWithTask(const Task *task) = 0;
 
     virtual void resumeThreadWithTask(const Task *task) = 0;
+
+    /**
+     * Returns true if the caller method is inside task processing callback (signal).
+     * This method is used to check if it is safe to run a message loop (or a modal dialog) with no side-effects for tasks.
+     */
+    virtual bool isCallerInsideTaskSchedulerCallback() const = 0;
 
 signals:
     void si_topLevelTaskRegistered(Task *);

--- a/src/corelibs/U2Gui/src/util/U2FileDialog.h
+++ b/src/corelibs/U2Gui/src/util/U2FileDialog.h
@@ -39,29 +39,26 @@ public:
                                    const QString &dir = QString(),
                                    const QString &filter = QString(),
                                    QString *selectedFilter = 0,
-                                   QFileDialog::Options options = 0);
+                                   const QFileDialog::Options &options = 0);
 
     static QStringList getOpenFileNames(QWidget *parent = 0,
                                         const QString &caption = QString(),
                                         const QString &dir = QString(),
                                         const QString &filter = QString(),
                                         QString *selectedFilter = 0,
-                                        QFileDialog::Options options = 0);
+                                        const QFileDialog::Options &options = 0);
 
     static QString getExistingDirectory(QWidget *parent = 0,
                                         const QString &caption = QString(),
                                         const QString &dir = QString(),
-                                        QFileDialog::Options options = QFileDialog::ShowDirsOnly);
+                                        const QFileDialog::Options &options = QFileDialog::ShowDirsOnly);
 
     static QString getSaveFileName(QWidget *parent = 0,
                                    const QString &caption = QString(),
                                    const QString &dir = QString(),
                                    const QString &filter = QString(),
                                    QString *selectedFilter = 0,
-                                   QFileDialog::Options options = 0);
-
-private:
-    static void activateWindow();
+                                   const QFileDialog::Options &options = 0);
 };
 
 }  // namespace U2

--- a/src/corelibs/U2Private/src/TaskSchedulerImpl.h
+++ b/src/corelibs/U2Private/src/TaskSchedulerImpl.h
@@ -66,8 +66,6 @@ public:
 
     TaskInfo *ti = nullptr;
 
-    QObject *finishEventListener = nullptr;
-
     QMutex subtasksLocker;
 
     QList<Task *> unconsideredNewSubtasks;
@@ -138,10 +136,6 @@ public:
 
     const QList<Task *> &getTopLevelTasks() const override;
 
-    Task *getTopLevelTaskById(qint64 id) const override;
-
-    QDateTime estimatedFinishTime(Task *) const override;
-
     void cancelAllTasks() override;
 
     QString getStateName(Task *t) const override;
@@ -156,9 +150,9 @@ public:
 
     void removeThreadId(qint64 taskId) override;
 
-    qint64 getNameByThreadId(Qt::HANDLE id) const override;
-
     void onSubTaskFinished(TaskThread *thread, Task *subtask);
+
+    bool isCallerInsideTaskSchedulerCallback() const override;
 
 private slots:
     void update();
@@ -202,6 +196,9 @@ private:
     AppResource *threadsResource = nullptr;
     bool stateChangesObserved = false;
     SleepPreventer *sleepPreventer = nullptr;
+
+    /** Set to 'true' for the time of any 'emit' method call. */
+    bool isInsideSchedulingUpdate = false;
 };
 
 }  // namespace U2

--- a/src/plugins/GUITestBase/src/GTUtilsMdi.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsMdi.cpp
@@ -298,7 +298,7 @@ QString GTUtilsMdi::activeWindowTitle(HI::GUITestOpStatus &os) {
 }
 #undef GT_METHOD_NAME
 
-#define GT_METHOD_NAME "activateWindow"
+#define GT_METHOD_NAME "activateAppWindow"
 void GTUtilsMdi::activateWindow(HI::GUITestOpStatus &os, const QString &windowTitlePart) {
     MainWindow *mainWindow = AppContext::getMainWindow();
 

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_3001_4000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_3001_4000.cpp
@@ -4195,21 +4195,22 @@ GUI_TEST_CLASS_DEFINITION(test_3702) {
 }
 
 GUI_TEST_CLASS_DEFINITION(test_3710) {
-    //    1. Open "_common_data/scenarios/msa/ma2_gapped.aln".
     GTFileDialog::openFile(os, testDir + "_common_data/scenarios/msa/ma2_gapped.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    //    2. Open the Highlighting option panel tab.
+
     GTUtilsOptionPanelMsa::openTab(os, GTUtilsOptionPanelMsa::Highlighting);
-    //    3. Select "Phaneroptera_falcata" as the reference sequence.
     GTUtilsOptionPanelMsa::addReference(os, "Phaneroptera_falcata");
-    //    4. Click the Export button.
+
+    GTUtils::checkExportServiceIsEnabled(os);
+
     GTUtilsNotifications::waitForNotification(os, false, "Report for task: 'Export highlighting'");
     GTUtilsDialog::waitForDialog(os, new ExportHighlightedDialogFiller(os, sandBoxDir + "export_test_3710"));
 
-    QComboBox *highlightingScheme = GTWidget::findExactWidget<QComboBox *>(os, "highlightingScheme");
+    auto highlightingScheme = GTWidget::findComboBox(os, "highlightingScheme");
     GTComboBox::selectItemByText(os, highlightingScheme, "Agreements");
     GTWidget::click(os, GTWidget::findWidget(os, "exportHighlightning"));
-    //    5. Export.
+    GTUtilsTaskTreeView::waitTaskFinished(os);
+
     CHECK_SET_ERR(GTFile::getSize(os, sandBoxDir + "export_test_3710") != 0, "Exported file is empty!");
 }
 

--- a/src/plugins/dbi_bam/src/ConvertToSQLiteDialog.cpp
+++ b/src/plugins/dbi_bam/src/ConvertToSQLiteDialog.cpp
@@ -261,13 +261,7 @@ void ConvertToSQLiteDialog::sl_refUrlButtonClicked() {
         currentUrl = sourceUrl;
     }
     QString dir = currentUrl.dirPath() + "/" + currentUrl.baseFileName();
-    QString value;
-#ifdef Q_OS_DARWIN
-    if (qgetenv(ENV_GUI_TEST).toInt() == 1 && qgetenv(ENV_USE_NATIVE_DIALOGS).toInt() == 0) {
-        value = U2FileDialog::getOpenFileName(this, QObject::tr("Reference File"), dir, "", 0, QFileDialog::DontUseNativeDialog);
-    } else
-#endif
-        value = U2FileDialog::getOpenFileName(this, QObject::tr("Reference File"), dir);
+    QString value = U2FileDialog::getOpenFileName(this, QObject::tr("Reference File"), dir);
     if (!value.isEmpty()) {
         ui.refUrlEdit->setText(value);
         hideReferenceMessage();


### PR DESCRIPTION
…ConvertToSQLiteDialog during SAM import

I fixed all QFileDialogs invocation in UGENE to fall-back to non-native mode in case if the dialog is called from within Task Scheduler callback. This mode is common for all platforms and is known to be safe.

This is workaround that works. The correct solution would be a complete ban of running modal dialogs from the TaskScheduler callback: this is a huge task that needs to be analyzed/estimated first.
