### PR TITLE
UGENE-5371. Problem with opening assembly from folder with non-ASCII symbols in path

### DIFF
--- a/src/corelibs/U2Core/src/globals/GUrl.cpp
+++ b/src/corelibs/U2Core/src/globals/GUrl.cpp
@@ -139,30 +139,6 @@ bool GUrl::operator!=(const GUrl& url) const {
     return !(*this == url);
 }
 
-QByteArray GUrl::getURLStringAnsi(int codePage) const {
-#ifdef Q_OS_WIN
-    std::wstring wPath = getURLString().toStdWString();
-    codePage = codePage < 0 ? CP_THREAD_ACP : codePage;
-
-    DWORD buffSize = WideCharToMultiByte(codePage, 0, wPath.c_str(), -1, nullptr, 0, nullptr, nullptr);
-    if (!buffSize) {
-        return QByteArray();
-    }
-
-    char* buffer = new char[buffSize + 1];
-    if (!WideCharToMultiByte(codePage, 0, wPath.c_str(), -1, buffer, buffSize, nullptr, nullptr)) {
-        delete[] buffer;
-        return QByteArray();
-    }
-    QByteArray bytes = QByteArray(buffer, buffSize + 1);
-    delete[] buffer;
-    return bytes;
-#else
-    Q_UNUSED(codePage);
-    return getURLString().toLocal8Bit();
-#endif  // Q_OS_WIN
-}
-
 static QString path(const GUrl* url) {
     // TODO: parse HTTP and other formats for path part
     QString result;

--- a/src/corelibs/U2Core/src/globals/GUrl.h
+++ b/src/corelibs/U2Core/src/globals/GUrl.h
@@ -77,12 +77,6 @@ public:
         return urlString;
     }
 
-    /**
-     * The function converts url string to multibyte form for Windows (default code page is CP_THREAD_ACP)
-     * And calls to getURLString().toLocal8Bit() on Linux & Mac platforms.
-     */
-    QByteArray getURLStringAnsi(int codePage = -1) const;
-
     GUrlType getType() const {
         return type;
     }

