### PR TITLE
UGENE-7649. [Mac] The version in Info.plist is outdated

### DIFF
--- a/etc/script/mac/bundle.sh
+++ b/etc/script/mac/bundle.sh
@@ -30,7 +30,18 @@ mkdir "${TARGET_PLUGINS_DIR}"
 echo Copying icons
 cp "${SOURCE_DIR}/src/ugeneui/images/ugene-doc.icns" "${TARGET_APP_DIR}/Contents/Resources"
 cp "${SOURCE_DIR}/src/ugeneui/images/ugeneui.icns" "${TARGET_APP_DIR}/Contents/Resources"
-cp "${SOURCE_DIR}/etc/script/mac/dmg/Info.plist" "${TARGET_APP_DIR}/Contents"
+
+echo Creating Info.plist
+# "\$UGENE_VER_type" is a variable that will be replaced below with the corresponding variables from ugene_version.pri:
+# UGENE_VER_MAJOR or UGENE_VER_MINOR.
+VERSION_PARSING_COMMAND="sed -n 's/^ *\$UGENE_VER_type *= *\([0-9][0-9]*\) *\(#.*\)*$/\1/p' '${SOURCE_DIR}/src/ugene_version.pri'"
+UGENE_VERSION_MAJOR=$(eval "${VERSION_PARSING_COMMAND/\$UGENE_VER_type/UGENE_VER_MAJOR}")
+UGENE_VERSION_MINOR=$(eval "${VERSION_PARSING_COMMAND/\$UGENE_VER_type/UGENE_VER_MINOR}")
+if [ ! "${UGENE_VERSION_MAJOR}" -o ! "${UGENE_VERSION_MINOR}" ]; then
+    echo "Unable to parse UGENE version from ugene_version.pri"
+    exit 1
+fi
+sed "s/\${UGENE_VERSION}/${UGENE_VERSION_MAJOR}.${UGENE_VERSION_MINOR}/g" "${SOURCE_DIR}/etc/script/mac/dmg/Info.plist" > "${TARGET_APP_DIR}/Contents/Info.plist"
 
 echo Copying translations
 cp "${BUILD_DIR}"/transl_*.qm "${TARGET_EXE_DIR}"

--- a/etc/script/mac/bundle.sh
+++ b/etc/script/mac/bundle.sh
@@ -41,9 +41,7 @@ if [ ! "${UGENE_VERSION_MAJOR}" -o ! "${UGENE_VERSION_MINOR}" ]; then
     echo "Unable to parse UGENE version from ugene_version.pri"
     exit 1
 fi
-UGENE_VERSION="${UGENE_VERSION_MAJOR}.${UGENE_VERSION_MINOR}"
-sed -e "s/\${UGENE_VERSION_FULL}/${UGENE_VERSION}.0/g" -e "s/\${UGENE_VERSION_SHORT}/${UGENE_VERSION}/g" \
-    "${SOURCE_DIR}/etc/script/mac/dmg/Info.plist" > "${TARGET_APP_DIR}/Contents/Info.plist"
+sed "s/\${UGENE_VERSION}/${UGENE_VERSION_MAJOR}.${UGENE_VERSION_MINOR}/g" "${SOURCE_DIR}/etc/script/mac/dmg/Info.plist" > "${TARGET_APP_DIR}/Contents/Info.plist"
 
 echo Copying translations
 cp "${BUILD_DIR}"/transl_*.qm "${TARGET_EXE_DIR}"

--- a/etc/script/mac/bundle.sh
+++ b/etc/script/mac/bundle.sh
@@ -41,7 +41,9 @@ if [ ! "${UGENE_VERSION_MAJOR}" -o ! "${UGENE_VERSION_MINOR}" ]; then
     echo "Unable to parse UGENE version from ugene_version.pri"
     exit 1
 fi
-sed "s/\${UGENE_VERSION}/${UGENE_VERSION_MAJOR}.${UGENE_VERSION_MINOR}/g" "${SOURCE_DIR}/etc/script/mac/dmg/Info.plist" > "${TARGET_APP_DIR}/Contents/Info.plist"
+UGENE_VERSION="${UGENE_VERSION_MAJOR}.${UGENE_VERSION_MINOR}"
+sed -e "s/\${UGENE_VERSION_FULL}/${UGENE_VERSION}.0/g" -e "s/\${UGENE_VERSION_SHORT}/${UGENE_VERSION}/g" \
+    "${SOURCE_DIR}/etc/script/mac/dmg/Info.plist" > "${TARGET_APP_DIR}/Contents/Info.plist"
 
 echo Copying translations
 cp "${BUILD_DIR}"/transl_*.qm "${TARGET_EXE_DIR}"

--- a/etc/script/mac/dmg/Info.plist
+++ b/etc/script/mac/dmg/Info.plist
@@ -7,10 +7,10 @@
     <string>net.ugene.ugene</string>
 
     <key>CFBundleVersion</key>
