### PR TITLE
Fix object-by-name sort in buildMoveSelectionToAnotherObjectMenu

### DIFF
--- a/src/corelibs/U2View/src/ov_msa/move_to_object/MoveToObjectMaController.cpp
+++ b/src/corelibs/U2View/src/ov_msa/move_to_object/MoveToObjectMaController.cpp
@@ -71,9 +71,7 @@ QMenu* MoveToObjectMaController::buildMoveSelectionToAnotherObjectMenu() const {
         menu->addSeparator();
         QList<GObject*> writableMsaObjects = GObjectUtils::findAllObjects(UOF_LoadedOnly, GObjectTypes::MULTIPLE_SEQUENCE_ALIGNMENT, true);
         writableMsaObjects.removeOne(maObject);
-        std::stable_sort(writableMsaObjects.begin(), writableMsaObjects.end(), [&](const GObject* o1, const GObject* o2) {
-            return o1->getGObjectName().compare(o2->getGObjectName(), Qt::CaseInsensitive);
-        });
+        std::stable_sort(writableMsaObjects.begin(), writableMsaObjects.end(), GObject::objectLessThan); // Sort objects in the menu by name.
 
         if (writableMsaObjects.isEmpty()) {
             QAction* noObjectsAction = menu->addAction(tr("No other alignment objects in the project"), []() {});


### PR DESCRIPTION
I found this fix while reviewing Igor's PR.
I do not know how to reproduce the problem from UI, but incorrect compactors in `std::sort` may cause crashes in UGENE.

This PR includes the fix + I reviewed all other usages of std::sort/stable_sort in UGENE.