### PR TITLE
BWA-MEM: Fix "skip mate rescue" parameter type in the workflow designer

### DIFF
--- a/src/plugins/external_tool_support/src/bwa/BwaMemWorker.cpp
+++ b/src/plugins/external_tool_support/src/bwa/BwaMemWorker.cpp
@@ -251,7 +251,6 @@ void BwaMemWorkerFactory::init() {
         delegates[BAND_WIDTH] = new SpinBoxDelegate(spinMap);
         delegates[DROPOFF] = new SpinBoxDelegate(spinMap);
         delegates[INTERNAL_SEED_LOOKUP] = new DoubleSpinBoxDelegate(spinMap);
-        delegates[SKIP_MATE_RESCUES] = new SpinBoxDelegate(spinMap);
         delegates[DROP_CHAINS_THRESHOLD] = new DoubleSpinBoxDelegate(spinMap);
         delegates[MAX_MATE_RESCUES] = new SpinBoxDelegate(spinMap);
         delegates[MATCH_SCORE] = new SpinBoxDelegate(spinMap);


### PR DESCRIPTION
Fix usage of the numeric value editor for the boolean BWA MEM parameter "skip mate rescue" in the workflow schemes designer.
Before:
![skip_mate_rescue_old](https://user-images.githubusercontent.com/19434095/154817646-def0dd99-3231-4271-b36b-02630a04c5b1.png)
After:
![SKIP_MATE_RESCUE](https://user-images.githubusercontent.com/19434095/154817658-f201fb96-b52c-43a3-b931-93ba17bfec39.png)