-    <string>${UGENE_VERSION}</string>
+    <string>${UGENE_VERSION_FULL}</string>
 
     <key>CFBundleShortVersionString</key>
-    <string>${UGENE_VERSION}</string>
+    <string>${UGENE_VERSION_SHORT}</string>
 
     <key>CFBundleDisplayName</key>
     <string>Unipro UGENE</string>

--- a/etc/script/mac/dmg/Info.plist
+++ b/etc/script/mac/dmg/Info.plist
@@ -7,10 +7,10 @@
     <string>net.ugene.ugene</string>
 
     <key>CFBundleVersion</key>
-    <string>${UGENE_VERSION_FULL}</string>
+    <string>${UGENE_VERSION}</string>
 
     <key>CFBundleShortVersionString</key>
-    <string>${UGENE_VERSION_SHORT}</string>
+    <string>${UGENE_VERSION}</string>
 
     <key>CFBundleDisplayName</key>
     <string>Unipro UGENE</string>

--- a/etc/script/mac/dmg/Info.plist
+++ b/etc/script/mac/dmg/Info.plist
@@ -7,10 +7,10 @@
     <string>net.ugene.ugene</string>
 
     <key>CFBundleVersion</key>
-    <string>40.0</string>
+    <string>43.0</string>
 
     <key>CFBundleShortVersionString</key>
-    <string>40.0</string>
+    <string>43.0</string>
 
     <key>CFBundleDisplayName</key>
     <string>Unipro UGENE</string>

--- a/etc/script/mac/dmg/Info.plist
+++ b/etc/script/mac/dmg/Info.plist
@@ -7,10 +7,10 @@
     <string>net.ugene.ugene</string>
 
     <key>CFBundleVersion</key>
-    <string>43.0</string>
+    <string>$(QMAKE_FULL_VERSION)</string>
 
     <key>CFBundleShortVersionString</key>
-    <string>43.0</string>
+    <string>$(QMAKE_SHORT_VERSION)</string>
 
     <key>CFBundleDisplayName</key>
     <string>Unipro UGENE</string>

--- a/etc/script/mac/dmg/Info.plist
+++ b/etc/script/mac/dmg/Info.plist
@@ -7,10 +7,10 @@
     <string>net.ugene.ugene</string>
 
     <key>CFBundleVersion</key>
-    <string>$(QMAKE_FULL_VERSION)</string>
+    <string>${UGENE_VERSION}</string>
 
     <key>CFBundleShortVersionString</key>
-    <string>$(QMAKE_SHORT_VERSION)</string>
+    <string>${UGENE_VERSION}</string>
 
     <key>CFBundleDisplayName</key>
     <string>Unipro UGENE</string>

