### PR TITLE
UGENE-7117 Can not remove folder for temporary files error if cancel building tree

### DIFF
--- a/src/corelibs/U2Core/src/tasks/ExternalToolRunTask.cpp
+++ b/src/corelibs/U2Core/src/tasks/ExternalToolRunTask.cpp
@@ -334,14 +334,8 @@ void ExternalToolSupportUtils::removeTmpDir(const QString& tmpDirUrl, U2OpStatus
         return;
     }
     QDir tmpDir(tmpDirUrl);
-    foreach (const QString& file, tmpDir.entryList(QDir::NoDotAndDotDot | QDir::AllEntries)) {
-        if (!tmpDir.remove(file)) {
-            os.setError(tr("Can not remove files from temporary folder."));
-            return;
-        }
-    }
-    if (!tmpDir.rmdir(tmpDir.absolutePath())) {
-        os.setError(tr("Can not remove folder for temporary files."));
+    if (!tmpDir.removeRecursively()) {
+        os.setError(tr("Can not remove folder for temporary files, folder \"%1\".").arg(tmpDir.absolutePath()));
     }
 }
 


### PR DESCRIPTION
The problem has appeared because files was removing a bit longer that anticipated and then `rmdir` function started to remove the directory, this directory wasn't empty (for [rmdir](https://doc.qt.io/qt-5/qdir.html#rmdir) success he removing directory should be empty, see docs)