### PR TITLE
UGENE-7544. Can't connect to locally created shared MySQL database

### DIFF
--- a/src/corelibs/U2Core/src/dbi/U2AbstractDbi.h
+++ b/src/corelibs/U2Core/src/dbi/U2AbstractDbi.h
@@ -145,6 +145,7 @@ public:
         std::sort(upgraders.begin(), upgraders.end());
         for (const U2DbiUpgrader* upgrader : qAsConst(upgraders)) {
             Version dbVersion = Version::parseVersion(getProperty(U2DbiOptions::APP_MIN_COMPATIBLE_VERSION, "0.0.0", os));
+            CHECK_OP(os, );
             if (upgrader->isApplicable(dbVersion)) {
                 upgrader->upgrade(os);
                 CHECK_OP(os, );

--- a/src/corelibs/U2Core/src/dbi/U2AbstractDbi.h
+++ b/src/corelibs/U2Core/src/dbi/U2AbstractDbi.h
@@ -143,8 +143,9 @@ public:
 
     virtual void upgrade(U2OpStatus& os) {
         std::sort(upgraders.begin(), upgraders.end());
-        foreach (const U2DbiUpgrader* upgrader, upgraders) {
-            if (upgrader->isAppliable(Version::parseVersion(getProperty(U2DbiOptions::APP_MIN_COMPATIBLE_VERSION, "0.0.0", os)))) {
+        for (const U2DbiUpgrader* upgrader : qAsConst(upgraders)) {
+            Version dbVersion = Version::parseVersion(getProperty(U2DbiOptions::APP_MIN_COMPATIBLE_VERSION, "0.0.0", os));
+            if (upgrader->isApplicable(dbVersion)) {
                 upgrader->upgrade(os);
                 CHECK_OP(os, );
             }

--- a/src/corelibs/U2Core/src/dbi/U2DbiUtils.cpp
+++ b/src/corelibs/U2Core/src/dbi/U2DbiUtils.cpp
@@ -208,8 +208,9 @@ bool U2DbiUtils::isDbiReadOnly(const U2DbiRef& dbiRef) {
 
 Version U2DbiUtils::getDbMinRequiredVersion(const U2DbiRef& dbiRef, U2OpStatus& os) {
     DbiConnection con(dbiRef, os);
-    CHECK_OP(os, Version());
+    CHECK_OP(os, {});
     QString minCompatibleVersionFromDb = con.dbi->getProperty(U2DbiOptions::APP_MIN_COMPATIBLE_VERSION, "", os);
+    CHECK_OP(os, {});
     return Version::parseVersion(minCompatibleVersionFromDb);
 }
 

--- a/src/corelibs/U2Core/src/dbi/U2DbiUtils.cpp
+++ b/src/corelibs/U2Core/src/dbi/U2DbiUtils.cpp
@@ -209,7 +209,8 @@ bool U2DbiUtils::isDbiReadOnly(const U2DbiRef& dbiRef) {
 Version U2DbiUtils::getDbMinRequiredVersion(const U2DbiRef& dbiRef, U2OpStatus& os) {
     DbiConnection con(dbiRef, os);
     CHECK_OP(os, Version());
-    return Version::parseVersion(con.dbi->getProperty(U2DbiOptions::APP_MIN_COMPATIBLE_VERSION, "", os));
+    QString minCompatibleVersionFromDb = con.dbi->getProperty(U2DbiOptions::APP_MIN_COMPATIBLE_VERSION, "", os);
+    return Version::parseVersion(minCompatibleVersionFromDb);
 }
 
 bool U2DbiUtils::isDatabaseTooNew(const U2DbiRef& dbiRef, const Version& ugeneVersion, QString& minRequiredVersionString, U2OpStatus& os) {
@@ -220,7 +221,7 @@ bool U2DbiUtils::isDatabaseTooNew(const U2DbiRef& dbiRef, const Version& ugeneVe
 }
 
 bool U2DbiUtils::isDatabaseTooOld(const U2DbiRef& dbiRef, const Version& ugeneVersion, U2OpStatus& os) {
-    const Version minRequiredVersion = getDbMinRequiredVersion(dbiRef, os);
+    Version minRequiredVersion = getDbMinRequiredVersion(dbiRef, os);
     CHECK_OP(os, false);
     return minRequiredVersion < ugeneVersion;
 }

--- a/src/corelibs/U2Core/src/util/U2DbiUpgrader.cpp
+++ b/src/corelibs/U2Core/src/util/U2DbiUpgrader.cpp
@@ -33,7 +33,7 @@ U2DbiUpgrader::U2DbiUpgrader(const Version& versionFrom, const Version& versionT
 U2DbiUpgrader::~U2DbiUpgrader() {
 }
 
-bool U2DbiUpgrader::isAppliable(const Version& dbVersion) const {
+bool U2DbiUpgrader::isApplicable(const Version& dbVersion) const {
     return versionFrom == dbVersion;
 }
 

--- a/src/corelibs/U2Core/src/util/U2DbiUpgrader.h
+++ b/src/corelibs/U2Core/src/util/U2DbiUpgrader.h
@@ -34,7 +34,7 @@ public:
     virtual ~U2DbiUpgrader();
 
     virtual void upgrade(U2OpStatus& os) const = 0;
-    bool isAppliable(const Version& dbVersion) const;
+    bool isApplicable(const Version& dbVersion) const;
     bool operator<(const U2DbiUpgrader& other) const;
 
 protected:

--- a/src/corelibs/U2Formats/U2Formats.pro
+++ b/src/corelibs/U2Formats/U2Formats.pro
@@ -79,6 +79,7 @@ HEADERS += src/ABIFormat.h \
            src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_16_To_1_17.h \
            src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_16_To_1_24.h \
            src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_24_To_1_25.h \
+           src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_25_unknown_To_1_25.h \
            src/sqlite_dbi/SQLiteAssemblyDbi.h \
            src/sqlite_dbi/SQLiteAttributeDbi.h \
            src/sqlite_dbi/SQLiteBlobInputStream.h \
@@ -188,6 +189,7 @@ SOURCES += src/ABIFormat.cpp \
            src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_16_To_1_17.cpp \
            src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_16_To_1_24.cpp \
            src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_24_To_1_25.cpp \
+           src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_25_unknown_To_1_25.cpp \
            src/sqlite_dbi/SQLiteAssemblyDbi.cpp \
            src/sqlite_dbi/SQLiteAttributeDbi.cpp \
            src/sqlite_dbi/SQLiteBlobInputStream.cpp \

--- a/src/corelibs/U2Formats/src/mysql_dbi/MysqlDbi.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/MysqlDbi.cpp
@@ -45,6 +45,7 @@
 #include "util/upgraders/MysqlUpgraderFrom_1_16_To_1_17.h"
 #include "util/upgraders/MysqlUpgraderFrom_1_16_To_1_24.h"
 #include "util/upgraders/MysqlUpgraderFrom_1_24_To_1_25.h"
+#include "util/upgraders/MysqlUpgraderFrom_1_25_unknown_To_1_25.h"
 
 namespace U2 {
 
@@ -73,6 +74,7 @@ MysqlDbi::MysqlDbi()
     upgraders << new MysqlUpgraderFrom_1_16_To_1_17(this);
     upgraders << new MysqlUpgraderFrom_1_16_To_1_24(this);
     upgraders << new MysqlUpgraderFrom_1_24_To_1_25(this);
+    upgraders << new MysqlUpgraderFrom_1_25_unknown_To_1_25(this);
 }
 
 MysqlDbi::~MysqlDbi() {

--- a/src/corelibs/U2Formats/src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_24_To_1_25.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_24_To_1_25.cpp
@@ -39,7 +39,7 @@ MysqlUpgraderFrom_1_24_To_1_25::MysqlUpgraderFrom_1_24_To_1_25(MysqlDbi* dbi)
 void MysqlUpgraderFrom_1_24_To_1_25::upgrade(U2OpStatus& os) const {
     MysqlTransaction t(dbi->getDbRef(), os);
 
-    dropOldPrecedure(os, dbi->getDbRef());
+    dropOldProcedure(os, dbi->getDbRef());
     CHECK_OP(os, );
 
     upgradeCoverageAttribute(os);
@@ -48,7 +48,7 @@ void MysqlUpgraderFrom_1_24_To_1_25::upgrade(U2OpStatus& os) const {
     dbi->setProperty(U2DbiOptions::APP_MIN_COMPATIBLE_VERSION, versionTo.toString(), os);
 }
 
-void MysqlUpgraderFrom_1_24_To_1_25::dropOldPrecedure(U2OpStatus& os, MysqlDbRef* dbRef) const {
+void MysqlUpgraderFrom_1_24_To_1_25::dropOldProcedure(U2OpStatus& os, MysqlDbRef* dbRef) const {
     U2OpStatus2Log nonCriticalOs;
     U2SqlQuery("DROP PROCEDURE IF EXISTS CreateIndex", dbRef, nonCriticalOs).execute();
 

--- a/src/corelibs/U2Formats/src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_24_To_1_25.h
+++ b/src/corelibs/U2Formats/src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_24_To_1_25.h
@@ -32,10 +32,10 @@ class MysqlUpgraderFrom_1_24_To_1_25 : public MysqlUpgrader {
 public:
     MysqlUpgraderFrom_1_24_To_1_25(MysqlDbi* dbi);
 
-    void upgrade(U2OpStatus& os) const;
+    void upgrade(U2OpStatus& os) const override;
 
 private:
-    void dropOldPrecedure(U2OpStatus& os, MysqlDbRef* dbRef) const;
+    void dropOldProcedure(U2OpStatus& os, MysqlDbRef* dbRef) const;
     void upgradeCoverageAttribute(U2OpStatus& os) const;
 };
 

--- a/src/corelibs/U2Formats/src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_25_unknown_To_1_25.cpp
+++ b/src/corelibs/U2Formats/src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_25_unknown_To_1_25.cpp
@@ -1,0 +1,49 @@
+/**
+ * UGENE - Integrated Bioinformatics Tools.
+ * Copyright (C) 2008-2022 UniPro <ugene@unipro.ru>
+ * http://ugene.net
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#include "MysqlUpgraderFrom_1_25_unknown_To_1_25.h"
+
+#include <U2Core/U2AssemblyUtils.h>
+#include <U2Core/U2AttributeUtils.h>
+#include <U2Core/U2CoreAttributes.h>
+#include <U2Core/U2OpStatusUtils.h>
+#include <U2Core/U2SafePoints.h>
+
+#include "mysql_dbi/MysqlDbi.h"
+#include "mysql_dbi/util/MysqlHelpers.h"
+
+namespace U2 {
+
+MysqlUpgraderFrom_1_25_unknown_To_1_25::MysqlUpgraderFrom_1_25_unknown_To_1_25(MysqlDbi* dbi)
+    : MysqlUpgrader(Version::parseVersion("unknown"), Version::parseVersion("1.25.0"), dbi) {
+}
+
+void MysqlUpgraderFrom_1_25_unknown_To_1_25::upgrade(U2OpStatus& os) const {
+    MysqlTransaction t(dbi->getDbRef(), os);
+    // Update version in the database to the correct one.
+    // Only UGENE v41 has 'unknown' in the DB which must be replaced with "1.25.0".
+    QString currentVersion = dbi->getProperty(U2DbiOptions::APP_MIN_COMPATIBLE_VERSION, "", os);
+    if (currentVersion == "unknown") {
+        dbi->setProperty(U2DbiOptions::APP_MIN_COMPATIBLE_VERSION, versionTo.toString(), os);
+    }
+}
+
+}  // namespace U2

--- a/src/corelibs/U2Formats/src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_25_unknown_To_1_25.h
+++ b/src/corelibs/U2Formats/src/mysql_dbi/util/upgraders/MysqlUpgraderFrom_1_25_unknown_To_1_25.h
@@ -19,27 +19,22 @@
  * MA 02110-1301, USA.
  */
 
-#ifndef _U2_MYSQL_UPGRADE_TASK_H_
-#define _U2_MYSQL_UPGRADE_TASK_H_
+#ifndef _U2_MYSQL_UPGRADER_FROM_1_25_UNKNOWN_TO_1_25_H_
+#define _U2_MYSQL_UPGRADER_FROM_1_25_UNKNOWN_TO_1_25_H_
 
-#include <U2Core/Task.h>
-#include <U2Core/U2Type.h>
+#include "MysqlUpgrader.h"
 
 namespace U2 {
 
-class U2FORMATS_EXPORT MysqlUpgradeTask : public Task {
-    Q_OBJECT
+class MysqlDbRef;
+
+class MysqlUpgraderFrom_1_25_unknown_To_1_25 : public MysqlUpgrader {
 public:
-    MysqlUpgradeTask(const U2DbiRef& dbiRef);
+    MysqlUpgraderFrom_1_25_unknown_To_1_25(MysqlDbi* dbi);
 
-    void run() override;
-
-    const U2DbiRef& getDbiRef() const;
-
-private:
-    const U2DbiRef dbiRef;
+    void upgrade(U2OpStatus& os) const override;
 };
 
 }  // namespace U2
 
-#endif  // _U2_MYSQL_UPGRADE_TASK_H_
+#endif  // _U2_MYSQL_UPGRADER_FROM_1_25_UNKNOWN_TO_1_25_H_

--- a/src/corelibs/U2Gui/src/util/shared_db/SharedConnectionsDialog.cpp
+++ b/src/corelibs/U2Gui/src/util/shared_db/SharedConnectionsDialog.cpp
@@ -503,8 +503,8 @@ bool SharedConnectionsDialog::checkDbShouldBeUpgraded(const U2DbiRef& ref) {
         const int dialogResult = question->exec();
         CHECK(!question.isNull(), true);
 
-        if (QMessageBox::Ok == dialogResult) {
-            MysqlUpgradeTask* upgradeTask = new MysqlUpgradeTask(ref);
+        if (dialogResult == QMessageBox::Ok) {
+            auto upgradeTask = new MysqlUpgradeTask(ref);
             upgradeTasks.insert(ui->lwConnections->currentItem(), upgradeTask);
             connect(new TaskSignalMapper(upgradeTask), SIGNAL(si_taskFinished(Task*)), SLOT(sl_upgradeComplete(Task*)));
             AppContext::getTaskScheduler()->registerTopLevelTask(upgradeTask);


### PR DESCRIPTION
About: database created in v41 can't be opened/upgraded in v42.

This fix adds almost 0 value: the broken database created by v41 can only be opened once during creation and never after. 

So such database most probably will have no user data and nothing to restore/migrate: a user should just re-create it.

If you think that we should not submit this fix at all please comment