--- a/src/ugeneui/ugeneui.pri
+++ b/src/ugeneui/ugeneui.pri
@@ -64,9 +64,13 @@ macx {
 
     # Configure Info.plist
     PLIST_DIR = _tmp/plist
+    UGENE_VERSION_FOR_PLIST=$${UGENE_VER_MAJOR}.$${UGENE_VER_MINOR}
     infoPlistTarget.target = $${PLIST_DIR}/Info.plist
     infoPlistTarget.depends = FORCE
-    infoPlistTarget.commands = mkdir -p $${PLIST_DIR}; sed \"s/\\\$${UGENE_VERSION}/$${UGENE_VER_MAJOR}.$${UGENE_VER_MINOR}/g\" $$absolute_path(../../etc/script/mac/dmg/Info.plist) > $${infoPlistTarget.target}
+    infoPlistTarget.commands = mkdir -p $${PLIST_DIR}; \
+                               sed -e \"s/\\\$${UGENE_VERSION_FULL}/$${UGENE_VERSION_FOR_PLIST}.0/g\" \
+                                   -e \"s/\\\$${UGENE_VERSION_SHORT}/$${UGENE_VERSION_FOR_PLIST}/g\" \
+                                   $$absolute_path(../../etc/script/mac/dmg/Info.plist) > $${infoPlistTarget.target}
     PRE_TARGETDEPS += $${infoPlistTarget.target}
     QMAKE_EXTRA_TARGETS += infoPlistTarget
     QMAKE_INFO_PLIST = $$OUT_PWD/$${infoPlistTarget.target}

--- a/src/ugeneui/ugeneui.pri
+++ b/src/ugeneui/ugeneui.pri
@@ -61,6 +61,17 @@ win32 {
 
 macx {
     RC_FILE = images/ugeneui.icns
+
+    # Configure Info.plist
+    PLIST_DIR = _tmp/plist
+    infoPlistTarget.target = $${PLIST_DIR}/Info.plist
+    infoPlistTarget.depends = FORCE
+    infoPlistTarget.commands = mkdir -p $${PLIST_DIR}; sed \"s/\\\$${UGENE_VERSION}/$${UGENE_VER_MAJOR}.$${UGENE_VER_MINOR}/g\" $$absolute_path(../../etc/script/mac/dmg/Info.plist) > $${infoPlistTarget.target}
+    PRE_TARGETDEPS += $${infoPlistTarget.target}
+    QMAKE_EXTRA_TARGETS += infoPlistTarget
+    QMAKE_INFO_PLIST = $$OUT_PWD/$${infoPlistTarget.target}
+    QMAKE_CLEAN += $${PLIST_DIR}
+
     QMAKE_RPATHDIR += @executable_path/
 }
 

--- a/src/ugeneui/ugeneui.pri
+++ b/src/ugeneui/ugeneui.pri
@@ -61,17 +61,6 @@ win32 {
 
 macx {
     RC_FILE = images/ugeneui.icns
-
-    # Configure Info.plist
-    PLIST_DIR = _tmp/plist
-    infoPlistTarget.target = $${PLIST_DIR}/Info.plist
-    infoPlistTarget.depends = FORCE
-    infoPlistTarget.commands = mkdir -p $${PLIST_DIR}; sed \"s/\\\$${UGENE_VERSION}/$${UGENE_VER_MAJOR}.$${UGENE_VER_MINOR}/g\" $$absolute_path(../../etc/script/mac/dmg/Info.plist) > $${infoPlistTarget.target}
-    PRE_TARGETDEPS += $${infoPlistTarget.target}
-    QMAKE_EXTRA_TARGETS += infoPlistTarget
-    QMAKE_INFO_PLIST = $$OUT_PWD/$${infoPlistTarget.target}
-    QMAKE_CLEAN += $${PLIST_DIR}
-
     QMAKE_RPATHDIR += @executable_path/
 }
 

--- a/src/ugeneui/ugeneui.pri
+++ b/src/ugeneui/ugeneui.pri
@@ -61,6 +61,7 @@ win32 {
 
 macx {
     RC_FILE = images/ugeneui.icns
+    VERSION = $${UGENE_VER_MAJOR}.$${UGENE_VER_MINOR}
     QMAKE_INFO_PLIST = ../../etc/script/mac/dmg/Info.plist
     QMAKE_RPATHDIR += @executable_path/
 }

--- a/src/ugeneui/ugeneui.pri
+++ b/src/ugeneui/ugeneui.pri
@@ -64,13 +64,9 @@ macx {
 
     # Configure Info.plist
     PLIST_DIR = _tmp/plist
-    UGENE_VERSION_FOR_PLIST=$${UGENE_VER_MAJOR}.$${UGENE_VER_MINOR}
     infoPlistTarget.target = $${PLIST_DIR}/Info.plist
     infoPlistTarget.depends = FORCE
-    infoPlistTarget.commands = mkdir -p $${PLIST_DIR}; \
-                               sed -e \"s/\\\$${UGENE_VERSION_FULL}/$${UGENE_VERSION_FOR_PLIST}.0/g\" \
-                                   -e \"s/\\\$${UGENE_VERSION_SHORT}/$${UGENE_VERSION_FOR_PLIST}/g\" \
-                                   $$absolute_path(../../etc/script/mac/dmg/Info.plist) > $${infoPlistTarget.target}
+    infoPlistTarget.commands = mkdir -p $${PLIST_DIR}; sed \"s/\\\$${UGENE_VERSION}/$${UGENE_VER_MAJOR}.$${UGENE_VER_MINOR}/g\" $$absolute_path(../../etc/script/mac/dmg/Info.plist) > $${infoPlistTarget.target}
     PRE_TARGETDEPS += $${infoPlistTarget.target}
     QMAKE_EXTRA_TARGETS += infoPlistTarget
     QMAKE_INFO_PLIST = $$OUT_PWD/$${infoPlistTarget.target}

--- a/src/ugeneui/ugeneui.pri
+++ b/src/ugeneui/ugeneui.pri
@@ -61,8 +61,6 @@ win32 {
 
 macx {
     RC_FILE = images/ugeneui.icns
-    VERSION = $${UGENE_VER_MAJOR}.$${UGENE_VER_MINOR}
-    QMAKE_INFO_PLIST = ../../etc/script/mac/dmg/Info.plist
     QMAKE_RPATHDIR += @executable_path/
 }
 


### PR DESCRIPTION
Info for the reviewers.
1. I didn't do
    - XML test, because as far as I understand our current XML testing system doesn't consider OS,
    - GUI test because we don't currently test the Mac.

    Is a test required for this issue?
2. [Release](http://ugene-teamcity.unipro.ru:8111/ugene-teamcity/buildConfiguration/ReleaseMacIntelDmg/244181) build doesn't break.

https://ugene.dev/tracker/browse/UGENE-7649