--- a/src/corelibs/U2Formats/src/BAMUtils.cpp
+++ b/src/corelibs/U2Formats/src/BAMUtils.cpp
@@ -92,9 +92,15 @@ BAMUtils::ConvertOption::ConvertOption(bool samToBam, const QString& referenceUr
     : samToBam(samToBam), referenceUrl(referenceUrl) {
 }
 
-static samfile_t* samOpen(const QString& url, const char* mode, const void* aux) {
-    int fd = fileno(BAMUtils::openFile(url, mode));
-    return samopen_with_fd("", fd, mode, aux);
+static samfile_t* samOpen(const QString& url, const char* samMode, const void* aux) {
+    QString fileMode = samMode;
+    fileMode.replace("h", "");
+    FILE* file = BAMUtils::openFile(url, fileMode);
+    samfile_t* samfile = samopen_with_fd("", fileno(file), samMode, aux);
+    if (samfile == nullptr) {
+        closeFileIfOpen(file);
+    }
+    return samfile;
 }
 
 /** Safely opens gzip file. Supports unicode file names. */

--- a/src/corelibs/U2Formats/src/BAMUtils.cpp
+++ b/src/corelibs/U2Formats/src/BAMUtils.cpp
@@ -95,11 +95,8 @@ static samfile_t* samOpen(const QString& url, const char* mode, const void* aux)
 static gzFile openGzipFile(const QString& fileUrl, const char* mode = "r") {
     gzFile fp = nullptr;
 #ifdef Q_OS_WIN
-    wchar_t* unicodeFileName = new wchar_t[fileUrl.length() + 1];
-    int unicodeFileNameLength = fileUrl.toWCharArray(unicodeFileName);
-    unicodeFileName[unicodeFileNameLength] = 0;
-    fp = gzopen_w(unicodeFileName, mode);
-    delete unicodeFileName;
+    QScopedPointer<wchar_t> unicodeFileName(toWideCharsArray(fileUrl));
+    fp = gzopen_w(unicodeFileName.data(), mode);
 #else
     fp = gzopen(fileUrl.toLocal8Bit().constData(), mode);
 #endif

--- a/src/corelibs/U2Formats/src/BAMUtils.cpp
+++ b/src/corelibs/U2Formats/src/BAMUtils.cpp
@@ -71,7 +71,7 @@ static wchar_t* toWideCharsArray(const QString& text) {
     return wideCharsText;
 }
 
-static int openFile(const QString& fileUrl, const QString& mode) {
+int BAMUtils::openFile(const QString& fileUrl, const QString& mode) {
 #ifdef Q_OS_WIN
     QScopedPointer<wchar_t> unicodeFileName(toWideCharsArray(fileUrl));
     QScopedPointer<wchar_t> unicodeMode(toWideCharsArray(mode));

--- a/src/corelibs/U2Formats/src/BAMUtils.cpp
+++ b/src/corelibs/U2Formats/src/BAMUtils.cpp
@@ -308,10 +308,9 @@ bool BAMUtils::isSortedBam(const GUrl& bamUrl, U2OpStatus& os) {
     QString error;
     bool result = false;
 
-    int fd = fileno(openFile(urlPath, "rb"));
-    bamFile bamHandler = bam_dopen(fd, "rb");
+    FILE* file = openFile(urlPath, "rb");
+    bamFile bamHandler = bam_dopen(fileno(file), "rb");
     if (bamHandler != nullptr) {
-        bamHandler->owned_file = 1;
         header = bam_header_read(bamHandler);
         if (header != nullptr) {
             result = isSorted(header->text);
@@ -330,6 +329,7 @@ bool BAMUtils::isSortedBam(const GUrl& bamUrl, U2OpStatus& os) {
         if (bamHandler != nullptr) {
             bam_close(bamHandler);
         }
+        closeFileIfOpen(file);
     }
 
     if (!error.isEmpty()) {

--- a/src/corelibs/U2Formats/src/BAMUtils.cpp
+++ b/src/corelibs/U2Formats/src/BAMUtils.cpp
@@ -304,8 +304,8 @@ bool BAMUtils::isSortedBam(const GUrl& bamUrl, U2OpStatus& os) {
     QString error;
     bool result = false;
 
-    int fd = fileno(openFile(urlPath, "r"));
-    bamFile bamHandler = bam_dopen(fd, "r");
+    int fd = fileno(openFile(urlPath, "rb"));
+    bamFile bamHandler = bam_dopen(fd, "rb");
     if (bamHandler != nullptr) {
         bamHandler->owned_file = 1;
         header = bam_header_read(bamHandler);
@@ -401,7 +401,7 @@ GUrl BAMUtils::sortBam(const GUrl& bamUrl, const QString& sortedBamBaseName, U2O
                             .arg(sortedFileName));
         size_t maxMemBytes = (size_t)(mB2bytes(maxMemMB));  // maxMemMB < 500 Mb, so the conversation is correct!
         QByteArray baseNameArray = baseName.toUtf8();
-        FILE* file = openFile(bamFileName, "r");
+        FILE* file = openFile(bamFileName, "rb");
         bam_sort_core_ext(0, "", baseNameArray.constData(), maxMemBytes, false, fileno(file));  // maxMemBytes
     }
     memory->release(maxMemMB);
@@ -523,9 +523,9 @@ bool BAMUtils::hasValidFastaIndex(const GUrl& fastaUrl) {
  * Exact copy of 'bam_index_build2' with a correct unicode file names support.
  */
 static int bam_index_build_unicode(const QString& bamFileName) {
-    FILE* bFile = BAMUtils::openFile(bamFileName, "r");
+    FILE* bFile = BAMUtils::openFile(bamFileName, "rb");
     CHECK(bFile != nullptr, -1);
-    bamFile fp = bam_dopen(fileno(bFile), "r");
+    bamFile fp = bam_dopen(fileno(bFile), "rb");
     if (fp == nullptr) {
         closeFileIfOpen(bFile);
         fprintf(stderr, "[bam_index_build2] fail to open the BAM file.\n");

--- a/src/corelibs/U2Formats/src/BAMUtils.cpp
+++ b/src/corelibs/U2Formats/src/BAMUtils.cpp
@@ -63,14 +63,8 @@ extern "C" {
 
 namespace U2 {
 
-OpenFile::OpenFile(const QString& path, const QString& mode) {
-    file = fopen(path.toLocal8Bit(), mode.toLocal8Bit());
-}
-
-OpenFile::~OpenFile() {
-    fclose(file);
-}
-int OpenFile::handle() const {
+int BAMUtils::openFile(const QString& path, const QString& mode) {
+    FILE* file = fopen(path.toLocal8Bit(), mode.toLatin1());
     return fileno(file);
 }
 
@@ -79,8 +73,8 @@ BAMUtils::ConvertOption::ConvertOption(bool samToBam, const QString& referenceUr
 }
 
 static samfile_t* samOpen(const QString& url, const char* mode, const void* aux) {
-    OpenFile file(url, mode);
-    return samopen_with_fd(url.toLocal8Bit(), file.handle(), mode, aux);
+    int fd = BAMUtils::openFile(url, mode);
+    return samopen_with_fd(url.toLocal8Bit(), fd, mode, aux);
 }
 
 /** Safely opens gzip file. Supports unicode file names. */
@@ -283,8 +277,8 @@ bool BAMUtils::isSortedBam(const GUrl& bamUrl, U2OpStatus& os) {
     QString error;
     bool result = false;
 
-    OpenFile file(urlPath);
-    bamFile bamHandler = bam_dopen(file.handle(), "r");
+    int fd = openFile(urlPath, "r");
+    bamFile bamHandler = bam_dopen(fd, "r");
     if (bamHandler != nullptr) {
         header = bam_header_read(bamHandler);
         if (header != nullptr) {

--- a/src/corelibs/U2Formats/src/BAMUtils.cpp
+++ b/src/corelibs/U2Formats/src/BAMUtils.cpp
@@ -382,7 +382,7 @@ GUrl BAMUtils::sortBam(const GUrl& bamUrl, const QString& sortedBamBaseName, U2O
                             .arg(maxMemMB)
                             .arg(sortedFileName));
         size_t maxMemBytes = (size_t)(mB2bytes(maxMemMB));  // maxMemMB < 500 Mb, so the conversation is correct!
-        QByteArray baseNameArray = baseName.toLocal8Bit();
+        QByteArray baseNameArray = baseName.toUtf8();
         FILE* file = openFile(bamFileName, "r");
         bam_sort_core_ext(0, "", baseNameArray.constData(), maxMemBytes, false, fileno(file));  // maxMemBytes
     }
@@ -450,7 +450,7 @@ void* BAMUtils::loadIndex(const QString& filePath) {
     // See bam_index_load_local.
     QString mode = "rb";
     FILE* fp = openFile(filePath, mode);
-    if (fp == nullptr && filePath.endsWith(".bai")) {
+    if (fp == nullptr && filePath.endsWith(".bam")) {
         fp = openFile(filePath.left(filePath.length() - 4) + ".bai", mode);
     }
     CHECK(fp != nullptr, nullptr);

--- a/src/corelibs/U2Formats/src/BAMUtils.cpp
+++ b/src/corelibs/U2Formats/src/BAMUtils.cpp
@@ -455,7 +455,10 @@ void* BAMUtils::loadIndex(const QString& filePath) {
     }
     CHECK(fp != nullptr, nullptr);
     bam_index_t* idx = bam_index_load_core(fp);
-    fclose(fp);
+    if(idx != nullptr){
+        fclose(fp);
+    }
+
     return idx;
 }
 

--- a/src/corelibs/U2Formats/src/BAMUtils.cpp
+++ b/src/corelibs/U2Formats/src/BAMUtils.cpp
@@ -532,7 +532,7 @@ void BAMUtils::createBamIndex(const GUrl& bamUrl, U2OpStatus& os) {
     QString urlPath = bamUrl.getURLString();
     coreLog.details(BAMUtils::tr("Build index for bam file: \"%1\"").arg(urlPath));
 
-    int error = bam_index_build(urlPath.toLocal8Bit());
+    int error = bam_index_build_unicode(urlPath);
     if (error == -1) {
         os.setError("Can't build the index");
     }

--- a/src/corelibs/U2Formats/src/BAMUtils.cpp
+++ b/src/corelibs/U2Formats/src/BAMUtils.cpp
@@ -63,8 +63,22 @@ extern "C" {
 
 namespace U2 {
 
-int BAMUtils::openFile(const QString& path, const QString& mode) {
-    FILE* file = fopen(path.toLocal8Bit(), mode.toLatin1());
+/** Converts QString to wchar_t*. Caller is responsible to deallocated the returned result memory. */
+static wchar_t* toWideCharsArray(const QString& text) {
+    wchar_t* wideCharsText = new wchar_t[text.length() + 1];
+    int unicodeFileNameLength = text.toWCharArray(wideCharsText);
+    wideCharsText[unicodeFileNameLength] = 0;
+    return wideCharsText;
+}
+
+static int openFile(const QString& fileUrl, const QString& mode) {
+#ifdef Q_OS_WIN
+    QScopedPointer<wchar_t> unicodeFileName(toWideCharsArray(fileUrl));
+    QScopedPointer<wchar_t> unicodeMode(toWideCharsArray(mode));
+    FILE* file = _wfopen(unicodeFileName.data(), unicodeMode.data());
+#else
+    FILE* file = fopen(fileUrl.toLocal8Bit(), mode.toLatin1());
+#endif
     return fileno(file);
 }
 

--- a/src/corelibs/U2Formats/src/BAMUtils.h
+++ b/src/corelibs/U2Formats/src/BAMUtils.h
@@ -92,9 +92,9 @@ public:
      * names and provides a file description (fd) for the opened file.
      * For 'mode' see fopen() function description.
      * It is responsibily of the caller to close the file.
-     * If any error happens the method returns -1.
+     * If any error happens the method returns nullptr.
      */
-    static int openFile(const QString& path, const QString& mode);
+    static FILE* openFile(const QString& path, const QString& mode);
 };
 
 // iterates over a FASTQ file (including zipped) with kseq from samtools

--- a/src/corelibs/U2Formats/src/BAMUtils.h
+++ b/src/corelibs/U2Formats/src/BAMUtils.h
@@ -86,6 +86,15 @@ public:
      * Saves the list of references to the file in the SAMtools fai format.
      */
     static void createFai(const GUrl& faiUrl, const QStringList& references, U2OpStatus& os);
+
+    /**
+     * Calls fopen() correctly for files with Unicode
+     * names and provides a file description (fd) for the opened file.
+     * For 'mode' see fopen() function description.
+     * It is responsibily of the caller to close the file.
+     * If any error happens the method returns -1.
+     */
+    static int openFile(const QString& path, const QString& mode);
 };
 
 // iterates over a FASTQ file (including zipped) with kseq from samtools
@@ -102,16 +111,6 @@ private:
 
     void* fp;
     void* seq;
-};
-
-class U2FORMATS_EXPORT OpenFile {
-public:
-    OpenFile(const QString& path, const QString& mode = "r");
-    ~OpenFile();
-
-    int handle() const;
-private:
-    FILE* file;
 };
 
 }  // namespace U2

--- a/src/corelibs/U2Formats/src/BAMUtils.h
+++ b/src/corelibs/U2Formats/src/BAMUtils.h
@@ -89,9 +89,9 @@ public:
 
     /**
      * Calls fopen() correctly for files with Unicode
-     * names and provides a file description (fd) for the opened file.
+     * names and returns a FILE* structure for the the opened file.
      * For 'mode' see fopen() function description.
-     * It is responsibily of the caller to close the file.
+     * Caller is responsible to close the file.
      * If any error happens the method returns nullptr.
      */
     static FILE* openFile(const QString& path, const QString& mode);

--- a/src/corelibs/U2Formats/src/BAMUtils.h
+++ b/src/corelibs/U2Formats/src/BAMUtils.h
@@ -22,6 +22,8 @@
 #ifndef _U2_BAM_UTILS_H_
 #define _U2_BAM_UTILS_H_
 
+#include <QFile>
+
 #include <U2Core/DNASequence.h>
 #include <U2Core/DocumentModel.h>
 #include <U2Core/GUrl.h>
@@ -100,6 +102,16 @@ private:
 
     void* fp;
     void* seq;
+};
+
+class U2FORMATS_EXPORT OpenFile {
+public:
+    OpenFile(const QString& path, const QString& mode = "r");
+    ~OpenFile();
+
+    int handle() const;
+private:
+    FILE* file;
 };
 
 }  // namespace U2

--- a/src/corelibs/U2Formats/src/BAMUtils.h
+++ b/src/corelibs/U2Formats/src/BAMUtils.h
@@ -95,6 +95,9 @@ public:
      * If any error happens the method returns nullptr.
      */
     static FILE* openFile(const QString& path, const QString& mode);
+
+    /** Loads BAM index from the file (bam_index_t*). Returns nullptr of error. */
+    static void* loadIndex(const QString& path);
 };
 
 // iterates over a FASTQ file (including zipped) with kseq from samtools

--- a/src/libs_3rdparty/samtools/src/samtools/bam.h
+++ b/src/libs_3rdparty/samtools/src/samtools/bam.h
@@ -595,6 +595,9 @@ extern "C" {
     /** Saves BAM index to the file. */
     void bam_index_save(const bam_index_t *idx, FILE *fp);
 
+    /** Loads BAM index from file. */
+    bam_index_t *bam_index_load_core(FILE *fp);
+
 	/*!
 	  @abstract   Load index from file "fn.bai".
 	  @param  fn  name of the BAM file (NOT the index file)

--- a/src/libs_3rdparty/samtools/src/samtools/bam.h
+++ b/src/libs_3rdparty/samtools/src/samtools/bam.h
@@ -589,6 +589,12 @@ extern "C" {
 	 */
 	int bam_index_build(const char *fn);
 
+    /** Builds BAM index structure. */
+    bam_index_t *bam_index_core(bamFile fp);
+
+    /** Saves BAM index to the file. */
+    void bam_index_save(const bam_index_t *idx, FILE *fp);
+
 	/*!
 	  @abstract   Load index from file "fn.bai".
 	  @param  fn  name of the BAM file (NOT the index file)

--- a/src/libs_3rdparty/samtools/src/samtools/bam.h
+++ b/src/libs_3rdparty/samtools/src/samtools/bam.h
@@ -300,6 +300,7 @@ extern "C" {
 	  @return     SAM file handler
 	 */
 	tamFile sam_open(const char *fn);
+	tamFile sam_dopen(int fd);
 
 	/*!
 	  @abstract   Close a SAM file handler

--- a/src/libs_3rdparty/samtools/src/samtools/bam_import.c
+++ b/src/libs_3rdparty/samtools/src/samtools/bam_import.c
@@ -176,11 +176,11 @@ static inline bool append_text(bam_header_t *header, kstring_t *str)
 {
 	size_t x = header->l_text, y = header->l_text + str->l + 2; // 2 = 1 byte dret + 1 byte null
 	kroundup32(x); kroundup32(y);
-	if (x < y) 
+	if (x < y)
     {
         header->n_text = y;
         header->text = (char*)realloc(header->text, y);
-        if ( !header->text ) 
+        if ( !header->text )
         {
             fprintf(stderr,"realloc failed to alloc %ld bytes\n", y);
             SAMTOOLS_ERROR_MESSAGE = "realloc failed to alloc bytes\n";
@@ -479,6 +479,17 @@ int sam_read1(tamFile fp, bam_header_t *header, bam1_t *b)
 	b->l_aux = doff - doff0;
 	b->data_len = doff;
 	return z;
+}
+
+tamFile sam_dopen(int fd) {
+    tamFile fp;
+    gzFile gzfp = gzdopen(fd, "rb");
+    if (gzfp == 0) return 0;
+    fp = (tamFile)calloc(1, sizeof(struct __tamFile_t));
+    fp->str = (kstring_t*)calloc(1, sizeof(kstring_t));
+    fp->fp = gzfp;
+    fp->ks = ks_init(fp->fp);
+    return fp;
 }
 
 tamFile sam_open(const char *fn)

--- a/src/libs_3rdparty/samtools/src/samtools/bam_import.c
+++ b/src/libs_3rdparty/samtools/src/samtools/bam_import.c
@@ -481,6 +481,7 @@ int sam_read1(tamFile fp, bam_header_t *header, bam1_t *b)
 	return z;
 }
 
+/** Same as sam_open(const char*) but uses the provided file handle instead of the file name. */
 tamFile sam_dopen(int fd) {
     tamFile fp;
     gzFile gzfp = gzdopen(fd, "rb");

--- a/src/libs_3rdparty/samtools/src/samtools/bam_index.c
+++ b/src/libs_3rdparty/samtools/src/samtools/bam_index.c
@@ -319,7 +319,7 @@ void bam_index_save(const bam_index_t *idx, FILE *fp)
 	fflush(fp);
 }
 
-static bam_index_t *bam_index_load_core(FILE *fp)
+bam_index_t *bam_index_load_core(FILE *fp)
 {
 	int i;
 	char magic[4];
@@ -334,7 +334,7 @@ static bam_index_t *bam_index_load_core(FILE *fp)
 		fclose(fp);
 		return 0;
 	}
-	idx = (bam_index_t*)calloc(1, sizeof(bam_index_t));	
+	idx = (bam_index_t*)calloc(1, sizeof(bam_index_t));
 	fread(&idx->n, 4, 1, fp);
 	if (bam_is_be) bam_swap_endian_4p(&idx->n);
 	idx->index = (khash_t(i)**)calloc(idx->n, sizeof(void*));
@@ -396,12 +396,12 @@ bam_index_t *bam_index_load_local(const char *_fn)
 	} else fn = strdup(_fn);
 	fnidx = (char*)calloc(strlen(fn) + 5, 1);
 	strcpy(fnidx, fn); strcat(fnidx, ".bai");
-	fp = ugene_custom_fopen(fnidx, "rb");
+	fp = fopen(fnidx, "rb");
     if (fp == 0 && strlen(fn) > 3) { // try "{base}.bai"
         if (!strcmp(fn + strlen(fn) - 3, "bam")) {
 			strcpy(fnidx, fn);
 			fnidx[strlen(fn)-1] = 'i';
-			fp = ugene_custom_fopen(fnidx, "rb");
+			fp = fopen(fnidx, "rb");
 		}
 	}
 	free(fnidx); free(fn);
@@ -575,7 +575,7 @@ struct __bam_iter_t {
 	pair64_t *off;
 };
 
-// bam_fetch helper function retrieves 
+// bam_fetch helper function retrieves
 bam_iter_t bam_iter_query(const bam_index_t *idx, int tid, int beg, int end)
 {
 	uint16_t *bins;

--- a/src/libs_3rdparty/samtools/src/samtools/bam_sort.c
+++ b/src/libs_3rdparty/samtools/src/samtools/bam_sort.c
@@ -388,7 +388,7 @@ static void sort_blocks(int n, int k, bam1_p *buf, const char *prefix, const bam
   and then merge them by calling bam_merge_core(). This function is
   NOT thread safe.
  */
-void bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix, size_t max_mem, int is_stdout)
+void bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix, size_t max_mem, int is_stdout, int fd)
 {
 	int n, ret, k, i;
 	size_t mem;
@@ -398,8 +398,8 @@ void bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix, size
 
 	g_is_by_qname = is_by_qname;
 	n = k = 0; mem = 0;
-	fp = strcmp(fn, "-")? bam_open(fn, "r") : bam_dopen(fileno(stdin), "r");
-	if (fp == 0) {
+    fp = fd > 0 ? bam_dopen(fd, "r") : (strcmp(fn, "-") ? bam_open(fn, "r") : bam_dopen(fileno(stdin), "r"));
+    if (fp == 0) {
 		fprintf(stderr, "[bam_sort_core] fail to open file %s\n", fn);
 		return;
 	}
@@ -455,7 +455,7 @@ void bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix, size
 
 void bam_sort_core(int is_by_qname, const char *fn, const char *prefix, size_t max_mem)
 {
-	bam_sort_core_ext(is_by_qname, fn, prefix, max_mem, 0);
+	bam_sort_core_ext(is_by_qname, fn, prefix, max_mem, 0, 0);
 }
 
 int bam_sort(int argc, char *argv[])
@@ -474,6 +474,6 @@ int bam_sort(int argc, char *argv[])
 		fprintf(stderr, "Usage: samtools sort [-on] [-m <maxMem>] <in.bam> <out.prefix>\n");
 		return 1;
 	}
-	bam_sort_core_ext(is_by_qname, argv[optind], argv[optind+1], max_mem, is_stdout);
+	bam_sort_core_ext(is_by_qname, argv[optind], argv[optind+1], max_mem, is_stdout, 0);
 	return 0;
 }

--- a/src/libs_3rdparty/samtools/src/samtools/bgzf.c
+++ b/src/libs_3rdparty/samtools/src/samtools/bgzf.c
@@ -219,7 +219,7 @@ bgzf_open(const char* __restrict path, const char* __restrict mode)
 #ifdef _WIN32
 		oflag |= O_BINARY;
 #endif
-		fd = ugene_custom_open2(path, oflag, 0666);
+		fd = open(path, oflag, 0666);
 		if (fd == -1) return 0;
 		{ // set compress_level
 			int i;

--- a/src/libs_3rdparty/samtools/src/samtools/sam.c
+++ b/src/libs_3rdparty/samtools/src/samtools/sam.c
@@ -106,7 +106,7 @@ samfile_t *samopen_with_fd(const char *fn, int fd, const char *mode, const void 
 				fwrite(fp->header->text, 1, fp->header->l_text, fp->x.tamw); // FIXME: better to skip the trailing NULL
 				if (alt->n_targets) { // then write the header text without dumping ->target_{name,len}
 					if (alt->n_targets != fp->header->n_targets && bam_verbose >= 1)
-						fprintf(stderr, "[samOpen] inconsistent number of target sequences. Output the text header.\n");
+						fprintf(stderr, "[samopen] inconsistent number of target sequences. Output the text header.\n");
 				} else { // then dump ->target_{name,len}
 					for (i = 0; i < fp->header->n_targets; ++i)
 						fprintf(fp->x.tamw, "@SQ\tSN:%s\tLN:%d\n", fp->header->target_name[i], fp->header->target_len[i]);

--- a/src/libs_3rdparty/samtools/src/samtools/sam.c
+++ b/src/libs_3rdparty/samtools/src/samtools/sam.c
@@ -50,11 +50,11 @@ samfile_t *samopen_with_fd(const char *fn, int fd, const char *mode, const void 
 		fp->type |= TYPE_READ;
 		if (strchr(mode, 'b')) { // binary
 			fp->type |= TYPE_BAM;
-            fp->x.bam = strcmp(fn, "-") ? (fd != -1 ? bam_dopen(fd, "r") : bam_open(fn, "r")) : bam_dopen(fileno(stdin), "r");
+            fp->x.bam = strcmp(fn, "-") ? (fd > 0 ? bam_dopen(fd, "r") : bam_open(fn, "r")) : bam_dopen(fileno(stdin), "r");
             if (fp->x.bam == 0) goto open_err_ret;
 			fp->header = bam_header_read(fp->x.bam);
 		} else { // text
-            fp->x.tamr = fd != -1 ? sam_dopen(fd) : sam_open(fn);
+            fp->x.tamr = fd > 0 ? sam_dopen(fd) : sam_open(fn);
             if (fp->x.tamr == 0) goto open_err_ret;
 			fp->header = sam_header_read(fp->x.tamr);
             if (NULL == fp->header) {
@@ -83,12 +83,12 @@ samfile_t *samopen_with_fd(const char *fn, int fd, const char *mode, const void 
 			if (strchr(mode, 'u')) compress_level = 0;
 			bmode[0] = 'w'; bmode[1] = compress_level < 0? 0 : compress_level + '0'; bmode[2] = 0;
 			fp->type |= TYPE_BAM;
-            fp->x.bam = strcmp(fn, "-") ? (fd != -1 ? bam_dopen(fd, bmode) : bam_open(fn, bmode)) : bam_dopen(fileno(stdout), bmode);
+            fp->x.bam = strcmp(fn, "-") ? (fd > 0 ? bam_dopen(fd, bmode) : bam_open(fn, bmode)) : bam_dopen(fileno(stdout), bmode);
             if (fp->x.bam == 0) goto open_err_ret;
 			bam_header_write(fp->x.bam, fp->header);
 		} else { // text
 			// open file
-            fp->x.tamw = strcmp(fn, "-") ? (fd != -1 ? fdopen(fd, "w") : fopen(fn, "w")) : stdout;
+            fp->x.tamw = strcmp(fn, "-") ? (fd > 0 ? fdopen(fd, "w") : fopen(fn, "w")) : stdout;
             if (fp->x.tamr == 0) goto open_err_ret;
 			if (strchr(mode, 'X')) fp->type |= BAM_OFSTR<<2;
 			else if (strchr(mode, 'x')) fp->type |= BAM_OFHEX<<2;

--- a/src/libs_3rdparty/samtools/src/samtools/sam.c
+++ b/src/libs_3rdparty/samtools/src/samtools/sam.c
@@ -29,7 +29,7 @@ static void append_header_text(bam_header_t *header, char* text, int len)
 	int x = header->l_text + 1;
 	int y = header->l_text + len + 1; // 1 byte null
 	if (text == 0) return;
-	kroundup32(x); 
+	kroundup32(x);
 	kroundup32(y);
 	if (x < y) header->text = (char*)realloc(header->text, y);
 	strncpy(header->text + header->l_text, text, len); // we cannot use strcpy() here.
@@ -37,7 +37,11 @@ static void append_header_text(bam_header_t *header, char* text, int len)
 	header->text[header->l_text] = 0;
 }
 
-samfile_t *samopen(const char *fn, const char *mode, const void *aux)
+samfile_t* samopen(const char* fn, const char* mode, const void* aux) {
+    return samopen_with_fd(fn, -1, mode, aux);
+}
+
+samfile_t *samopen_with_fd(const char *fn, int fd, const char *mode, const void *aux)
 {
 	samfile_t *fp;
 	fp = (samfile_t*)calloc(1, sizeof(samfile_t));
@@ -46,12 +50,12 @@ samfile_t *samopen(const char *fn, const char *mode, const void *aux)
 		fp->type |= TYPE_READ;
 		if (strchr(mode, 'b')) { // binary
 			fp->type |= TYPE_BAM;
-			fp->x.bam = strcmp(fn, "-")? bam_open(fn, "r") : bam_dopen(fileno(stdin), "r");
-			if (fp->x.bam == 0) goto open_err_ret;
+            fp->x.bam = strcmp(fn, "-") ? (fd != -1 ? bam_dopen(fd, "r") : bam_open(fn, "r")) : bam_dopen(fileno(stdin), "r");
+            if (fp->x.bam == 0) goto open_err_ret;
 			fp->header = bam_header_read(fp->x.bam);
 		} else { // text
-			fp->x.tamr = sam_open(fn);
-			if (fp->x.tamr == 0) goto open_err_ret;
+            fp->x.tamr = fd != -1 ? sam_dopen(fd) : sam_open(fn);
+            if (fp->x.tamr == 0) goto open_err_ret;
 			fp->header = sam_header_read(fp->x.tamr);
             if (NULL == fp->header) {
                 free(fp);
@@ -66,8 +70,8 @@ samfile_t *samopen(const char *fn, const char *mode, const void *aux)
 					bam_header_destroy(textheader);
 				}
 				if (fp->header->n_targets == 0 && bam_verbose >= 1)
-					fprintf(stderr, "[samopen] no @SQ lines in the header.\n");
-			} else if (bam_verbose >= 2) fprintf(stderr, "[samopen] SAM header is present: %d sequences.\n", fp->header->n_targets);
+					fprintf(stderr, "[samOpen] no @SQ lines in the header.\n");
+			} else if (bam_verbose >= 2) fprintf(stderr, "[samOpen] SAM header is present: %d sequences.\n", fp->header->n_targets);
 		}
 	} else if (strchr(mode, 'w')) { // write
 		fp->header = bam_header_dup((const bam_header_t*)aux);
@@ -79,13 +83,13 @@ samfile_t *samopen(const char *fn, const char *mode, const void *aux)
 			if (strchr(mode, 'u')) compress_level = 0;
 			bmode[0] = 'w'; bmode[1] = compress_level < 0? 0 : compress_level + '0'; bmode[2] = 0;
 			fp->type |= TYPE_BAM;
-			fp->x.bam = strcmp(fn, "-")? bam_open(fn, bmode) : bam_dopen(fileno(stdout), bmode);
-			if (fp->x.bam == 0) goto open_err_ret;
+            fp->x.bam = strcmp(fn, "-") ? (fd != -1 ? bam_dopen(fd, bmode) : bam_open(fn, bmode)) : bam_dopen(fileno(stdout), bmode);
+            if (fp->x.bam == 0) goto open_err_ret;
 			bam_header_write(fp->x.bam, fp->header);
 		} else { // text
 			// open file
-			fp->x.tamw = strcmp(fn, "-") ? ugene_custom_fopen(fn, "w") : stdout;
-			if (fp->x.tamr == 0) goto open_err_ret;
+            fp->x.tamw = strcmp(fn, "-") ? (fd != -1 ? fdopen(fd, "w") : fopen(fn, "w")) : stdout;
+            if (fp->x.tamr == 0) goto open_err_ret;
 			if (strchr(mode, 'X')) fp->type |= BAM_OFSTR<<2;
 			else if (strchr(mode, 'x')) fp->type |= BAM_OFHEX<<2;
 			else fp->type |= BAM_OFDEC<<2;
@@ -93,7 +97,7 @@ samfile_t *samopen(const char *fn, const char *mode, const void *aux)
 			if (strchr(mode, 'h')) {
 				int i;
 				bam_header_t *alt;
-				// parse the header text 
+				// parse the header text
 				alt = bam_header_init();
 				alt->l_text = fp->header->l_text; alt->text = fp->header->text;
 				sam_header_parse(alt);
@@ -102,7 +106,7 @@ samfile_t *samopen(const char *fn, const char *mode, const void *aux)
 				fwrite(fp->header->text, 1, fp->header->l_text, fp->x.tamw); // FIXME: better to skip the trailing NULL
 				if (alt->n_targets) { // then write the header text without dumping ->target_{name,len}
 					if (alt->n_targets != fp->header->n_targets && bam_verbose >= 1)
-						fprintf(stderr, "[samopen] inconsistent number of target sequences. Output the text header.\n");
+						fprintf(stderr, "[samOpen] inconsistent number of target sequences. Output the text header.\n");
 				} else { // then dump ->target_{name,len}
 					for (i = 0; i < fp->header->n_targets; ++i)
 						fprintf(fp->x.tamw, "@SQ\tSN:%s\tLN:%d\n", fp->header->target_name[i], fp->header->target_len[i]);

--- a/src/libs_3rdparty/samtools/src/samtools/sam.c
+++ b/src/libs_3rdparty/samtools/src/samtools/sam.c
@@ -70,8 +70,8 @@ samfile_t *samopen_with_fd(const char *fn, int fd, const char *mode, const void 
 					bam_header_destroy(textheader);
 				}
 				if (fp->header->n_targets == 0 && bam_verbose >= 1)
-					fprintf(stderr, "[samOpen] no @SQ lines in the header.\n");
-			} else if (bam_verbose >= 2) fprintf(stderr, "[samOpen] SAM header is present: %d sequences.\n", fp->header->n_targets);
+					fprintf(stderr, "[samopen] no @SQ lines in the header.\n");
+			} else if (bam_verbose >= 2) fprintf(stderr, "[samopen] SAM header is present: %d sequences.\n", fp->header->n_targets);
 		}
 	} else if (strchr(mode, 'w')) { // write
 		fp->header = bam_header_dup((const bam_header_t*)aux);

--- a/src/libs_3rdparty/samtools/src/samtools/sam.h
+++ b/src/libs_3rdparty/samtools/src/samtools/sam.h
@@ -44,6 +44,8 @@ extern "C" {
 	  @param fn SAM/BAM file name; "-" is recognized as stdin (for
 	  reading) or stdout (for writing).
 
+	  @param fd File descriptor for the file referenced by 'fn'. Used when is valid (!= -1).
+
 	  @param mode open mode /[rw](b?)(u?)(h?)([xX]?)/: 'r' for reading,
 	  'w' for writing, 'b' for BAM I/O, 'u' for uncompressed BAM output,
 	  'h' for outputing header in SAM, 'x' for HEX flag and 'X' for
@@ -59,6 +61,7 @@ extern "C" {
 
 	  @return       SAM/BAM file handler
 	 */
+	samfile_t *samopen_with_fd(const char *fn, int fd, const char *mode, const void *aux);
 	samfile_t *samopen(const char *fn, const char *mode, const void *aux);
 
 	/*!

--- a/src/libs_3rdparty/samtools/src/ugene_custom_io.c
+++ b/src/libs_3rdparty/samtools/src/ugene_custom_io.c
@@ -28,23 +28,6 @@ int ugene_custom_open(const char *filename, int oflag) {
 #endif
 }
 
-// The func accepts filename in multibyte string form
-// then converts it to wide string form and call _wopen
-// The conversion is with CP_THREAD_ACP by default
-int ugene_custom_open2(const char *filename, int oflag, int pflag) {
-#ifndef _WIN32
-    return open(filename, oflag, pflag);
-#else
-    int wchars_num = MultiByteToWideChar(CP_THREAD_ACP, 0, filename, -1, NULL, 0);
-    wchar_t* w_filename = malloc(sizeof(wchar_t) * wchars_num);
-    MultiByteToWideChar(CP_THREAD_ACP, 0, filename, -1, w_filename, wchars_num);
-
-    int fd = _wopen(w_filename, oflag, pflag);
-    free(w_filename);
-    return fd;
-#endif
-}
-
 // The func accepts filename and mode in multibyte string form
 // then converts it to wide string form and call _wfopen
 // The conversion is with CP_THREAD_ACP by default

--- a/src/libs_3rdparty/samtools/src/ugene_custom_io.h
+++ b/src/libs_3rdparty/samtools/src/ugene_custom_io.h
@@ -10,7 +10,6 @@
 // The conversion is with CP_THREAD_ACP by default
 
 int   ugene_custom_open(const char *filename, int oflag);
-int   ugene_custom_open2(const char *filename, int oflag, int pflag);
 FILE* ugene_custom_fopen(const char *filename, const char* mode);
 
 #endif // UGENE_CUSTOM_IO_H

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/Assembling/dna_assembly/GTTestsIndexReuse.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/Assembling/dna_assembly/GTTestsIndexReuse.cpp
@@ -64,7 +64,7 @@ public:
             GTWidget::click(os, GTWidget::findWidget(os, "addShortreadsButton", dialog));
         }
 
-        //    Expcted state: warning messagebox appeared
+        //    Expected state: warning messagebox appeared
         GTUtilsDialog::waitForDialog(os, new MessageBoxDialogFiller(os, b, message));
         GTUtilsDialog::clickButtonBox(os, QDialogButtonBox::Ok);
         GTUtilsDialog::clickButtonBox(os, QDialogButtonBox::Cancel);

--- a/src/plugins/dbi_bam/src/SamtoolsBasedDbi.cpp
+++ b/src/plugins/dbi_bam/src/SamtoolsBasedDbi.cpp
@@ -103,8 +103,8 @@ void SamtoolsBasedDbi::init(const QHash<QString, QString>& properties, const QVa
 
 bool SamtoolsBasedDbi::initBamStructures(const GUrl& fileName) {
     QString filePath = fileName.getURLString();
-    int fd = fileno(BAMUtils::openFile(filePath, "r"));
-    bamHandler = bam_dopen(fd, "r");
+    int fd = fileno(BAMUtils::openFile(filePath, "rb"));
+    bamHandler = bam_dopen(fd, "rb");
     if (bamHandler == nullptr) {
         throw IOException(BAMDbiPlugin::tr("Can't open file '%1'").arg(filePath));
     }

--- a/src/plugins/dbi_bam/src/SamtoolsBasedDbi.cpp
+++ b/src/plugins/dbi_bam/src/SamtoolsBasedDbi.cpp
@@ -108,6 +108,7 @@ bool SamtoolsBasedDbi::initBamStructures(const GUrl& fileName) {
     if (bamHandler == nullptr) {
         throw IOException(BAMDbiPlugin::tr("Can't open file '%1'").arg(filePath));
     }
+    bamHandler->owned_file = 1;
 
     bool indexed = BAMUtils::hasValidBamIndex(fileName);
     if (!indexed) {

--- a/src/plugins/dbi_bam/src/SamtoolsBasedDbi.cpp
+++ b/src/plugins/dbi_bam/src/SamtoolsBasedDbi.cpp
@@ -103,8 +103,8 @@ void SamtoolsBasedDbi::init(const QHash<QString, QString>& properties, const QVa
 
 bool SamtoolsBasedDbi::initBamStructures(const GUrl& fileName) {
     QString filePath = fileName.getURLString();
-    OpenFile file(filePath);
-    bamHandler = bam_dopen(file.handle(), "r");
+    int fd = BAMUtils::openFile(filePath, "r");
+    bamHandler = bam_dopen(fd, "r");
     if (bamHandler == nullptr) {
         throw IOException(BAMDbiPlugin::tr("Can't open file '%1'").arg(filePath));
     }

--- a/src/plugins/dbi_bam/src/SamtoolsBasedDbi.cpp
+++ b/src/plugins/dbi_bam/src/SamtoolsBasedDbi.cpp
@@ -103,7 +103,7 @@ void SamtoolsBasedDbi::init(const QHash<QString, QString>& properties, const QVa
 
 bool SamtoolsBasedDbi::initBamStructures(const GUrl& fileName) {
     QString filePath = fileName.getURLString();
-    int fd = BAMUtils::openFile(filePath, "r");
+    int fd = fileno(BAMUtils::openFile(filePath, "r"));
     bamHandler = bam_dopen(fd, "r");
     if (bamHandler == nullptr) {
         throw IOException(BAMDbiPlugin::tr("Can't open file '%1'").arg(filePath));

--- a/src/plugins/dbi_bam/src/SamtoolsBasedDbi.cpp
+++ b/src/plugins/dbi_bam/src/SamtoolsBasedDbi.cpp
@@ -102,26 +102,25 @@ void SamtoolsBasedDbi::init(const QHash<QString, QString>& properties, const QVa
 }
 
 bool SamtoolsBasedDbi::initBamStructures(const GUrl& fileName) {
-    QByteArray urlBA = fileName.getURLString().toLocal8Bit();
-    const char* url = urlBA.constData();
-    bamHandler = bam_open(url, "r");
-    if (nullptr == bamHandler) {
-        throw IOException(BAMDbiPlugin::tr("Can't open file '%1'").arg(url));
+    QString filePath = fileName.getURLString();
+    OpenFile file(filePath);
+    bamHandler = bam_dopen(file.handle(), "r");
+    if (bamHandler == nullptr) {
+        throw IOException(BAMDbiPlugin::tr("Can't open file '%1'").arg(filePath));
     }
 
     bool indexed = BAMUtils::hasValidBamIndex(fileName);
-    if (indexed) {
-        index = bam_index_load(url);
-    } else {
+    if (!indexed) {
         throw Exception("Only indexed sorted BAM files could be used by this DBI");
     }
-    if (nullptr == index) {
-        throw IOException(BAMDbiPlugin::tr("Can't load index file for '%1'").arg(url));
+    index = bam_index_load(filePath.toLocal8Bit());
+    if (index == nullptr) {
+        throw IOException(BAMDbiPlugin::tr("Can't load index file for '%1'").arg(filePath));
     }
 
     header = bam_header_read(bamHandler);
-    if (nullptr == header) {
-        throw IOException(BAMDbiPlugin::tr("Can't read header from file '%1'").arg(url));
+    if (header == nullptr) {
+        throw IOException(BAMDbiPlugin::tr("Can't read header from file '%1'").arg(filePath));
     }
     return true;
 }

--- a/src/plugins/dbi_bam/src/SamtoolsBasedDbi.cpp
+++ b/src/plugins/dbi_bam/src/SamtoolsBasedDbi.cpp
@@ -113,7 +113,7 @@ bool SamtoolsBasedDbi::initBamStructures(const GUrl& fileName) {
     if (!indexed) {
         throw Exception("Only indexed sorted BAM files could be used by this DBI");
     }
-    index = bam_index_load(filePath.toLocal8Bit());
+    index = (bam_index_t*)BAMUtils::loadIndex(filePath);
     if (index == nullptr) {
         throw IOException(BAMDbiPlugin::tr("Can't load index file for '%1'").arg(filePath));
     }


### PR DESCRIPTION
The solution is to always pass a file handle (int) instead of file name (const char*) to samtools while working with BAM/SAM files