### PR TITLE
Rename 'Number of CPUs being used' to 'Number of threads'

### DIFF
--- a/src/plugins/external_tool_support/src/blast/BlastLocalSearchDialog.ui
+++ b/src/plugins/external_tool_support/src/blast/BlastLocalSearchDialog.ui
@@ -266,7 +266,7 @@
          <item>
           <widget class="QLabel" name="label_15">
            <property name="text">
-            <string>Number of CPUs being used</string>
+            <string>Number of threads</string>
            </property>
           </widget>
          </item>

--- a/src/plugins/external_tool_support/src/clustalo/ClustalOSupportRunDialog.ui
+++ b/src/plugins/external_tool_support/src/clustalo/ClustalOSupportRunDialog.ui
@@ -224,7 +224,7 @@
             <item row="0" column="0">
              <widget class="QLabel" name="label">
               <property name="text">
-               <string>Number of CPUs being used</string>
+               <string>Number of threads</string>
               </property>
              </widget>
             </item>

--- a/src/plugins/external_tool_support/transl/russian.ts
+++ b/src/plugins/external_tool_support/transl/russian.ts
@@ -200,7 +200,7 @@
     </message>
     <message>
         <location filename="../src/blast/BlastLocalSearchDialog.ui" line="269"/>
-        <source>Number of CPUs being used</source>
+        <source>Number of threads</source>
         <translation>Использовать процессоров</translation>
     </message>
     <message>
@@ -1620,7 +1620,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../src/clustalo/ClustalOSupportRunDialog.ui" line="227"/>
-        <source>Number of CPUs being used</source>
+        <source>Number of threads</source>
         <translation>Использовать процессоров</translation>
     </message>
     <message>

--- a/src/plugins/external_tool_support/transl/turkish.ts
+++ b/src/plugins/external_tool_support/transl/turkish.ts
@@ -151,7 +151,7 @@
     </message>
     <message>
         <location filename="../src/utils/BlastAllSupportDialog.ui" line="274"/>
-        <source>Number of CPUs being used</source>
+        <source>Number of threads</source>
         <translation>Kullanılan CPU sayısı</translation>
     </message>
     <message>
@@ -1654,7 +1654,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../src/clustalo/ClustalOSupportRunDialog.ui" line="227"/>
-        <source>Number of CPUs being used</source>
+        <source>Number of threads</source>
         <translation>Kullanılan CPU sayısı</translation>
     </message>
     <message>


### PR DESCRIPTION
This way it correlates with the original BLAST option (num_threads) and sounds better.