### PR TITLE
Fix GCC warnings when built with Qt 5.15.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ if (CMAKE_COMPILER_IS_GNUCXX)
             " -Werror=unused-parameter"
             " -Werror=unused-value"
             " -Werror=unused-variable"
+            " -Wno-deprecated-declarations"
             )
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_WARNING_FLAGS}")
     LIST(APPEND COMPILER_FLAGS -Wl,--no-undefined )

--- a/src/corelibs/U2Core/src/dbi/U2SQLiteTripleStore.cpp
+++ b/src/corelibs/U2Core/src/dbi/U2SQLiteTripleStore.cpp
@@ -36,10 +36,6 @@ U2Triplet::U2Triplet(const QString& _key, const QString& _role, const QString& _
     : id(-1), key(_key), role(_role), value(_value) {
 }
 
-U2Triplet::U2Triplet(const U2Triplet& other)
-    : id(other.id), key(other.key), role(other.role), value(other.value) {
-}
-
 QString U2Triplet::getKey() const {
     return key;
 }
@@ -285,7 +281,7 @@ QList<U2Triplet> U2SQLiteTripleStore::getTriplets(U2OpStatus& os) const {
     while (q.step()) {
         U2Triplet t(q.getString(1), q.getString(2), q.getString(3));
         t.id = q.getInt64(0);
-        result << t;
+        result.append(t);
     }
     return result;
 }

--- a/src/corelibs/U2Core/src/dbi/U2SQLiteTripleStore.h
+++ b/src/corelibs/U2Core/src/dbi/U2SQLiteTripleStore.h
@@ -36,7 +36,6 @@ class U2CORE_EXPORT U2Triplet {
 
 public:
     U2Triplet(const QString& key, const QString& role, const QString& value);
-    U2Triplet(const U2Triplet& other);
     QString getKey() const;
     QString getRole() const;
     QString getValue() const;

--- a/src/corelibs/U2Core/src/globals/AppFileStorage.cpp
+++ b/src/corelibs/U2Core/src/globals/AppFileStorage.cpp
@@ -257,7 +257,7 @@ void AppFileStorage::cleanup(U2OpStatus& os) {
                 unremovedFiles << info.getKey();  // source url for hash
             }
         } else {
-            newData << triplet;
+            newData.append(triplet);
         }
     }
 

--- a/src/corelibs/U2Core/src/tasks/CmdlineTaskRunner.cpp
+++ b/src/corelibs/U2Core/src/tasks/CmdlineTaskRunner.cpp
@@ -122,7 +122,7 @@ QList<long> CmdlineTaskRunner::getChildrenProcesses(qint64 processId, bool fullT
         }
     }
     free(buff);
-    fclose(fp);
+    pclose(fp);
 #elif defined(Q_OS_WIN)
     HANDLE hProcessSnap;
     HANDLE hProcess;

--- a/src/corelibs/U2Designer/src/DatasetsController.cpp
+++ b/src/corelibs/U2Designer/src/DatasetsController.cpp
@@ -515,7 +515,7 @@ UrlAndDatasetController::UrlAndDatasetController(const QList<Dataset>& _urls, co
 }
 
 void UrlAndDatasetController::initSets(const QList<Dataset>& _urls, const QList<Dataset>& s) {
-    foreach (Dataset urlSet, _urls) {
+    for (Dataset urlSet : qAsConst(_urls)) {
         foreach (URLContainer* urlCon, urlSet.getUrls()) {
             urls << urlCon->getUrl();
         }

--- a/src/corelibs/U2Designer/src/PropertyWidget.cpp
+++ b/src/corelibs/U2Designer/src/PropertyWidget.cpp
@@ -527,7 +527,8 @@ void URLWidget::setValue(const QVariant& value) {
     if (value.canConvert<QList<Dataset>>()) {
         QStringList urls;
         foreach (const Dataset& set, value.value<QList<Dataset>>()) {
-            foreach (URLContainer* c, set.getUrls()) {
+            QList<URLContainer*> containers = set.getUrls();
+            for (URLContainer* c : qAsConst(containers)) {
                 urls << c->getUrl();
             }
         }

--- a/src/corelibs/U2Designer/src/QDScheduler.cpp
+++ b/src/corelibs/U2Designer/src/QDScheduler.cpp
@@ -211,12 +211,13 @@ QVector<U2Region> QDResultLinker::findLocation(QDStep* step) {
     }
     QDActor* actor = step->getActor();
     const QList<QDSchemeUnit*>& units = actor->getSchemeUnits();
-    foreach (QDResultGroup* candidate, candidates) {
+    for (QDResultGroup* candidate : qAsConst(candidates)) {
         bool complement = candidate->strand == QDStrand_ComplementOnly;
         QVector<U2Region> actorLocation;
-        foreach (QDSchemeUnit* su, units) {
+        for (QDSchemeUnit* su : qAsConst(units)) {
             U2Region suRegion(0, scheme->getSequence().length());
-            foreach (const QDResultUnit& ru, candidate->getResultsList()) {
+            QList<QDResultUnit> resultList = candidate->getResultsList();
+            for (const QDResultUnit& ru : qAsConst(resultList)) {
                 foreach (QDConstraint* c, step->getConstraints(su, ru->owner)) {
                     QDDistanceConstraint* dc = static_cast<QDDistanceConstraint*>(c);
                     const U2Region& reg = QDConstraintController::matchLocation(dc, ru, complement);
@@ -322,14 +323,14 @@ void QDResultLinker::formGroupResults() {
     }
 
     currentResults.clear();
-    foreach (const QList<QDActor*>& selection, groupSelections) {
+    for (const QList<QDActor*>& selection : qAsConst(groupSelections)) {
         assert(currentGroupResults.keys().contains(selection.first()));
         QList<QDResultGroup*> results = currentGroupResults.value(selection.first());
         for (int i = 1; i < selection.size(); i++) {
             QList<QDResultGroup*> newResults;
             assert(currentGroupResults.keys().contains(selection.at(i)));
             QList<QDResultGroup*> nextResults = currentGroupResults.value(selection.at(i));
-            foreach (QDResultGroup* res, results) {
+            for (QDResultGroup* res : qAsConst(results)) {
                 foreach (QDResultGroup* nextRes, nextResults) {
                     QDResultGroup* newRes = new QDResultGroup(*res);
                     newRes->add(nextRes->getResultsList());
@@ -424,7 +425,7 @@ void QDResultLinker::updateCandidates(int& progress) {
     int i = 0;
 
     foreach (QDResultGroup* candidate, candidates) {
-        foreach (QDResultGroup* actorRes, currentResults) {
+        for (QDResultGroup* actorRes : qAsConst(currentResults)) {
             if (sched->isCanceled()) {
                 cleanupCandidates();
                 qDeleteAll(newCandidates);
@@ -507,10 +508,10 @@ bool QDResultLinker::canAdd(QDResultGroup* actorResult, QDResultGroup* candidate
         actorResults = actorResult->getResultsList();
         candidateResults = candidate->getResultsList();
     }
-    foreach (const QDResultUnit& actorResUnit, actorResults) {
-        foreach (const QDResultUnit& candidateResUnit, candidateResults) {
-            const QList<QDConstraint*>& cl = currentStep->getConstraints(actorResUnit->owner, candidateResUnit->owner);
-            foreach (QDConstraint* c, cl) {
+    for (const QDResultUnit& actorResUnit : qAsConst(actorResults)) {
+        for (const QDResultUnit& candidateResUnit : qAsConst(candidateResults)) {
+            QList<QDConstraint*> constraints = currentStep->getConstraints(actorResUnit->owner, candidateResUnit->owner);
+            for (QDConstraint* c : qAsConst(constraints)) {
                 if (!QDConstraintController::match(c, actorResUnit, candidateResUnit, complement)) {
                     return false;
                 }
@@ -576,7 +577,8 @@ void QDResultLinker::createAnnotations(const QString& groupPrefix) {
 
         QList<SharedAnnotationData> groupAnns;
 
-        foreach (const QDResultUnit& res, candidate->getResultsList()) {
+        QList<QDResultUnit> results = candidate->getResultsList();
+        for (const QDResultUnit& res : qAsConst(results)) {
             SharedAnnotationData a = result2annotation.value(res, SharedAnnotationData());
             if (a == SharedAnnotationData()) {
                 SharedAnnotationData ad(new AnnotationData);
@@ -607,9 +609,10 @@ void QDResultLinker::createMergedAnnotations(const QString& groupPrefix) {
             return;
         }
 
-        qint64 startPos = candidate->getResultsList().first()->region.startPos;
-        qint64 endPos = candidate->getResultsList().first()->region.endPos();
-        foreach (const QDResultUnit& ru, candidate->getResultsList()) {
+        QList<QDResultUnit> results = candidate->getResultsList();
+        qint64 startPos = results.first()->region.startPos;
+        qint64 endPos = results.first()->region.endPos();
+        for (const QDResultUnit& ru : qAsConst(results)) {
             startPos = qMin(startPos, ru->region.startPos);
             endPos = qMax(endPos, ru->region.endPos());
         }

--- a/src/corelibs/U2Designer/src/wizard/WizardController.cpp
+++ b/src/corelibs/U2Designer/src/wizard/WizardController.cpp
@@ -539,7 +539,8 @@ void WizardController::setAttributeValue(const AttributeInfo& info, const QVaria
         if (otherAttr == attr) {
             continue;
         }
-        foreach (const AttributeRelation* relation, otherAttr->getRelations()) {
+        QVector<const AttributeRelation*> relations = otherAttr->getRelations();
+        for (const AttributeRelation* relation : qAsConst(relations)) {
             if (relation->getType() != VISIBILITY || relation->getRelatedAttrId() != attr->getId()) {
                 continue;
             }

--- a/src/corelibs/U2Gui/src/ProjectParsing.cpp
+++ b/src/corelibs/U2Gui/src/ProjectParsing.cpp
@@ -130,7 +130,8 @@ void ProjectFileUtils::saveProjectFile(U2OpStatus& ts, Project* project, const Q
     QDir projectDir = projectFile.absoluteDir();
 
     // save documents
-    foreach (Document* gbDoc, project->getDocuments()) {
+    QList<Document*> documents = project->getDocuments();
+    for (Document* gbDoc : qAsConst(documents)) {
         gbDoc->getDocumentFormat()->updateFormatSettings(gbDoc);
 
         QString docUrl = gbDoc->getURLString();

--- a/src/corelibs/U2Gui/src/UnloadDocumentTask.cpp
+++ b/src/corelibs/U2Gui/src/UnloadDocumentTask.cpp
@@ -104,7 +104,7 @@ QList<Task*> UnloadDocumentTask::runUnloadTaskHelper(const QList<Document*>& doc
 
     QList<Task*> result;
 
-    foreach (Document* doc, docs) {
+    for (Document* doc : qAsConst(docs)) {
         QString err = checkSafeUnload(doc);
         if (err == ACTIVE_VIEW_ERROR) {
             QMessageBox::StandardButtons buttons = QMessageBox::StandardButtons(QMessageBox::Yes) | QMessageBox::No;
@@ -234,7 +234,7 @@ void ReloadDocumentTask::saveObjectRelationsFromDoc() {
             if (savedObjectRelations.contains(curObjName)) {
                 coreLog.error("Objects with same names detected during saving of object relations!");
             }
-            foreach (const GObjectRelation& relation, curObjRelations) {
+            for (const GObjectRelation& relation : qAsConst(curObjRelations)) {
                 if (doc->getURLString() != relation.getDocURL()) {  // don't save relations within a single object
                     savedObjectRelations.insert(curObjName, relation);
                 }

--- a/src/corelibs/U2Gui/src/options_panel/OPWidgetFactoryRegistry.cpp
+++ b/src/corelibs/U2Gui/src/options_panel/OPWidgetFactoryRegistry.cpp
@@ -51,7 +51,7 @@ QList<OPWidgetFactory*> OPWidgetFactoryRegistry::getRegisteredFactories(const QL
 
     QList<OPWidgetFactory*> factoriesForObjView;
 
-    foreach (OPWidgetFactory* factory, opWidgetFactories) {
+    for (OPWidgetFactory* factory : qAsConst(opWidgetFactories)) {
         bool pass = true;
         foreach (OPFactoryFilterVisitorInterface* filter, filters) {
             pass &= factory->passFiltration(filter);

--- a/src/corelibs/U2Gui/src/util/ExportAnnotations2CSVTask.cpp
+++ b/src/corelibs/U2Gui/src/util/ExportAnnotations2CSVTask.cpp
@@ -97,7 +97,7 @@ void ExportAnnotations2CSVTask::run() {
     }
 
     bool hasSequenceNameQualifier = false;
-    foreach (Annotation* annotation, annotations) {
+    for (Annotation* annotation: qAsConst(annotations)) {
         foreach (const U2Qualifier& qualifier, annotation->getQualifiers()) {
             const QString& qName = qualifier.name;
             if (qName == SEQUENCE_NAME) {
@@ -114,8 +114,9 @@ void ExportAnnotations2CSVTask::run() {
     CHECK_OP(stateInfo, );
 
     bool noComplementarySequence = false;
-    foreach (Annotation* annotation, annotations) {
-        foreach (const U2Region& region, annotation->getRegions()) {
+    for (Annotation* annotation: qAsConst(annotations)) {
+        QVector<U2Region> regions = annotation->getRegions();
+        for (const U2Region& region: qAsConst(regions)) {
             QStringList values;
             values << annotation->getGroup()->getGroupPath();
             values << annotation->getName();

--- a/src/corelibs/U2Gui/src/util/ExportObjectUtils.cpp
+++ b/src/corelibs/U2Gui/src/util/ExportObjectUtils.cpp
@@ -194,7 +194,7 @@ Task* ExportObjectUtils::saveAnnotationsTask(const QString& filepath, const Docu
     QMap<U2DataId, AnnotationTableObject*> annTables;
     QMap<AnnotationTableObject*, QMap<QString, QList<SharedAnnotationData>>> annTable2Anns;
 
-    foreach (Annotation* a, annList) {
+    for (Annotation* a : qAsConst(annList)) {
         const AnnotationTableObject* parentObject = a->getGObject();
         if (parentObject != nullptr) {
             U2DataId objId = parentObject->getRootFeatureId();
@@ -216,7 +216,8 @@ Task* ExportObjectUtils::saveAnnotationsTask(const QString& filepath, const Docu
         }
     }
 
-    foreach (AnnotationTableObject* ato, annTable2Anns.keys()) {
+    QList<AnnotationTableObject*> annotationObjects = annTable2Anns.keys();
+    for (AnnotationTableObject* ato : qAsConst(annotationObjects)) {
         foreach (const QString& groupName, annTable2Anns[ato].keys()) {
             ato->addAnnotations(annTable2Anns[ato][groupName], groupName);
         }

--- a/src/corelibs/U2Gui/src/util/ProjectTreeItemSelectorDialog.cpp
+++ b/src/corelibs/U2Gui/src/util/ProjectTreeItemSelectorDialog.cpp
@@ -125,7 +125,7 @@ void ProjectTreeItemSelectorDialog::selectObjectsAndFolders(const ProjectTreeCon
         SAFE_POINT(nullptr != os, "Invalid object selection", );
         foreach (GObject* obj, os->getSelectedObjects()) {
             bool objectIsAlreadySelected = false;
-            foreach (const Folder& selectedFolder, folderList) {
+            for (const Folder& selectedFolder : qAsConst(folderList)) {
                 if (d->controller->isObjectInFolder(obj, selectedFolder)) {
                     objectIsAlreadySelected = true;
                     break;

--- a/src/corelibs/U2Gui/src/util/project/ProjectTreeController.cpp
+++ b/src/corelibs/U2Gui/src/util/project/ProjectTreeController.cpp
@@ -938,7 +938,7 @@ void ProjectTreeController::connectToResourceTracker() {
     foreach (Document* doc, AppContext::getProject()->getDocuments()) {
         QString resName = LoadUnloadedDocumentTask::getResourceName(doc);
         QList<Task*> users = AppContext::getResourceTracker()->getResourceUsers(resName);
-        foreach (Task* t, users) {
+        for (Task* t : qAsConst(users)) {
             sl_onResourceUserRegistered(resName, t);
         }
     }

--- a/src/corelibs/U2Gui/src/util/project/ProjectViewFilterModel.cpp
+++ b/src/corelibs/U2Gui/src/util/project/ProjectViewFilterModel.cpp
@@ -306,7 +306,7 @@ void ProjectViewFilterModel::sl_rowsAboutToBeRemoved(const QModelIndex& parent, 
             FAIL("Unexpected project item type", );
     }
 
-    foreach (GObject* obj, objectsBeingRemoved) {
+    for (GObject* obj : qAsConst(objectsBeingRemoved)) {
         foreach (FilteredProjectGroup* group, filterGroups) {
             WrappedObject* wrappedObj = group->getWrappedObject(obj);
             if (wrappedObj != nullptr) {

--- a/src/corelibs/U2Gui/src/util/project/filter_tasks/FeatureKeyFilterTask.cpp
+++ b/src/corelibs/U2Gui/src/util/project/filter_tasks/FeatureKeyFilterTask.cpp
@@ -77,7 +77,8 @@ void FeatureKeyFilterTask::filterDocument(Document* doc) {
         }
         SafeObjList filteredResult;
         filteredResult.append(annTable);
-        foreach (const QString& filterName, annNames[annTableId]) {
+        QStringList filterNames = annNames[annTableId];
+        for (const QString& filterName : qAsConst(filterNames)) {
             emit si_objectsFiltered(filterName, filteredResult);
         }
         stateInfo.setProgress(stateInfo.getProgress() + (totalDocObjectsNumber / foundObjectsNumber / totalObjectCount) * 100);

--- a/src/corelibs/U2Lang/src/library/LocalDomain.cpp
+++ b/src/corelibs/U2Lang/src/library/LocalDomain.cpp
@@ -120,7 +120,8 @@ Message BaseWorker::getMessageAndSetupScriptValues(CommunicationChannel* channel
 }
 
 void BaseWorker::bindScriptValues() {
-    foreach (IntegralBus* bus, ports.values()) {
+    QList<IntegralBus*> busList = ports.values();
+    for (IntegralBus* bus : qAsConst(busList)) {
         assert(bus != nullptr);
         if (!bus->hasMessage()) {  // means that it is bus for output port
             continue;

--- a/src/corelibs/U2Lang/src/model/GrouperOutSlot.cpp
+++ b/src/corelibs/U2Lang/src/model/GrouperOutSlot.cpp
@@ -171,11 +171,14 @@ GrouperOutSlot::GrouperOutSlot(const QString& outSlotId, const QString& inSlotSt
 GrouperOutSlot::GrouperOutSlot(const GrouperOutSlot& another) {
     outSlotId = another.outSlotId;
     inSlotStr = another.inSlotStr;
-    if (nullptr == another.action) {
-        action = nullptr;
-    } else {
-        action = new GrouperSlotAction(*another.action);
-    }
+    action = another.action == nullptr ? nullptr : new GrouperSlotAction(*another.action);
+}
+
+GrouperOutSlot& GrouperOutSlot::operator=(const GrouperOutSlot& another) {
+    outSlotId = another.outSlotId;
+    inSlotStr = another.inSlotStr;
+    action = another.action == nullptr ? nullptr : new GrouperSlotAction(*another.action);
+    return *this;
 }
 
 GrouperOutSlot::~GrouperOutSlot() {

--- a/src/corelibs/U2Lang/src/model/GrouperOutSlot.h
+++ b/src/corelibs/U2Lang/src/model/GrouperOutSlot.h
@@ -89,7 +89,10 @@ public:
     GrouperOutSlot(const GrouperOutSlot& another);
     ~GrouperOutSlot();
 
+    GrouperOutSlot& operator=(const GrouperOutSlot& t);
+
     bool operator==(const GrouperOutSlot& other) const;
+
 
     GrouperSlotAction* getAction();
     GrouperSlotAction* getAction() const;

--- a/src/corelibs/U2Lang/src/model/GrouperSlotAttribute.cpp
+++ b/src/corelibs/U2Lang/src/model/GrouperSlotAttribute.cpp
@@ -54,7 +54,7 @@ void GrouperOutSlotAttribute::addOutSlot(const GrouperOutSlot& outSlot) {
 
 void GrouperOutSlotAttribute::updateActorIds(const QMap<ActorId, ActorId>& actorIdsMap) {
     QList<GrouperOutSlot> newOutSlots;
-    foreach (const GrouperOutSlot& gSlot, outSlots) {
+    for (const GrouperOutSlot& gSlot : qAsConst(outSlots)) {
         QString slotStr = gSlot.getInSlotStr();
         slotStr = GrouperOutSlot::readable2busMap(slotStr);
         Workflow::IntegralBusType::remapSlotString(slotStr, actorIdsMap);

--- a/src/corelibs/U2Lang/src/model/Schema.cpp
+++ b/src/corelibs/U2Lang/src/model/Schema.cpp
@@ -52,7 +52,7 @@ Schema& Schema::operator=(const Schema& other) {
     procs = other.procs;
     domain = other.domain;
     graph = ActorBindingsGraph(other.graph);
-    deepCopy = false;    
+    deepCopy = false;
     includedTypeName = other.includedTypeName;
     return *this;
 }
@@ -250,8 +250,9 @@ QList<Wizard*> Schema::takeWizards() {
 
 void Schema::removeProcess(Actor* actor) {
     // remove actors flows
-    foreach (Port* p, actor->getPorts()) {
-        foreach (Link* l, p->getLinks()) {
+    QList<Port*> ports = actor->getPorts();
+    for (auto port : qAsConst(ports)) {
+        foreach (Link* l, port->getLinks()) {
             removeFlow(l);
         }
     }
@@ -328,7 +329,7 @@ QStringList removeAliasesDupliucates(const QList<Actor*>& actors, Actor* newActo
 void Schema::merge(Schema& other) {
     foreach (Actor* newActor, other.procs) {
         QStringList removed = removeAliasesDupliucates(procs, newActor);
-        foreach (const QString& alias, removed) {
+        for (const QString& alias : qAsConst(removed)) {
             coreLog.error(QObject::tr("Duplicate alias '%1'. It has been removed").arg(alias));
         }
         procs << newActor;
@@ -342,7 +343,8 @@ void Schema::replaceProcess(Actor* oldActor, Actor* newActor, const QList<PortMa
     QMap<int, QList<Actor*>> top = graph.getTopologicalSortedGraph(procs);
 
     // replace actors flows
-    foreach (Port* p, oldActor->getPorts()) {
+    QList<Port*> ports = oldActor->getPorts();
+    for (Port* p : qAsConst(ports)) {
         U2OpStatus2Log os;
         PortMapping pm = PortMapping::getMappingBySrcPort(p->getId(), mappings, os);
         if (os.hasError()) {
@@ -738,7 +740,7 @@ QMap<int, QList<Actor*>> ActorBindingsGraph::getTopologicalSortedGraph(QList<Act
 
         foreach (Actor* a, graph.keys()) {
             QList<Port*> ports = graph.value(a);
-            foreach (Port* p, ports) {
+            for (Port* p : qAsConst(ports)) {
                 if (endVertexes.contains(p->owner())) {
                     ports.removeOne(p);
                 }
@@ -770,7 +772,8 @@ bool ActorBindingsGraph::isEmpty() const {
 
 QList<Link*> ActorBindingsGraph::getFlows() const {
     QList<Link*> result;
-    foreach (Port* src, bindings.keys()) {
+    QList<Port*> ports = bindings.keys();
+    for (Port* src : qAsConst(ports)) {
         foreach (Link* l, src->getLinks()) {
             SAFE_POINT(l->source() == src, "Link's source port mismatch", result);
             Port* dst = l->destination();

--- a/src/corelibs/U2Lang/src/support/WorkflowRunTask.cpp
+++ b/src/corelibs/U2Lang/src/support/WorkflowRunTask.cpp
@@ -116,12 +116,15 @@ int WorkflowRunTask::getMsgPassed(const Link* l) {
 
 QString WorkflowRunTask::generateReport() const {
     QString report;
-    foreach (WorkflowMonitor* monitor, getMonitors()) {
+    QList<WorkflowMonitor*> monitors = getMonitors();
+    for (const WorkflowMonitor* monitor : qAsConst(monitors)) {
         const QMap<QString, QMultiMap<QString, QString>> workersReports = monitor->getWorkersReports();
-        foreach (const QString& worker, workersReports.keys()) {
-            const QMultiMap<QString, QString> tasksReports = workersReports[worker];
+        QList<QString> workerReportKeys = workersReports.keys();
+        for (const QString& worker : qAsConst(workerReportKeys)) {
+            QMultiMap<QString, QString> tasksReports = workersReports[worker];
             QString workerReport;
-            foreach (const QString& taskName, tasksReports.uniqueKeys()) {
+            QList<QString> taskNames = tasksReports.uniqueKeys();
+            for (const QString& taskName : qAsConst(taskNames)) {
                 foreach (const QString& taskReport, tasksReports.values(taskName)) {
                     if (!taskReport.isEmpty()) {
                         workerReport += QString("<div class=\"task\" id=\"%1\">%2</div>").arg(taskName).arg(QString(taskReport.toUtf8().toBase64()));
@@ -139,7 +142,7 @@ QString WorkflowRunTask::getTaskError() const {
         return getError();
     }
 
-    foreach (WorkflowMonitor* monitor, monitors) {
+    for (const WorkflowMonitor* monitor : qAsConst(monitors)) {
         foreach (const WorkflowNotification& notification, monitor->getNotifications()) {
             if (WorkflowNotification::U2_ERROR == notification.type) {
                 return notification.message;
@@ -323,7 +326,7 @@ Task::ReportResult WorkflowIterationRunTask::report() {
     foreach (Actor* a, schema->getProcesses()) {
         LocalWorkflow::BaseWorker* bw = a->castPeer<LocalWorkflow::BaseWorker>();
         QStringList urls = bw->getOutputFiles();
-        foreach (const QString& url, urls) {
+        for (const QString& url : qAsConst(urls)) {
             QString absUrl = context->absolutePath(url);
             if (isValidFile(absUrl, startTimeSec)) {
                 context->getMonitor()->addOutputFile(absUrl, a->getId());

--- a/src/corelibs/U2Lang/src/support/WorkflowUtils.cpp
+++ b/src/corelibs/U2Lang/src/support/WorkflowUtils.cpp
@@ -126,7 +126,7 @@ QStringList WorkflowUtils::expandToUrls(const QString& s) {
     QStringList urls = s.split(";");
     QStringList result;
     QRegExp wcard("[*?\\[\\]]");
-    foreach (QString url, urls) {
+    for (QString url : qAsConst(urls)) {
         int idx = url.indexOf(wcard);
         if (idx >= 0) {
             int dirIdx = url.lastIndexOf('/', idx);
@@ -205,7 +205,7 @@ bool validatePorts(Actor* a, NotificationsList& infoList) {
         NotificationsList notificationList;
         good = p->validate(notificationList) && good;
         if (!notificationList.isEmpty()) {
-            foreach (WorkflowNotification notification, notificationList) {
+            for (const WorkflowNotification& notification : qAsConst(notificationList)) {
                 WorkflowNotification item;
                 item.message = notification.message;
                 item.port = p->getId();
@@ -222,7 +222,7 @@ bool graphDepthFirstSearch(Actor* vertex, QList<Actor*>& visitedVertices) {
     visitedVertices.append(vertex);
     const QList<Port*> outputPorts = vertex->getOutputPorts();
     QList<Actor*> receivingVertices;
-    foreach (Port* outputPort, outputPorts) {
+    for (Port* outputPort : qAsConst(outputPorts)) {
         foreach (Port* receivingPort, outputPort->getLinks().keys()) {
             receivingVertices.append(receivingPort->owner());
         }
@@ -330,7 +330,7 @@ bool WorkflowUtils::validate(const Workflow::Schema& schema, QStringList& errs) 
     NotificationsList notifications;
     bool good = validate(schema, notifications);
 
-    foreach (const WorkflowNotification& notification, notifications) {
+    for (const WorkflowNotification& notification : qAsConst(notifications)) {
         QString res = QString();
         Actor* a = schema.actorById(notification.actorId);
         if (notification.actorId.isEmpty() || a == nullptr) {
@@ -474,7 +474,8 @@ QString WorkflowUtils::findPathToSchemaFile(const QString& name) {
 void WorkflowUtils::getLinkedActorsId(Actor* a, QList<QString>& linkedActors) {
     if (!linkedActors.contains(a->getId())) {
         linkedActors.append(a->getId());
-        foreach (Port* p, a->getPorts()) {
+        QList<Port*> ports = a->getPorts();
+        for (Port* p : qAsConst(ports)) {
             foreach (Port* pp, p->getLinks().keys()) {
                 getLinkedActorsId(pp->owner(), linkedActors);
             }
@@ -493,7 +494,8 @@ bool WorkflowUtils::isPathExist(const Port* src, const Port* dest) {
     }
     const Actor* destElement = dest->owner();
 
-    foreach (const Port* port, src->owner()->getPorts()) {
+    QList<Port*> ports = src->owner()->getPorts();
+    for (const Port* port : qAsConst(ports)) {
         if (src == port) {
             continue;
         }
@@ -656,7 +658,8 @@ bool WorkflowUtils::validateSchemaForIncluding(const Schema& s, QString& error) 
         }
     }
 
-    foreach (Actor* actor, s.getProcesses()) {
+    QList<Actor*> processes = s.getProcesses();
+    for (Actor* actor : qAsConst(processes)) {
         // check that free input ports are aliased
         foreach (Port* port, actor->getPorts()) {
             if (!port->isInput()) {
@@ -691,7 +694,7 @@ void WorkflowUtils::extractPathsFromBindings(StrStrMap& busMap, SlotPathMap& pat
     QStringList path;
     foreach (const QString& dest, busMap.keys()) {
         QStringList srcs = busMap.value(dest).split(";");
-        foreach (const QString& src, srcs) {
+        for (const QString& src : qAsConst(srcs)) {
             BusMap::parseSource(src, srcId, path);
             if (!path.isEmpty()) {
                 QPair<QString, QString> slotPair(dest, srcId);
@@ -703,18 +706,19 @@ void WorkflowUtils::extractPathsFromBindings(StrStrMap& busMap, SlotPathMap& pat
 }
 
 void WorkflowUtils::applyPathsToBusMap(StrStrMap& busMap, const SlotPathMap& pathMap) {
-    foreach (const QString& dest, busMap.keys()) {
+    QList<QString> busMapKeys = busMap.keys();
+    for (const QString& dest : qAsConst(busMapKeys)) {
         QStringList newSrcs;
 
         QStringList srcs = busMap.value(dest).split(";");
         QStringList uniqList;
-        foreach (QString src, srcs) {
+        for (const QString& src : qAsConst(srcs)) {
             if (!uniqList.contains(src)) {
                 uniqList << src;
             }
         }
 
-        foreach (const QString& src, uniqList) {
+        for (const QString& src : qAsConst(uniqList)) {
             QPair<QString, QString> slotPair(dest, src);
             if (pathMap.contains(slotPair)) {
                 QList<QStringList> paths = pathMap.values(slotPair);
@@ -738,7 +742,7 @@ bool WorkflowUtils::startExternalProcess(QProcess* process, const QString& progr
 
 QStringList WorkflowUtils::getDatasetsUrls(const QList<Dataset>& sets) {
     QStringList result;
-    foreach (const Dataset& dSet, sets) {
+    for (const Dataset& dSet : qAsConst(sets)) {
         foreach (URLContainer* url, dSet.getUrls()) {
             result << url->getUrl();
         }
@@ -1215,7 +1219,7 @@ bool WorkflowUtils::validateSharedDbUrl(const QString& url, NotificationsList& n
 
 bool WorkflowUtils::validateDatasets(const QList<Dataset>& sets, NotificationsList& notificationList) {
     bool res = true;
-    foreach (const Dataset& set, sets) {
+    for (const Dataset& set : qAsConst(sets)) {
         foreach (URLContainer* urlContainer, set.getUrls()) {
             SAFE_POINT(nullptr != urlContainer, "NULL URLContainer!", false);
             bool urlIsValid = urlContainer->validateUrl(notificationList);

--- a/src/corelibs/U2Script/src/WorkflowElementFacade.cpp
+++ b/src/corelibs/U2Script/src/WorkflowElementFacade.cpp
@@ -170,7 +170,7 @@ U2ErrorType WorkflowElementFacade::getElementSlotIds(const QString& elementType,
     slotIds.clear();
     QList<Workflow::PortDescriptor*> ports;
     CHECK(U2_OK == (result = getElementPorts(elementType, ports)), result);
-    foreach (Workflow::PortDescriptor* port, ports) {
+    for (const Workflow::PortDescriptor* port: qAsConst(ports)) {
         if ((!(inputSlot ^ port->isInput()) && portId.isEmpty()) || portId == port->getId()) {
             QList<Descriptor> slotList = port->getOwnTypeMap().keys();
             foreach (Descriptor slotDescriptor, slotList) {
@@ -232,7 +232,7 @@ U2ErrorType getConvenientPortIdForSlot(const QString& elementId, const QString& 
         while (currElement != currGroup.end()) {
             if ((*currElement)->getId() == elementId) {
                 QList<PortDescriptor*> currPorts = (*currElement)->getPortDesciptors();
-                foreach (Workflow::PortDescriptor* port, currPorts) {
+                for (Workflow::PortDescriptor* port: qAsConst(currPorts)) {
                     if ((isInput && port->isInput()) || (!isInput && port->isOutput())) {
                         QList<Descriptor> slotList = port->getOwnTypeMap().keys();
                         foreach (Descriptor slotDescriptor, slotList) {

--- a/src/corelibs/U2View/src/ov_assembly/ExportCoverageTask.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/ExportCoverageTask.cpp
@@ -135,7 +135,7 @@ void ExportCoverageTask::identifyAlphabet(QVector<CoveragePerBaseInfo>* regionCo
     CHECK(alphabetChars.size() == 4, );
     foreach (const CoveragePerBaseInfo& info, *regionCoverage) {
         QList<char> chars = info.basesCount.keys();
-        foreach (char curChar, chars) {
+        for (char curChar : qAsConst(chars)) {
             if (EXTENDED_CHARACTERS.contains(curChar)) {
                 alphabetChars.append(EXTENDED_CHARACTERS);
                 return;
@@ -240,12 +240,12 @@ void ExportCoveragePerBaseTask::writeResult(const QVector<CoveragePerBaseInfo>* 
     foreach (const CoveragePerBaseInfo& info, *data) {
         alreadyProcessed++;
 
-        const bool coverageSatisfy = settings.exportCoverage && (settings.threshold <= info.coverage);
+        bool coverageSatisfy = settings.exportCoverage && (settings.threshold <= info.coverage);
         int baseCountsScore = 0;
-        foreach (char curChar, alphabetChars) {
+        for (char curChar : qAsConst(alphabetChars)) {
             baseCountsScore += info.basesCount.value(curChar, 0);
         }
-        const bool basesCountSatisfy = settings.exportBasesCount && (settings.threshold <= baseCountsScore);
+        bool basesCountSatisfy = settings.exportBasesCount && (settings.threshold <= baseCountsScore);
         if (!coverageSatisfy && !basesCountSatisfy) {
             continue;
         }

--- a/src/corelibs/U2View/src/ov_msa/MaEditorFactory.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorFactory.cpp
@@ -73,10 +73,10 @@ Task* MaEditorFactory::createViewTask(const MultiGSelection& multiSelection, boo
                                                                            false);
     QList<OpenMaEditorTask*> resTasks;
 
-    foreach (Document* doc, docsWithMSA) {
+    for (Document* doc : qAsConst(docsWithMSA)) {
         QList<GObject*> docObjs = doc->findGObjectByType(type, UOF_LoadedAndUnloaded);
         if (!docObjs.isEmpty()) {
-            foreach (GObject* obj, docObjs) {
+            for (GObject* obj : qAsConst(docObjs)) {
                 if (!msaObjects.contains(obj)) {
                     msaObjects.append(obj);
                 }

--- a/src/corelibs/U2View/src/ov_phyltree/TreeViewerFactory.cpp
+++ b/src/corelibs/U2View/src/ov_phyltree/TreeViewerFactory.cpp
@@ -62,7 +62,7 @@ Task* TreeViewerFactory::createViewTask(const MultiGSelection& multiSelection, b
                                                                            false);
     QList<OpenTreeViewerTask*> resTasks;
 
-    foreach (Document* doc, docsWithPhy) {
+    for (Document* doc : qAsConst(docsWithPhy)) {
         QList<GObject*> docObjs = doc->findGObjectByType(GObjectTypes::PHYLOGENETIC_TREE, UOF_LoadedAndUnloaded);
         if (!docObjs.isEmpty()) {
             foreach (GObject* obj, docObjs) {

--- a/src/corelibs/U2View/src/ov_sequence/ADVSingleSequenceWidget.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/ADVSingleSequenceWidget.cpp
@@ -843,7 +843,8 @@ void ADVSingleSequenceWidget::sl_createCustomRuler() {
         }
 
         // find minimum of start positions of selected annotations
-        foreach (const U2Region& region, ann->getRegions()) {
+        QVector<U2Region> regions = ann->getRegions();
+        for (const U2Region& region : qAsConst(regions)) {
             annOffset = annOffset > region.startPos ? region.startPos : annOffset;
         }
     }

--- a/src/corelibs/U2View/src/ov_sequence/ADVSyncViewManager.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/ADVSyncViewManager.cpp
@@ -525,11 +525,11 @@ void ADVSyncViewManager::updateAutoAnnotationActions() {
     foreach (ADVSequenceWidget* w, adv->getSequenceWidgets()) {
         QList<ADVSequenceWidgetAction*> actions = w->getADVSequenceWidgetActions();
         bool active = false;
-        foreach (ADVSequenceWidgetAction* action, actions) {
+        for (ADVSequenceWidgetAction* action : qAsConst(actions)) {
             AutoAnnotationsADVAction* aaAction = qobject_cast<AutoAnnotationsADVAction*>(action);
             if (aaAction != nullptr) {
                 QList<QAction*> aaToggleActions = aaAction->getToggleActions();
-                foreach (QAction* toggleAction, aaToggleActions) {
+                for (QAction* toggleAction : qAsConst(aaToggleActions)) {
                     if (toggleAction->isEnabled()) {
                         aaActionMap.insertMulti(toggleAction->text(), toggleAction);
                         active = true;
@@ -571,7 +571,7 @@ void ADVSyncViewManager::sl_toggleAutoAnnotationHighlighting() {
 void ADVSyncViewManager::sl_updateAutoAnnotationsMenu() {
     QList<QAction*> menuActions = toggleAutoAnnotationsMenu->actions();
 
-    foreach (QAction* menuAction, menuActions) {
+    for (QAction* menuAction : qAsConst(menuActions)) {
         QString aName = menuAction->objectName();
         bool haveEnabledAutoAnnotations = false;
         // if have at least 1 checked  -> uncheck all

--- a/src/corelibs/U2View/src/ov_sequence/AnnotatedDNAView.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/AnnotatedDNAView.cpp
@@ -1068,7 +1068,8 @@ void AnnotatedDNAView::cancelAutoAnnotationUpdates(AutoAnnotationObject* aa, boo
                 aaUpdateTask->cancel();
                 if (removeTaskExist) {
                     *removeTaskExist = false;
-                    foreach (const QPointer<Task>& subTask, aaUpdateTask->getSubtasks()) {
+                    QList<QPointer<Task>> subtasks = aaUpdateTask->getSubtasks();
+                    for (const QPointer<Task>& subTask : qAsConst(subtasks)) {
                         RemoveAnnotationsTask* rTask = qobject_cast<RemoveAnnotationsTask*>(subTask.data());
                         if (rTask && !rTask->isFinished()) {
                             *removeTaskExist = true;
@@ -1109,7 +1110,7 @@ void AnnotatedDNAView::importDocAnnotations(Document* doc) {
             continue;
         }
         QList<GObject*> relatedAnns = GObjectUtils::findObjectsRelatedToObjectByRole(obj, GObjectTypes::ANNOTATION_TABLE, ObjectRole_Sequence, docObjects, UOF_LoadedOnly);
-        foreach (GObject* annObj, relatedAnns) {
+        for (GObject* annObj : qAsConst(relatedAnns)) {
             addObject(annObj);
         }
     }
@@ -1391,7 +1392,8 @@ void AnnotatedDNAView::sl_sequenceModifyTaskStateChanged() {
                 U2Region oldMaxRange(0, newMaxRange.length - seqSizeDelta);
                 foreach (ADVSequenceObjectContext* ctx, seqContexts) {
                     if (ctx->getSequenceGObject() == modifyContentTask->getSequenceObject()) {
-                        foreach (ADVSequenceWidget* w, seqCtx->getSequenceWidgets()) {
+                        QList<ADVSequenceWidget*> widgets = seqCtx->getSequenceWidgets();
+                        for (ADVSequenceWidget* w : qAsConst(widgets)) {
                             if (w->getVisibleRange() == oldMaxRange) {
                                 w->setVisibleRange(newMaxRange);
                             }
@@ -1512,9 +1514,10 @@ QAction* AnnotatedDNAView::getEditActionFromSequenceWidget(ADVSequenceWidget* se
 bool AnnotatedDNAView::areAnnotationsInRange(const QList<Annotation*>& toCheck) {
     foreach (Annotation* a, toCheck) {
         QList<ADVSequenceObjectContext*> relatedSeqObjects = findRelatedSequenceContexts(a->getGObject());
-        foreach (ADVSequenceObjectContext* seq, relatedSeqObjects) {
+        for (ADVSequenceObjectContext* seq : qAsConst(relatedSeqObjects)) {
             SAFE_POINT(seq != nullptr, "Sequence is NULL", true);
-            foreach (const U2Region& r, a->getRegions()) {
+            QVector<U2Region> regions = a->getRegions();
+            for (const U2Region& r : qAsConst(regions)) {
                 if (r.endPos() > seq->getSequenceLength()) {
                     return false;
                 }

--- a/src/corelibs/U2View/src/ov_sequence/AnnotatedDNAViewFactory.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/AnnotatedDNAViewFactory.cpp
@@ -107,14 +107,17 @@ Task* AnnotatedDNAViewFactory::createViewTask(const MultiGSelection& multiSelect
     const DocumentSelection* ds = qobject_cast<const DocumentSelection*>(multiSelection.findSelectionByType(GSelectionTypes::DOCUMENTS));
     if (ds != nullptr) {
         foreach (Document* doc, ds->getSelectedDocuments()) {
-            foreach (GObject* obj, doc->findGObjectByType(GObjectTypes::SEQUENCE, UOF_LoadedAndUnloaded)) {
+            QList<GObject*> sequenceObjects = doc->findGObjectByType(GObjectTypes::SEQUENCE, UOF_LoadedAndUnloaded);
+            for (GObject* obj : qAsConst(sequenceObjects)) {
                 if (!objectsToOpen.contains(obj)) {
                     objectsToOpen.append(obj);
                 }
             }
-            foreach (GObject* obj, GObjectUtils::selectObjectsWithRelation(doc->getObjects(), GObjectTypes::SEQUENCE, ObjectRole_Sequence, UOF_LoadedAndUnloaded, true)) {
-                if (!objectsToOpen.contains(obj)) {
-                    objectsToOpen.append(obj);
+            QList<GObject*> objectsWithRelation = GObjectUtils::selectObjectsWithRelation(
+                doc->getObjects(), GObjectTypes::SEQUENCE, ObjectRole_Sequence, UOF_LoadedAndUnloaded, true);
+            for (GObject* objectWithRelation : qAsConst(objectsWithRelation)) {
+                if (!objectsToOpen.contains(objectWithRelation)) {
+                    objectsToOpen.append(objectWithRelation);
                 }
             }
         }
@@ -147,7 +150,7 @@ bool AnnotatedDNAViewFactory::isStateInSelection(const MultiGSelection& multiSel
 
         // check that object associated with sequence object is in selection
         bool refIsSelected = false;
-        foreach (const GObject* selObject, selectedObjects) {
+        for (const GObject* selObject : qAsConst(selectedObjects)) {
             GObjectReference selRef(selObject);
             if (ref == selRef) {
                 refIsSelected = true;

--- a/src/corelibs/U2View/src/ov_sequence/AnnotationsTreeView.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/AnnotationsTreeView.cpp
@@ -650,7 +650,7 @@ void AnnotationsTreeView::sl_onAnnotationsRemoved(const QList<Annotation*>& as) 
     foreach (Annotation* a, as) {
         QList<AVAnnotationItem*> aItems;
         groupItem->findAnnotationItems(aItems, a);
-        foreach (AVAnnotationItem* ai, aItems) {
+        for (AVAnnotationItem* ai : qAsConst(aItems)) {
             selectedAnnotation.remove(ai);
 
             AVGroupItem* parentGroup = static_cast<AVGroupItem*>(ai->parent());
@@ -678,7 +678,7 @@ void AnnotationsTreeView::sl_onAnnotationsModified(const QList<AnnotationModific
             case AnnotationModification_TypeChanged: {
                 QList<AVAnnotationItem*> aItems = findAnnotationItems(annotationModification.annotation);
                 assert(!aItems.isEmpty());
-                foreach (AVAnnotationItem* ai, aItems) {
+                for (AVAnnotationItem* ai : qAsConst(aItems)) {
                     ai->updateVisual(ATVAnnUpdateFlag_BaseColumns);
                 }
             } break;
@@ -686,14 +686,14 @@ void AnnotationsTreeView::sl_onAnnotationsModified(const QList<AnnotationModific
             case AnnotationModification_QualifierRemoved: {
                 const QualifierModification& qm = static_cast<const QualifierModification&>(annotationModification);
                 QList<AVAnnotationItem*> aItems = findAnnotationItems(qm.annotation);
-                foreach (AVAnnotationItem* ai, aItems) {
+                for (AVAnnotationItem* ai : qAsConst(aItems)) {
                     ai->removeQualifier(qm.getQualifier());
                 }
             } break;
             case AnnotationModification_QualifierAdded: {
                 const QualifierModification& qm = static_cast<const QualifierModification&>(annotationModification);
                 QList<AVAnnotationItem*> aItems = findAnnotationItems(qm.annotation);
-                foreach (AVAnnotationItem* ai, aItems) {
+                for (AVAnnotationItem* ai : qAsConst(aItems)) {
                     if (ai->isExpanded() || ai->childCount() > 1) {  // if item was expanded - add real qualifier items
                         ai->addQualifier(qm.getQualifier());
                     } else {
@@ -1000,7 +1000,7 @@ void AnnotationsTreeView::sl_pasteFinished(Task* _pasteTask) {
     if (docs.length() == 0) {
         return;
     }
-    foreach (Document* doc, docs) {
+    for (Document* doc : qAsConst(docs)) {
         foreach (GObject* annObj, doc->findGObjectByType(GObjectTypes::ANNOTATION_TABLE)) {
             ctx->tryAddObject(annObj);
         }
@@ -1808,8 +1808,9 @@ void AnnotationsTreeView::annotationClicked(AVAnnotationItem* item, QMap<AVAnnot
             }
         }
         foreach (AVAnnotationItem* annItem, selectedAnnotations.keys()) {
-            foreach (U2Region newRegion, selectedAnnotations.value(annItem)) {
-                foreach (const U2Region& toSel, toSelect) {
+            QList<U2Region> regions = selectedAnnotations.value(annItem);
+            for (U2Region newRegion : qAsConst(regions)) {
+                for (const U2Region& toSel : qAsConst(toSelect)) {
                     if (toSel.intersects(newRegion)) {
                         newRegion = U2Region::containingRegion(newRegion, toSel);
                         toSelect.removeOne(toSel);
@@ -1840,8 +1841,8 @@ void AnnotationsTreeView::annotationDoubleClicked(AVAnnotationItem* item, const 
 
     QList<U2Region> regionsToSelect = selectedRegions;
     const QVector<U2Region> regions = sequenceSelection->getSelectedRegions();
-    foreach (const U2Region& reg, regions) {
-        foreach (const U2Region& selectedRegion, selectedRegions) {
+    for (const U2Region& reg : qAsConst(regions)) {
+        for (const U2Region& selectedRegion : qAsConst(selectedRegions)) {
             if (reg.intersects(selectedRegion)) {
                 sequenceSelection->removeRegion(reg);
                 regionsToSelect.removeOne(selectedRegion);

--- a/src/corelibs/U2View/src/ov_sequence/AutoAnnotationUtils.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/AutoAnnotationUtils.cpp
@@ -213,7 +213,7 @@ QAction* AutoAnnotationUtils::findAutoAnnotationsToggleAction(ADVSequenceObjectC
         AutoAnnotationsADVAction* aaAction = qobject_cast<AutoAnnotationsADVAction*>(advAction);
         assert(aaAction != nullptr);
         QList<QAction*> toggleActions = aaAction->getToggleActions();
-        foreach (QAction* tAction, toggleActions) {
+        for (QAction* tAction : qAsConst(toggleActions)) {
             if (tAction->property(AUTO_ANNOTATION_GROUP_NAME) == groupName) {
                 return tAction;
             }
@@ -276,7 +276,7 @@ QList<QAction*> AutoAnnotationUtils::getAutoAnnotationToggleActions(ADVSequenceO
         res = aaAction->getToggleActions();
 
         int selectedCount = 0;
-        foreach (QAction* a, res) {
+        for (QAction* a : qAsConst(res)) {
             if (a->isChecked()) {
                 selectedCount += 1;
             }

--- a/src/corelibs/U2View/src/ov_sequence/Overview.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/Overview.cpp
@@ -429,14 +429,15 @@ void OverviewRenderArea::setAnnotationsOnPos() {
 
     const U2Region sequenceRange(0, ctx->getSequenceObject()->getSequenceLength());
     AnnotationSettingsRegistry* asr = AppContext::getAnnotationsSettingsRegistry();
-    const QSet<AnnotationTableObject*> aObjs = ctx->getAnnotationObjects(true);
+    QSet<AnnotationTableObject*> aObjs = ctx->getAnnotationObjects(true);
 
-    foreach (AnnotationTableObject* at, aObjs) {
+    for (AnnotationTableObject* at : qAsConst(aObjs)) {
         foreach (Annotation* a, at->getAnnotations()) {
             const SharedAnnotationData& ad = a->getData();
             const AnnotationSettings* as = asr->getAnnotationSettings(ad);
             if (as->visible) {
-                foreach (const U2Region& r, ad->getRegions()) {
+                QVector<U2Region> regions = ad->getRegions();
+                for (const U2Region& r : qAsConst(regions)) {
                     const U2Region innerRegion = r.intersect(sequenceRange);
                     for (qint64 i = innerRegion.startPos; i < innerRegion.endPos(); i++) {
                         annotationsOnPos[i]++;

--- a/src/corelibs/U2View/src/ov_sequence/PanView.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/PanView.cpp
@@ -306,7 +306,7 @@ void PanView::sl_onAnnotationsModified(const QList<AnnotationModification>& anno
 
 void PanView::sl_onAnnotationSettingsChanged(const QStringList& changedSettings) {
     AnnotationSettingsRegistry* asr = AppContext::getAnnotationsSettingsRegistry();
-    foreach (const QString& name, changedSettings) {
+    for (const QString& name : qAsConst(changedSettings)) {
         AnnotationSettings* as = asr->getAnnotationSettings(name);
         bool hasRow = rowsManager->hasRowWithName(name);
         if (as->visible == hasRow) {

--- a/src/corelibs/U2View/src/ov_sequence/annot_highlight/AnnotHighlightWidget.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/annot_highlight/AnnotHighlightWidget.cpp
@@ -207,7 +207,7 @@ bool AnnotHighlightWidget::findFirstAnnotatedRegionAfterPos(AnnotatedRegion& ann
         SAFE_POINT(annotatedDnaView->getSequenceContext(annObject) != nullptr, tr("Sequence context is NULL"), false);
         qint64 seqLen = annotatedDnaView->getSequenceContext(annObject)->getSequenceLength();
         QList<Annotation*> annots = annObject->getAnnotationsByRegion(U2Region(isForward ? startPos : 0, isForward ? seqLen - startPos : startPos));
-        foreach (Annotation* a, annots) {
+        for (Annotation* a : qAsConst(annots)) {
             QVector<U2Region> regions = a->getRegions();
             for (int i = 0; i < regions.size(); i++) {
                 if (sign * regions[i].startPos > sign * startPos && sign * regions[i].startPos < sign * pos) {
@@ -240,7 +240,7 @@ bool AnnotHighlightWidget::findNextUnselectedAnnotatedRegion(AnnotatedRegion& an
     // detect the most right/left start position in selection
     const QList<Annotation*> selectionData = as->getAnnotations();
     int start = -1;
-    foreach (Annotation* selectionItem, selectionData) {
+    for (Annotation* selectionItem : qAsConst(selectionData)) {
         foreach (U2Region region, selectionItem->getRegions()) {
             if (start == -1) {
                 start = region.startPos;
@@ -297,7 +297,8 @@ void AnnotHighlightWidget::sl_onAnnotationSelectionChanged() {
 
         // find first or last annotation region
         foreach (Annotation* a, as->getAnnotations()) {
-            foreach (U2Region region, a->getRegions()) {
+            QVector<U2Region> regions = a->getRegions();
+            for (const U2Region& region : qAsConst(regions)) {
                 if (isFirstAnnotatedRegion(a, region, false)) {
                     nextAnnotationButton->setDisabled(true);
                 }
@@ -401,11 +402,10 @@ void AnnotHighlightWidget::findAllAnnotationsNamesForSequence() {
         bool isAminoSeq = seqAlphabet->isAmino();
 
         QSet<AnnotationTableObject*> seqAnnotTableObjects = seqContext->getAnnotationObjects(true);
-
-        foreach (AnnotationTableObject* annotTableObj, seqAnnotTableObjects) {
+        for (AnnotationTableObject* annotTableObj : qAsConst(seqAnnotTableObjects)) {
             const QList<Annotation*> annotations = annotTableObj->getAnnotations();
 
-            foreach (Annotation* annot, annotations) {
+            for (Annotation* annot : qAsConst(annotations)) {
                 const QString annotName = annot->getName();
 
                 // If the annotation was found on a nucleotide sequence
@@ -540,7 +540,7 @@ void AnnotHighlightWidget::sl_onAnnotationsRemoved(const QList<Annotation*>& ann
     QList<AnnotationTableObject*> annTables = annotatedDnaView->getAnnotationObjects(true);
     foreach (const QString& annotName, observedAnnNames.keys()) {
         int count = 0;
-        foreach (AnnotationTableObject* t, annTables) {
+        for (AnnotationTableObject* t : qAsConst(annTables)) {
             count += t->getAnnotationsByName(annotName).size();
         }
         if (count == observedAnnNames[annotName]) {

--- a/src/corelibs/U2View/src/ov_sequence/sequence_info/CharOccurTask.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/sequence_info/CharOccurTask.cpp
@@ -66,9 +66,9 @@ void CharOccurTask::run() {
     QVector<quint64> charactersOccurrence(256, 0);
     qint64 totalLength = U2Region::sumLength(regions);
     qint64 processedLength = 0;
-    foreach (const U2Region& region, regions) {
+    for (const U2Region& region : qAsConst(regions)) {
         QList<U2Region> blocks = U2Region::split(region, REGION_TO_ANALAYZE);
-        foreach (const U2Region& block, blocks) {
+        for (const U2Region& block : qAsConst(blocks)) {
             // Get the selected region and verify that the data has been correctly read
             QByteArray sequence = sequenceDbi->getSequenceData(seqRef.entityId, block, os);
             if (os.hasError() || sequence.isEmpty()) {

--- a/src/corelibs/U2View/src/ov_sequence/sequence_info/DNAStatisticsTask.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/sequence_info/DNAStatisticsTask.cpp
@@ -149,9 +149,10 @@ static QMap<char, QByteArray> createRnaAlphabetResolutionMap() {
 }
 
 static void fillMapWithAvarageValues(QVector<QVector<int>>& map, const QMap<char, QByteArray>& alphabetResolutionMap) {
-    foreach (const char i, alphabetResolutionMap.keys()) {
-        foreach (const char j, alphabetResolutionMap.keys()) {
-            if (0 == map[i][j]) {
+    QList<char> keys = alphabetResolutionMap.keys();
+    for (const char i : qAsConst(keys)) {
+        for (const char j : qAsConst(keys)) {
+            if (map[i][j] == 0) {
                 // Unambiguous nucleotide pairs are already registered
                 // If at least one nucleotide in pair is ambiguous, then the pair value should be an avarage value of all possible variants.
                 int value = 0;
@@ -367,9 +368,9 @@ void DNAStatisticsTask::computeStats() {
         return;
     }
 
-    foreach (const U2Region& region, regions) {
+    for (const U2Region& region : qAsConst(regions)) {
         QList<U2Region> blocks = U2Region::split(region, 1024 * 1024);
-        foreach (const U2Region& block, blocks) {
+        for (const U2Region& block : qAsConst(blocks)) {
             if (isCanceled() || hasError()) {
                 break;
             }
@@ -515,9 +516,9 @@ void DNAStatisticsTask::computeStats() {
 double DNAStatisticsTask::calcPi(U2SequenceDbi* sequenceDbi) {
     U2OpStatus2Log os;
     QVector<qint64> countMap(256, 0);
-    foreach (const U2Region& region, regions) {
+    for (const U2Region& region : qAsConst(regions)) {
         QList<U2Region> blocks = U2Region::split(region, 1024 * 1024);
-        foreach (const U2Region& block, blocks) {
+        for (const U2Region& block : qAsConst(blocks)) {
             if (isCanceled() || hasError()) {
                 break;
             }

--- a/src/corelibs/U2View/src/ov_sequence/sequence_info/DinuclOccurTask.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/sequence_info/DinuclOccurTask.cpp
@@ -70,9 +70,9 @@ void DinuclOccurTask::run() {
     QVector<quint64> dinuclOccurrence(256 * 256, 0);
     qint64 totalLength = U2Region::sumLength(regions);
     qint64 processedLength = 0;
-    foreach (const U2Region& region, regions) {
+    for (const U2Region& region : qAsConst(regions)) {
         QList<U2Region> blocks = U2Region::split(region, REGION_TO_ANALAYZE);
-        foreach (const U2Region& block, blocks) {
+        for (const U2Region& block : qAsConst(blocks)) {
             // Get the selected region and verify that the data has been correctly read
             QByteArray sequence = sequenceDbi->getSequenceData(seqRef.entityId, block, os);
             if (os.hasError() || sequence.isEmpty()) {
@@ -98,8 +98,8 @@ void DinuclOccurTask::run() {
     }
 
     // Convert to the result
-    foreach (char firstChar, alphabetChars) {
-        foreach (char secondChar, alphabetChars) {
+    for (char firstChar : qAsConst(alphabetChars)) {
+        for (char secondChar : qAsConst(alphabetChars)) {
             qint64 count = (qint64)dinuclOccurrence[DI_NUCL_CODE(firstChar, secondChar)];
             if (count == 0) {
                 continue;

--- a/src/libs_3rdparty/QSpec/src/GTGlobals.h
+++ b/src/libs_3rdparty/QSpec/src/GTGlobals.h
@@ -120,12 +120,10 @@ public:
 
 /** Unconditionally marks active test as failed. Prints 'errorMessage' into the log. */
 #define GT_FAIL(errorMessage, result) \
-    { \
-        GT_DEBUG_MESSAGE(false, errorMessage, result); \
-        HI::GTGlobals::GUITestFail(); \
-        os.setError(errorMessage); \
-        return result; \
-    }
+    GT_DEBUG_MESSAGE(false, errorMessage, result); \
+    HI::GTGlobals::GUITestFail(); \
+    os.setError(errorMessage); \
+    return result;
 
 #define CHECK_OP_SET_ERR_RESULT(os, errorMessage, result) \
     CHECK_SET_ERR_RESULT(!os.isCoR(), errorMessage, result)

--- a/src/plugins/CoreTests/src/CMDLineTests.cpp
+++ b/src/plugins/CoreTests/src/CMDLineTests.cpp
@@ -123,7 +123,7 @@ QString GTest_RunCMDLine::splitVal(const QString& val, const QString& prefValue,
     foreach (const QString& dsVal, dsVals) {
         QStringList realVals = dsVal.split(splitter);
         QStringList dsResult;
-        foreach (QString s, realVals) {
+        for (QString s : qAsConst(realVals)) {
             if (s.startsWith(prefValue)) {
                 s = s.mid(midSize);
             }

--- a/src/plugins/CoreTests/src/EditSequenceTests.cpp
+++ b/src/plugins/CoreTests/src/EditSequenceTests.cpp
@@ -123,18 +123,19 @@ Task::ReportResult GTest_AddPartToSequenceTask::report() {
         if (strat != U1AnnotationUtils::AnnotationStrategyForResize_Split_To_Separate) {
             Document* loadedDocument = getContext<Document>(this, docName);
             QList<GObject*> annotationTablesList = loadedDocument->findGObjectByType(GObjectTypes::ANNOTATION_TABLE);
-            foreach (GObject* table, annotationTablesList) {
+            for (GObject* table : qAsConst(annotationTablesList)) {
                 AnnotationTableObject* ato = dynamic_cast<AnnotationTableObject*>(table);
                 foreach (Annotation* curentAnnotation, ato->getAnnotations()) {
                     if (curentAnnotation->getName() == annotationName) {
                         int i = 0;
-                        if (curentAnnotation->getRegions().size() != expectedRegions.size()) {
+                        QVector<U2Region> regions = curentAnnotation->getRegions();
+                        if (regions.size() != expectedRegions.size()) {
                             stateInfo.setError(GTest::tr("Regions is incorrect. Expected size:%1 Actual size:%2")
                                                    .arg(expectedRegions.size())
-                                                   .arg(curentAnnotation->getRegions().size()));
+                                                   .arg(regions.size()));
                             break;
                         }
-                        foreach (const U2Region& curRegion, curentAnnotation->getRegions()) {
+                        for (const U2Region& curRegion : qAsConst(regions)) {
                             if (curRegion != expectedRegions.at(i)) {
                                 stateInfo.setError(GTest::tr("Regions is incorrect. Expected:%3,%4, but Actual:%1,%2")
                                                        .arg(curRegion.startPos)
@@ -151,11 +152,12 @@ Task::ReportResult GTest_AddPartToSequenceTask::report() {
         } else {
             Document* loadedDocument = getContext<Document>(this, docName);
             QList<GObject*> annotationTablesList = loadedDocument->findGObjectByType(GObjectTypes::ANNOTATION_TABLE);
-            foreach (GObject* table, annotationTablesList) {
+            for (GObject* table : qAsConst(annotationTablesList)) {
                 AnnotationTableObject* ato = dynamic_cast<AnnotationTableObject*>(table);
                 foreach (Annotation* curentAnnotation, ato->getAnnotations()) {
                     if (curentAnnotation->getName() == annotationName) {
-                        foreach (const U2Region& curRegion, curentAnnotation->getRegions()) {
+                        QVector<U2Region> regions = curentAnnotation->getRegions();
+                        for (const U2Region& curRegion : qAsConst(regions)) {
                             if (!expectedRegions.contains(curRegion)) {
                                 stateInfo.setError(GTest::tr("Regions is incorrect. actual region didn't found in expected region list"));
                             }
@@ -254,18 +256,19 @@ Task::ReportResult GTest_RemovePartFromSequenceTask::report() {
     if (annotationName.length() != 0) {
         Document* loadedDocument = getContext<Document>(this, docName);
         QList<GObject*> annotationTablesList = loadedDocument->findGObjectByType(GObjectTypes::ANNOTATION_TABLE);
-        foreach (GObject* table, annotationTablesList) {
+        for (GObject* table : qAsConst(annotationTablesList)) {
             AnnotationTableObject* ato = dynamic_cast<AnnotationTableObject*>(table);
             foreach (Annotation* curentAnnotation, ato->getAnnotations()) {
                 if (curentAnnotation->getName() == annotationName) {
                     int i = 0;
-                    if (curentAnnotation->getRegions().size() != expectedRegions.size()) {
+                    QVector<U2Region> currentAnnotationRegions = curentAnnotation->getRegions();
+                    if (currentAnnotationRegions.size() != expectedRegions.size()) {
                         stateInfo.setError(GTest::tr("Regions is incorrect. Expected size:%1 Actual size:%2")
                                                .arg(expectedRegions.size())
-                                               .arg(curentAnnotation->getRegions().size()));
+                                               .arg(currentAnnotationRegions.size()));
                         break;
                     }
-                    foreach (const U2Region& curRegion, curentAnnotation->getRegions()) {
+                    for (const U2Region& curRegion : qAsConst(currentAnnotationRegions)) {
                         if (curRegion != expectedRegions.at(i)) {
                             stateInfo.setError(GTest::tr("Regions is incorrect. Expected:%3,%4, but Actual:%1,%2")
                                                    .arg(curRegion.startPos)
@@ -382,18 +385,19 @@ Task::ReportResult GTest_ReplacePartOfSequenceTask::report() {
     if (!annotationName.isEmpty()) {
         Document* loadedDocument = getContext<Document>(this, docName);
         QList<GObject*> annotationTablesList = loadedDocument->findGObjectByType(GObjectTypes::ANNOTATION_TABLE);
-        foreach (GObject* table, annotationTablesList) {
+        for (GObject* table : qAsConst(annotationTablesList)) {
             AnnotationTableObject* ato = dynamic_cast<AnnotationTableObject*>(table);
             foreach (Annotation* curentAnnotation, ato->getAnnotations()) {
                 if (curentAnnotation->getName() == annotationName) {
                     int i = 0;
-                    if (curentAnnotation->getRegions().size() != expectedRegions.size()) {
+                    QVector<U2Region> currentAnnotationRegions = curentAnnotation->getRegions();
+                    if (currentAnnotationRegions.size() != expectedRegions.size()) {
                         stateInfo.setError(GTest::tr("Regions is incorrect. Expected size:%1 Actual size:%2")
                                                .arg(expectedRegions.size())
-                                               .arg(curentAnnotation->getRegions().size()));
+                                               .arg(currentAnnotationRegions.size()));
                         break;
                     }
-                    foreach (const U2Region& curRegion, curentAnnotation->getRegions()) {
+                    for (const U2Region& curRegion : currentAnnotationRegions) {
                         if (curRegion != expectedRegions.at(i)) {
                             stateInfo.setError(GTest::tr("Regions is incorrect. Expected:%3,%4, but Actual:%1,%2")
                                                    .arg(curRegion.startPos)

--- a/src/plugins/CoreTests/src/FindAlgorithmTests.cpp
+++ b/src/plugins/CoreTests/src/FindAlgorithmTests.cpp
@@ -177,7 +177,7 @@ void GTest_FindAlgorithmTest::init(XMLTestFormat*, const QDomElement& el) {
 
             QStringList regList = regStr.split(",", QString::SkipEmptyParts);
             r = U2Region();
-            foreach (QString reg, regList) {
+            for (const QString& reg : qAsConst(regList)) {
                 U2Region regionPart = stringToRegion(reg);
                 if (regionPart.startPos > r.startPos) {
                     r.startPos = regionPart.startPos;

--- a/src/plugins/GUITestBase/src/GTUtilsAssemblyBrowser.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsAssemblyBrowser.cpp
@@ -296,13 +296,12 @@ void GTUtilsAssemblyBrowser::callExportCoverageDialog(HI::GUITestOpStatus& os, A
 QScrollBar* GTUtilsAssemblyBrowser::getScrollBar(GUITestOpStatus& os, Qt::Orientation orientation) {
     AssemblyBrowserUi* ui = getView(os);
     QList<QScrollBar*> scrollBars = ui->findChildren<QScrollBar*>();
-    foreach (QScrollBar* bar, scrollBars) {
+    for (QScrollBar* bar : qAsConst(scrollBars)) {
         if (bar->orientation() == orientation) {
             return bar;
         }
     }
-
-    GT_CHECK_RESULT(false, QString("Scrollbar with orientation %1 not found").arg(orientation), nullptr);
+    GT_FAIL(QString("Scrollbar with orientation %1 not found").arg(orientation), nullptr);
 }
 #undef GT_METHOD_NAME
 

--- a/src/plugins/GUITestBase/src/GTUtilsDashboard.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsDashboard.cpp
@@ -94,7 +94,7 @@ ExternalToolsTreeNode* GTUtilsDashboard::getExternalToolNodeByText(GUITestOpStat
             return node;
         }
     }
-    GT_CHECK_RESULT(false, "External tool node by text not found: " + textPattern, nullptr);
+    GT_FAIL("External tool node by text not found: " + textPattern, nullptr);
 }
 #undef GT_METHOD_NAME
 

--- a/src/plugins/GUITestBase/src/GTUtilsOptionPanelMSA.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsOptionPanelMSA.cpp
@@ -533,20 +533,11 @@ QWidget* GTUtilsOptionPanelMsa::getWidget(HI::GUITestOpStatus& os, const QString
     GT_CHECK_RESULT(y1 != y2, "coordinates are unexpectidly equal", nullptr);
 
     if (number == 1) {
-        if (y1 < y2) {
-            return w1;
-        } else {
-            return w2;
-        }
+        return y1 < y2 ? w1 : w2;
     } else if (number == 2) {
-        if (y1 < y2) {
-            return w2;
-        } else {
-            return w1;
-        }
-    } else {
-        GT_CHECK_RESULT(false, "number should be 1 or 2", nullptr);
+        return y1 < y2 ? w2 : w1;
     }
+    GT_FAIL("Number should be 1 or 2", nullptr);
 }
 #undef GT_METHOD_NAME
 

--- a/src/plugins/GUITestBase/src/GTUtilsProjectTreeView.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsProjectTreeView.cpp
@@ -707,10 +707,10 @@ void GTUtilsProjectTreeView::markSequenceAsCircular(HI::GUITestOpStatus& os, con
 QMap<QString, QStringList> GTUtilsProjectTreeView::getDocuments(GUITestOpStatus& os) {
     ensureFilteringIsDisabled(os);
     GTGlobals::FindOptions options(false, Qt::MatchContains, 1);
-    const QModelIndexList documentsItems = findIndeciesInProjectViewNoWait(os, "", QModelIndex(), 0, options);
+    QModelIndexList documentsItems = findIndeciesInProjectViewNoWait(os, "", QModelIndex(), 0, options);
 
     QMap<QString, QStringList> documents;
-    foreach (const QModelIndex& documentItem, documentsItems) {
+    for (const QModelIndex& documentItem : qAsConst(documentsItems)) {
         const QModelIndexList objectsItems = findIndeciesInProjectViewNoWait(os, "", documentItem, 0, options);
         QStringList objects;
         foreach (const QModelIndex& objectItem, objectsItems) {

--- a/src/plugins/GUITestBase/src/GTUtilsSequenceView.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsSequenceView.cpp
@@ -507,7 +507,8 @@ void GTUtilsSequenceView::clickAnnotationPan(HI::GUITestOpStatus& os, const QStr
 
     QList<Annotation*> anns;
     foreach (const AnnotationTableObject* ao, context->getAnnotationObjects(true)) {
-        foreach (Annotation* a, ao->getAnnotations()) {
+        const QList<Annotation*>& annotations = ao->getAnnotations();
+        for (Annotation* a : qAsConst(annotations)) {
             const int sp = a->getLocation().data()->regions.first().startPos;
             const QString annName = a->getName();
             if (sp == startPos - 1 && annName == name) {

--- a/src/plugins/GUITestBase/src/GTUtilsWorkflowDesigner.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsWorkflowDesigner.cpp
@@ -589,7 +589,8 @@ WorkflowProcessItem* GTUtilsWorkflowDesigner::getWorker(HI::GUITestOpStatus& os,
 #define GT_METHOD_NAME "getWorkerText"
 QString GTUtilsWorkflowDesigner::getWorkerText(HI::GUITestOpStatus& os, const QString& itemName, const GTGlobals::FindOptions& options) {
     WorkflowProcessItem* worker = getWorker(os, itemName, options);
-    foreach (QGraphicsItem* child, worker->childItems()) {
+    QList<QGraphicsItem*> workerChildren = worker->childItems();
+    for (QGraphicsItem* child : qAsConst(workerChildren)) {
         foreach (QGraphicsItem* subchild, child->childItems()) {
             QGraphicsObject* graphObject = subchild->toGraphicsObject();
             QGraphicsTextItem* textItem = qobject_cast<QGraphicsTextItem*>(graphObject);
@@ -629,12 +630,12 @@ bool GTUtilsWorkflowDesigner::isWorkerExtended(HI::GUITestOpStatus& os, const QS
 #define GT_METHOD_NAME "getPortById"
 WorkflowPortItem* GTUtilsWorkflowDesigner::getPortById(HI::GUITestOpStatus& os, WorkflowProcessItem* worker, QString id) {
     QList<WorkflowPortItem*> list = getPorts(os, worker);
-    foreach (WorkflowPortItem* p, list) {
+    for (WorkflowPortItem* p : qAsConst(list)) {
         if (p && p->getPort()->getId() == id) {
             return p;
         }
     }
-    GT_CHECK_RESULT(false, "port with id " + id + "not found", nullptr);
+    GT_FAIL("Port with id " + id + "not found", nullptr);
 }
 #undef GT_METHOD_NAME
 
@@ -836,20 +837,18 @@ WorkflowBusItem* GTUtilsWorkflowDesigner::getConnectionArrow(HI::GUITestOpStatus
     GT_CHECK_RESULT(sceneView, "sceneView not found", nullptr)
     QList<WorkflowPortItem*> fromList = from->getPortItems();
     QList<WorkflowPortItem*> toList = to->getPortItems();
-
     QList<WorkflowBusItem*> arrows = getAllConnectionArrows(os);
 
-    foreach (WorkflowPortItem* fromPort, fromList) {
-        foreach (WorkflowPortItem* toPort, toList) {
-            foreach (WorkflowBusItem* arrow, arrows) {
+    for (WorkflowPortItem* fromPort : qAsConst(fromList)) {
+        for (WorkflowPortItem* toPort : qAsConst(toList)) {
+            for (WorkflowBusItem* arrow : qAsConst(arrows)) {
                 if (arrow->getInPort() == toPort && arrow->getOutPort() == fromPort) {
                     return arrow;
                 }
             }
         }
     }
-
-    GT_CHECK_RESULT(false, "no suitable ports to connect", nullptr);
+    GT_FAIL("No suitable ports to connect", nullptr);
 }
 #undef GT_METHOD_NAME
 

--- a/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/AppSettingsDialogFiller.cpp
+++ b/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/AppSettingsDialogFiller.cpp
@@ -180,7 +180,7 @@ bool AppSettingsDialogFiller::isExternalToolValid(HI::GUITestOpStatus& os, const
 
     auto treeWidget = GTWidget::findTreeWidget(os, "twIntegratedTools", dialog);
     QList<QTreeWidgetItem*> listOfItems = treeWidget->findItems("", Qt::MatchContains | Qt::MatchRecursive);
-    foreach (QTreeWidgetItem* item, listOfItems) {
+    for (QTreeWidgetItem* item : qAsConst(listOfItems)) {
         if (item->text(0) == toolName) {
             GTTreeWidget::click(os, item);
             GTMouseDriver::doubleClick();
@@ -188,7 +188,7 @@ bool AppSettingsDialogFiller::isExternalToolValid(HI::GUITestOpStatus& os, const
             return descriptionTextBrowser->toPlainText().contains("Version:");
         }
     }
-    GT_CHECK_RESULT(false, "external tool " + toolName + " not found in tree view", false);
+    GT_FAIL("external tool " + toolName + " not found in tree view", false);
 }
 #undef GT_METHOD_NAME
 

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_6001_7000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_6001_7000.cpp
@@ -1836,7 +1836,7 @@ GUI_TEST_CLASS_DEFINITION(test_6397) {
     }
 
     QSpinBox* qsb = nullptr;
-    foreach (QWidget* w, list) {
+    for (QWidget* w : qAsConst(list)) {
         foreach (QObject* o, w->findChildren<QObject*>()) {
             qsb = qobject_cast<QSpinBox*>(o);
             if (qsb != nullptr) {

--- a/src/plugins/annotator/src/AnnotatorPlugin.cpp
+++ b/src/plugins/annotator/src/AnnotatorPlugin.cpp
@@ -108,7 +108,8 @@ void AnnotatorViewContext::sl_showCollocationDialog() {
     QSet<QString> allNames;
 
     foreach (AnnotationTableObject* ao, av->getAnnotationObjects()) {
-        foreach (Annotation* annotation, ao->getAnnotations()) {
+        QList<Annotation*> annotations = ao->getAnnotations();
+        for (Annotation* annotation : qAsConst(annotations)) {
             allNames.insert(annotation->getName());
         }
     }

--- a/src/plugins/annotator/src/CollocationsDialogController.cpp
+++ b/src/plugins/annotator/src/CollocationsDialogController.cpp
@@ -319,7 +319,7 @@ CollocationSearchTask::CollocationSearchTask(const QList<AnnotationTableObject*>
     foreach (const QString& name, names) {
         getItem(name);
     }
-    foreach (AnnotationTableObject* ao, table) {
+    for (AnnotationTableObject* ao : qAsConst(table)) {
         foreach (Annotation* a, ao->getAnnotations()) {
             const QString& name = a->getName();
             if ((a->getStrand().isDirect() && cfg.strand == StrandOption_ComplementOnly) ||
@@ -329,7 +329,8 @@ CollocationSearchTask::CollocationSearchTask(const QList<AnnotationTableObject*>
             }
             if (names.contains(name)) {
                 CollocationsAlgorithmItem& item = getItem(name);
-                foreach (const U2Region& r, a->getRegions()) {
+                QVector<U2Region> regions = a->getRegions();
+                for (const U2Region& r : qAsConst(regions)) {
                     if (cfg.searchRegion.intersects(r)) {
                         item.regions.append(r);
                     }
@@ -346,7 +347,7 @@ CollocationSearchTask::CollocationSearchTask(const QList<SharedAnnotationData>& 
     foreach (const QString& name, names) {
         getItem(name);
     }
-    foreach (const SharedAnnotationData& a, table) {
+    for (const SharedAnnotationData& a : qAsConst(table)) {
         const QString& name = a->name;
         if ((a->getStrand().isDirect() && cfg.strand == StrandOption_ComplementOnly) ||
             (a->getStrand().isComplementary() && cfg.strand == StrandOption_DirectOnly)) {
@@ -433,7 +434,7 @@ U2Region CollocationSearchTask::cutResult(const U2Region& res) const {
     qint64 right = res.startPos;
 
     foreach (const CollocationsAlgorithmItem& item, items) {
-        foreach (const U2Region& r, item.regions) {
+        for (const U2Region& r : qAsConst(item.regions)) {
             if (r.startPos == res.startPos) {
                 if (r.endPos() < left) {
                     left = r.endPos();

--- a/src/plugins/annotator/src/CollocationsSearchAlgorithm.cpp
+++ b/src/plugins/annotator/src/CollocationsSearchAlgorithm.cpp
@@ -34,7 +34,7 @@ void CollocationsAlgorithm::findN(const QList<CollocationsAlgorithmItem>& items,
 
     qint64 i = searchRegion.endPos();
     foreach (const CollocationsAlgorithmItem& item, items) {
-        foreach (const U2Region& r, item.regions) {
+        for (const U2Region& r : qAsConst(item.regions)) {
             SAFE_POINT(searchRegion.contains(r), "Region is not in the search region", );
             i = qMin(i, r.startPos);
         }
@@ -49,7 +49,7 @@ void CollocationsAlgorithm::findN(const QList<CollocationsAlgorithmItem>& items,
         U2Region currentRegion(i, qMin(i + distance, searchRegion.endPos()) - i);
         bool onResult = true;
         qint64 nextI = currentRegion.endPos();
-        foreach (const CollocationsAlgorithmItem& item, items) {
+        for (const CollocationsAlgorithmItem& item : qAsConst(items)) {
             bool foundItem = false;
             qint64 nextItemStart = currentRegion.endPos();
             foreach (const U2Region& r, item.regions) {
@@ -105,7 +105,7 @@ void averagingRes(U2Region& res, const U2Region& min, const U2Region& max, qint6
 
 void CollocationsAlgorithm::findP(const QList<CollocationsAlgorithmItem>& items, TaskStateInfo& si, CollocationsAlgorithmListener* l, const U2Region& searchRegion, qint64 distance) {
     qint64 i = searchRegion.endPos();
-    foreach (const CollocationsAlgorithmItem& item, items) {
+    for (const CollocationsAlgorithmItem& item : qAsConst(items)) {
         foreach (const U2Region& r, item.regions) {
             SAFE_POINT(searchRegion.contains(r), "Region is not in the search region", );
             if (i > r.endPos() - 1) {
@@ -126,7 +126,7 @@ void CollocationsAlgorithm::findP(const QList<CollocationsAlgorithmItem>& items,
         max.startPos = 0;
         bool onResult = true;
         qint64 nextI = currentRegion.endPos();
-        foreach (const CollocationsAlgorithmItem& item, items) {
+        for (const CollocationsAlgorithmItem& item : qAsConst(items)) {
             bool foundItem = false;
             qint64 nextItemEnd = searchRegion.endPos();
             foreach (const U2Region& r, item.regions) {

--- a/src/plugins/api_tests/src/UnitTestSuite.cpp
+++ b/src/plugins/api_tests/src/UnitTestSuite.cpp
@@ -122,7 +122,7 @@ void UnitTestSuite::runTest(const QString& testName) {
 void UnitTestSuite::runAllTests() {
     foreach (const QString& suite, tests.keys()) {
         QStringList testList = tests.value(suite);
-        foreach (const QString& testName, testList) {
+        for (const QString& testName : qAsConst(testList)) {
             runTest(suite + "_" + testName);
         }
     }

--- a/src/plugins/api_tests/src/core/format/sqlite_msa_dbi/MsaDbiSQLiteSpecificUnitTests.cpp
+++ b/src/plugins/api_tests/src/core/format/sqlite_msa_dbi/MsaDbiSQLiteSpecificUnitTests.cpp
@@ -887,8 +887,8 @@ IMPLEMENT_TEST(MsaDbiSQLiteSpecificUnitTests, updateRowContent_undo) {
 
     QList<QList<U2SingleModStep>> modSteps = sqliteDbi->getSQLiteModDbi()->getModSteps(msaId, oldMsaVersion, os);
     QList<U2SingleModStep> msaSingleModSteps;
-    foreach (QList<U2SingleModStep> multiStep, modSteps) {
-        foreach (U2SingleModStep singleStep, multiStep) {
+    for (const QList<U2SingleModStep>& multiStep : qAsConst(modSteps)) {
+        for (const U2SingleModStep& singleStep : qAsConst(multiStep)) {
             msaSingleModSteps.append(singleStep);
         }
     }
@@ -1007,8 +1007,8 @@ IMPLEMENT_TEST(MsaDbiSQLiteSpecificUnitTests, updateRowContent_redo) {
 
     QList<QList<U2SingleModStep>> modSteps = sqliteDbi->getSQLiteModDbi()->getModSteps(msaId, oldMsaVersion, os);
     QList<U2SingleModStep> msaSingleModSteps;
-    foreach (QList<U2SingleModStep> multiStep, modSteps) {
-        foreach (U2SingleModStep singleStep, multiStep) {
+    for (const QList<U2SingleModStep>& multiStep : qAsConst(modSteps)) {
+        for (const U2SingleModStep& singleStep : qAsConst(multiStep)) {
             msaSingleModSteps.append(singleStep);
         }
     }
@@ -1174,9 +1174,9 @@ IMPLEMENT_TEST(MsaDbiSQLiteSpecificUnitTests, setNewRowsOrder_noModTrack) {
     QList<U2MsaRow> newRows = sqliteDbi->getMsaDbi()->getRows(msaId, os);
     CHECK_NO_ERROR(os);
     CHECK_EQUAL(oldRows.length(), newRows.length(), "rows length");
-    foreach (U2MsaRow newRow, newRows) {
+    for (const U2MsaRow& newRow : qAsConst(newRows)) {
         bool ok = false;
-        foreach (U2MsaRow oldRow, oldRows) {
+        for (const U2MsaRow& oldRow : qAsConst(oldRows)) {
             if (newRow.gaps == oldRow.gaps && newRow.gend == oldRow.gend &&
                 newRow.gstart == oldRow.gstart && newRow.length == oldRow.length &&
                 newRow.rowId == oldRow.rowId && newRow.sequenceId == oldRow.sequenceId) {
@@ -1266,9 +1266,9 @@ IMPLEMENT_TEST(MsaDbiSQLiteSpecificUnitTests, setNewRowsOrder_undo) {
     QList<U2MsaRow> newRows = sqliteDbi->getMsaDbi()->getRows(msaId, os);
     CHECK_NO_ERROR(os);
     CHECK_EQUAL(oldRows.length(), newRows.length(), "rows length");
-    foreach (U2MsaRow newRow, newRows) {
+    for (const U2MsaRow& newRow : qAsConst(newRows)) {
         bool ok = false;
-        foreach (U2MsaRow oldRow, oldRows) {
+        for (const U2MsaRow& oldRow : qAsConst(oldRows)) {
             if (newRow.gaps == oldRow.gaps && newRow.gend == oldRow.gend &&
                 newRow.gstart == oldRow.gstart && newRow.length == oldRow.length &&
                 newRow.rowId == oldRow.rowId && newRow.sequenceId == oldRow.sequenceId) {
@@ -1320,9 +1320,9 @@ IMPLEMENT_TEST(MsaDbiSQLiteSpecificUnitTests, setNewRowsOrder_undo) {
     newRows = sqliteDbi->getMsaDbi()->getRows(msaId, os);
     CHECK_NO_ERROR(os);
     CHECK_EQUAL(oldRows.length(), newRows.length(), "rows length");
-    foreach (U2MsaRow newRow, newRows) {
+    for (const U2MsaRow& newRow : qAsConst(newRows)) {
         bool ok = false;
-        foreach (U2MsaRow oldRow, oldRows) {
+        for (const U2MsaRow& oldRow : qAsConst(oldRows)) {
             if (newRow.gaps == oldRow.gaps && newRow.gend == oldRow.gend &&
                 newRow.gstart == oldRow.gstart && newRow.length == oldRow.length &&
                 newRow.rowId == oldRow.rowId && newRow.sequenceId == oldRow.sequenceId) {
@@ -1411,9 +1411,9 @@ IMPLEMENT_TEST(MsaDbiSQLiteSpecificUnitTests, setNewRowsOrder_redo) {
     QList<U2MsaRow> newRows = sqliteDbi->getMsaDbi()->getRows(msaId, os);
     CHECK_NO_ERROR(os);
     CHECK_EQUAL(oldRows.length(), newRows.length(), "rows length");
-    foreach (U2MsaRow newRow, newRows) {
+    for (const U2MsaRow& newRow : qAsConst(newRows)) {
         bool ok = false;
-        foreach (U2MsaRow oldRow, oldRows) {
+        for (const U2MsaRow& oldRow : qAsConst(oldRows)) {
             if (newRow.gaps == oldRow.gaps && newRow.gend == oldRow.gend &&
                 newRow.gstart == oldRow.gstart && newRow.length == oldRow.length &&
                 newRow.rowId == oldRow.rowId && newRow.sequenceId == oldRow.sequenceId) {
@@ -1464,9 +1464,9 @@ IMPLEMENT_TEST(MsaDbiSQLiteSpecificUnitTests, setNewRowsOrder_redo) {
     newRows = sqliteDbi->getMsaDbi()->getRows(msaId, os);
     CHECK_NO_ERROR(os);
     CHECK_EQUAL(oldRows.length(), newRows.length(), "rows length");
-    foreach (U2MsaRow newRow, newRows) {
+    for (const U2MsaRow& newRow : qAsConst(newRows)) {
         bool ok = false;
-        foreach (U2MsaRow oldRow, oldRows) {
+        for (const U2MsaRow& oldRow : qAsConst(oldRows)) {
             if (newRow.gaps == oldRow.gaps && newRow.gend == oldRow.gend &&
                 newRow.gstart == oldRow.gstart && newRow.length == oldRow.length &&
                 newRow.rowId == oldRow.rowId && newRow.sequenceId == oldRow.sequenceId) {
@@ -1517,9 +1517,9 @@ IMPLEMENT_TEST(MsaDbiSQLiteSpecificUnitTests, setNewRowsOrder_redo) {
     newRows = sqliteDbi->getMsaDbi()->getRows(msaId, os);
     CHECK_NO_ERROR(os);
     CHECK_EQUAL(oldRows.length(), newRows.length(), "rows length");
-    foreach (U2MsaRow newRow, newRows) {
+    for (const U2MsaRow& newRow : qAsConst(newRows)) {
         bool ok = false;
-        foreach (U2MsaRow oldRow, oldRows) {
+        for (const U2MsaRow& oldRow : qAsConst(oldRows)) {
             if (newRow.gaps == oldRow.gaps && newRow.gend == oldRow.gend &&
                 newRow.gstart == oldRow.gstart && newRow.length == oldRow.length &&
                 newRow.rowId == oldRow.rowId && newRow.sequenceId == oldRow.sequenceId) {
@@ -1645,9 +1645,9 @@ IMPLEMENT_TEST(MsaDbiSQLiteSpecificUnitTests, setNewRowsOrder_severalSteps) {
     QList<U2MsaRow> newRows = sqliteDbi->getMsaDbi()->getRows(msaId, os);
     CHECK_NO_ERROR(os);
     CHECK_EQUAL(oldRows.length(), newRows.length(), "rows length");
-    foreach (U2MsaRow newRow, newRows) {
+    for (const U2MsaRow& newRow : qAsConst(newRows)) {
         bool ok = false;
-        foreach (U2MsaRow oldRow, oldRows) {
+        for (const U2MsaRow& oldRow : qAsConst(oldRows)) {
             if (newRow.gaps == oldRow.gaps && newRow.gend == oldRow.gend &&
                 newRow.gstart == oldRow.gstart && newRow.length == oldRow.length &&
                 newRow.rowId == oldRow.rowId && newRow.sequenceId == oldRow.sequenceId) {

--- a/src/plugins/api_tests/src/core/gobjects/FeaturesTableObjectUnitTest.cpp
+++ b/src/plugins/api_tests/src/core/gobjects/FeaturesTableObjectUnitTest.cpp
@@ -499,7 +499,7 @@ IMPLEMENT_TEST(FeatureTableObjectUnitTest, clone) {
         const QList<Annotation*> clonedAnns = clonedSubgroup->getAnnotations();
 
         bool groupMatched = false;
-        foreach (AnnotationGroup* sourceSubgroup, sourceSubgroups) {
+        for (AnnotationGroup* sourceSubgroup : qAsConst(sourceSubgroups)) {
             if (sourceSubgroup->getName() == clonedSubgroup->getName()) {
                 groupMatched = true;
                 const QList<Annotation*> sourceAnns = sourceSubgroup->getAnnotations();

--- a/src/plugins/biostruct3d_view/src/BallAndStickGLRenderer.cpp
+++ b/src/plugins/biostruct3d_view/src/BallAndStickGLRenderer.cpp
@@ -19,8 +19,6 @@
  * MA 02110-1301, USA.
  */
 
-#include <time.h>
-
 #include <U2Core/BioStruct3D.h>
 #include <U2Core/Log.h>
 
@@ -165,15 +163,12 @@ void BallAndStickGLRenderer::createDisplayList() {
 
     glNewList(dl, GL_COMPILE);
 
-    foreach (const SharedMolecule mol, bioStruct.moleculeMap) {
+    for (const SharedMolecule& mol : qAsConst(bioStruct.moleculeMap)) {
         foreach (int index, shownModelsIds) {
             const Molecule3DModel& model = mol->models.value(index);
-
             colors.clear();
-
-            foreach (const SharedAtom atom, model.atoms) {
+            for (const SharedAtom& atom : qAsConst(model.atoms)) {
                 Color4f atomColor = colorScheme->getAtomColor(atom);
-
                 if (colors.contains(atomColor)) {
                     continue;  // Atom and bonds with this color has been already viewed
                 } else {

--- a/src/plugins/biostruct3d_view/src/BioStruct3DColorScheme.cpp
+++ b/src/plugins/biostruct3d_view/src/BioStruct3DColorScheme.cpp
@@ -162,7 +162,7 @@ const QMap<int, QColor> ChainsColorScheme::getChainColors(const BioStruct3DObjec
 
     if (nullptr != biostructObj->getDocument()) {
         QList<GObject*> aObjs = GObjectUtils::selectRelationsFromParentDoc(biostructObj, GObjectTypes::ANNOTATION_TABLE, ObjectRole_AnnotationTable);
-        foreach (GObject* obj, aObjs) {
+        for (GObject* obj : qAsConst(aObjs)) {
             AnnotationTableObject* ao = qobject_cast<AnnotationTableObject*>(obj);
             SAFE_POINT(nullptr != ao, "Invalid annotation table!", colorMap);
 
@@ -211,9 +211,9 @@ const QMap<QString, QColor> SecStructColorScheme::getSecStructAnnotationColors(c
     Document* doc = biostruct->getDocument();
     if (doc) {
         QList<GObject*> targetAnnotations = GObjectUtils::selectRelationsFromParentDoc(biostruct, GObjectTypes::ANNOTATION_TABLE, ObjectRole_AnnotationTable);
-        foreach (GObject* obj, targetAnnotations) {
+        for (GObject* obj : qAsConst(targetAnnotations)) {
             AnnotationTableObject* ao = qobject_cast<AnnotationTableObject*>(obj);
-            SAFE_POINT(nullptr != ao, "Invalid annotation table!", colors);
+            SAFE_POINT(ao != nullptr, "Invalid annotation table!", colors);
 
             foreach (Annotation* a, ao->getAnnotationsByName(BioStruct3D::SecStructAnnotationTag)) {
                 QString ssName = a->getQualifiers().first().value;

--- a/src/plugins/biostruct3d_view/src/TubeGLRenderer.cpp
+++ b/src/plugins/biostruct3d_view/src/TubeGLRenderer.cpp
@@ -38,8 +38,8 @@ void TubeGLRenderer::drawTubes(const BioStruct3DColorScheme* colorScheme) {
     static float ribbonThickness = 0.3f;
     SharedAtom bufAtom;
 
-    foreach (Tube tube, tubeMap) {
-        foreach (int index, shownModelsIds) {
+    for (const Tube& tube : qAsConst(tubeMap)) {
+        for (int index : qAsConst(shownModelsIds)) {
             const AtomsVector& tubeAtoms = tube.modelsMap.value(index);
             foreach (const SharedAtom atom, tubeAtoms) {
                 Color4f atomColor = colorScheme->getAtomColor(atom);
@@ -86,9 +86,9 @@ bool TubeGLRenderer::isAvailableFor(const BioStruct3D& bioStruct) {
     const char* alphaCarbonTag = "CA";
     const char* phosporTag = "P";
 
-    foreach (const SharedMolecule mol, bioStruct.moleculeMap) {
+    for (const SharedMolecule& mol : qAsConst(bioStruct.moleculeMap)) {
         foreach (const Molecule3DModel& model, mol->models.values()) {
-            foreach (const SharedAtom atom, model.atoms) {
+            for (const SharedAtom& atom : qAsConst(model.atoms)) {
                 if (atom->name == alphaCarbonTag || atom->name == phosporTag) {
                     available = true;
                 }
@@ -107,10 +107,10 @@ void TubeGLRenderer::create() {
     const char* alphaCarbonTag = "CA";
     const char* phosporTag = "P";
 
-    foreach (const SharedMolecule mol, bioStruct.moleculeMap) {
+    for (const SharedMolecule& mol : qAsConst(bioStruct.moleculeMap)) {
         foreach (int modelId, mol->models.keys()) {
             const Molecule3DModel& model = mol->models.value(modelId);
-            foreach (const SharedAtom atom, model.atoms) {
+            for (const SharedAtom& atom : qAsConst(model.atoms)) {
                 if (atom->name == alphaCarbonTag || atom->name == phosporTag) {
                     tubeMap[atom->chainIndex].modelsMap[modelId].append(atom);
                 }

--- a/src/plugins/biostruct3d_view/src/VanDerWaalsGLRenderer.cpp
+++ b/src/plugins/biostruct3d_view/src/VanDerWaalsGLRenderer.cpp
@@ -49,10 +49,10 @@ void VanDerWaalsGLRenderer::drawAtoms(const BioStruct3DColorScheme* colorScheme)
 
     // Draw atoms as spheres
 
-    foreach (const SharedMolecule mol, bioStruct.moleculeMap) {
+    for (const SharedMolecule& mol : qAsConst(bioStruct.moleculeMap)) {
         foreach (int index, shownModelsIds) {
             const Molecule3DModel& model = mol->models.value(index);
-            foreach (const SharedAtom atom, model.atoms) {
+            for (const SharedAtom& atom : qAsConst(model.atoms)) {
                 float radius = AtomConstants::getAtomCovalentRadius(atom->atomicNumber);
                 Vector3D pos = atom->coord3d;
                 Color4f atomColor = colorScheme->getAtomColor(atom);

--- a/src/plugins/biostruct3d_view/src/WormsGLRenderer.cpp
+++ b/src/plugins/biostruct3d_view/src/WormsGLRenderer.cpp
@@ -43,7 +43,7 @@ bool WormsGLRenderer::isAvailableFor(const BioStruct3D& bioStruct) {
     createBioPolymerMap(bioStruct.moleculeMap, bioPolymerMap);
 
     // Find objects to draw
-    foreach (const SharedSecondaryStructure ss, bioStruct.secondaryStructures) {
+    for (const SharedSecondaryStructure& ss : qAsConst(bioStruct.secondaryStructures)) {
         int startId = ss->startSequenceNumber;
         int endId = ss->endSequenceNumber;
         int chainId = ss->chainIndex;
@@ -128,7 +128,7 @@ void WormsGLRenderer::drawWorms() {
 
             // Draw 3d objects
             if (shownModelsIds.count() == 1) {
-                foreach (Object3D* obj, model.objects) {
+                for (Object3D* obj : qAsConst(model.objects)) {
                     obj->draw(settings->detailLevel);
                 }
             }
@@ -224,7 +224,7 @@ void WormsGLRenderer::createWorms() {
             b = (r2 - r1) / 100.f;
             wormModel.closingAtom = a + b * (-10.f);
             // Add worm-building atom coords
-            foreach (const Monomer& monomer, monomers) {
+            for (const Monomer& monomer : qAsConst(monomers)) {
                 const SharedAtom& atom = monomer.alphaCarbon;
                 wormModel.atoms.append(atom);
             }

--- a/src/plugins/circular_view/src/CircularView.cpp
+++ b/src/plugins/circular_view/src/CircularView.cpp
@@ -495,7 +495,8 @@ void CircularViewRenderArea::drawAnnotationsSelection(QPainter& p) {
                 CircularAnnotationItem* item = circItems[annotation];
                 item->setSelected(true);
                 item->paint(&p, nullptr, this);
-                foreach (const CircularAnnotationRegionItem* r, item->getRegions()) {
+                QList<CircularAnnotationRegionItem*> regions = item->getRegions();
+                for (const CircularAnnotationRegionItem* r : qAsConst(regions)) {
                     SAFE_POINT(r != nullptr, "NULL annotation region item is CV!", );
                     CircularAnnotationLabel* lbl = r->getLabel();
                     SAFE_POINT(lbl != nullptr, "NULL annotation label item is CV!", );
@@ -828,7 +829,7 @@ void CircularViewRenderArea::buildItems(QFont labelFont) {
     QSet<AnnotationTableObject*> anns = ctx->getAnnotationObjects(true);
     QSet<AnnotationTableObject*> autoAnns = ctx->getAutoAnnotationObjects();
     QSet<Annotation*> restrictionSites;
-    foreach (AnnotationTableObject* ao, anns) {
+    for (AnnotationTableObject* ao : qAsConst(anns)) {
         bool isAutoAnnotation = autoAnns.contains(ao);
         foreach (Annotation* a, ao->getAnnotations()) {
             if (a->getType() == U2FeatureTypes::RestrictionSite) {
@@ -855,7 +856,7 @@ int CircularViewRenderArea::findOrbit(const QVector<U2Region>& location, Annotat
     for (; yLevel < regionY.count(); yLevel++) {
         bool intersects = false;
         foreach (const U2Region& r, regionY[yLevel]) {
-            foreach (const U2Region& locRegion, location) {
+            for (const U2Region& locRegion : qAsConst(location)) {
                 if (r.intersects(locRegion)) {
                     intersects = true;
                 }

--- a/src/plugins/circular_view/src/RestrictionMapWidget.cpp
+++ b/src/plugins/circular_view/src/RestrictionMapWidget.cpp
@@ -194,7 +194,7 @@ void RestrctionMapWidget::initTreeWidget() {
     QSet<AnnotationTableObject*> aObjs = ctx->getAnnotationObjects(true);
     foreach (AnnotationTableObject* obj, aObjs) {
         QList<Annotation*> anns = obj->getAnnotations();
-        foreach (Annotation* a, anns) {
+        for (Annotation* a : qAsConst(anns)) {
             QString aName = a->getName();
             EnzymeFolderItem* folderItem = findEnzymeFolderByName(aName);
             if (folderItem) {

--- a/src/plugins/circular_view/src/ShiftSequenceStartTask.cpp
+++ b/src/plugins/circular_view/src/ShiftSequenceStartTask.cpp
@@ -76,9 +76,9 @@ Task::ReportResult ShiftSequenceStartTask::report() {
         documentsToUpdate.append(documentWithSequence);
     }
 
-    foreach (Document* document, documentsToUpdate) {
+    for (Document* document : qAsConst(documentsToUpdate)) {
         QList<GObject*> annotationTablesList = document->findGObjectByType(GObjectTypes::ANNOTATION_TABLE);
-        foreach (GObject* object, annotationTablesList) {
+        for (GObject* object : qAsConst(annotationTablesList)) {
             AnnotationTableObject* annotationTableObject = qobject_cast<AnnotationTableObject*>(object);
             if (annotationTableObject->hasObjectRelation(sequenceObject, ObjectRole_Sequence)) {
                 foreach (Annotation* annotation, annotationTableObject->getAnnotations()) {

--- a/src/plugins/dbi_bam/src/BaiWriter.cpp
+++ b/src/plugins/dbi_bam/src/BaiWriter.cpp
@@ -38,17 +38,19 @@ void BaiWriter::writeIndex(const Index& index) {
         writeInt32(referenceIndex.getBins().size());
         for (int i = 0; i < referenceIndex.getBins().size(); i++) {
             const Index::ReferenceIndex::Bin& bin = referenceIndex.getBins()[i];
-            if (!bin.getChunks().isEmpty()) {
+            QList<Index::ReferenceIndex::Chunk> chunks = bin.getChunks();
+            if (!chunks.isEmpty()) {
                 writeUint32(bin.getBin());
-                writeInt32(bin.getChunks().size());
-                foreach (const Index::ReferenceIndex::Chunk& chunk, bin.getChunks()) {
+                writeInt32(chunks.size());
+                for (const Index::ReferenceIndex::Chunk& chunk : qAsConst(chunks)) {
                     writeUint64(chunk.getStart().getPackedOffset());
                     writeUint64(chunk.getEnd().getPackedOffset());
                 }
             }
         }
-        writeInt32(referenceIndex.getIntervals().size());
-        foreach (const VirtualOffset& offset, referenceIndex.getIntervals()) {
+        QList<VirtualOffset> intervals = referenceIndex.getIntervals();
+        writeInt32(intervals.size());
+        for (const VirtualOffset& offset : qAsConst(intervals)) {
             writeUint64(offset.getPackedOffset());
         }
     }

--- a/src/plugins/dbi_bam/src/ConvertToSQLiteDialog.cpp
+++ b/src/plugins/dbi_bam/src/ConvertToSQLiteDialog.cpp
@@ -217,8 +217,8 @@ void ConvertToSQLiteDialog::sl_bamInfoButtonClicked() {
             rgList << QString(rg.getSequencingCenter()) << QString(rg.getDescription()) << QString(rg.getDate().toString()) << QString(rg.getLibrary())
                    << QString(rg.getPlatform()) << QString(rg.getPredictedInsertSize()) << QString(rg.getPlatform()) << QString(rg.getPlatformUnit()) << QString(rg.getSample());
             int j = 0;
-            foreach (const QString& s, rgList) {
-                QTableWidgetItem* item = new QTableWidgetItem(s);
+            for (const QString& s : qAsConst(rgList)) {
+                auto item = new QTableWidgetItem(s);
                 item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
                 table->setItem(i, j, item);
                 j++;
@@ -240,8 +240,8 @@ void ConvertToSQLiteDialog::sl_bamInfoButtonClicked() {
             QStringList pgList;
             pgList << QString(pg.getName()) << QString(pg.getVersion()) << QString(pg.getCommandLine()) << QString(pg.getPreviousId());
             int j = 0;
-            foreach (const QString& s, pgList) {
-                QTableWidgetItem* item = new QTableWidgetItem(s);
+            for (const QString& s : qAsConst(pgList)) {
+                auto item = new QTableWidgetItem(s);
                 item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
                 table->setItem(i, j, item);
                 j++;

--- a/src/plugins/dbi_bam/src/ConvertToSQLiteTask.cpp
+++ b/src/plugins/dbi_bam/src/ConvertToSQLiteTask.cpp
@@ -382,7 +382,8 @@ public:
           hasReads(false) {
         {
             VirtualOffset minOffset = VirtualOffset(0xffffffffffffLL, 0xffff);
-            foreach (const Index::ReferenceIndex::Bin& bin, index.getReferenceIndices()[referenceId].getBins()) {
+            QList<Index::ReferenceIndex::Bin> bins = index.getReferenceIndices()[referenceId].getBins();
+            for (const Index::ReferenceIndex::Bin& bin : qAsConst(bins)) {
                 foreach (const Index::ReferenceIndex::Chunk& chunk, bin.getChunks()) {
                     if (minOffset > chunk.getStart()) {
                         minOffset = chunk.getStart();
@@ -653,7 +654,8 @@ qint64 ConvertToSQLiteTask::importUnmappedSortedReads(BamReader* bamReader, Read
         VirtualOffset maxOffset = VirtualOffset(0, 0);
 
         for (int refId = 0; refId < reader->getHeader().getReferences().size(); ++refId) {
-            foreach (const Index::ReferenceIndex::Bin& bin, index.getReferenceIndices()[refId].getBins()) {
+            QList<Index::ReferenceIndex::Bin> bins = index.getReferenceIndices()[refId].getBins();
+            for (const Index::ReferenceIndex::Bin& bin : qAsConst(bins)) {
                 foreach (const Index::ReferenceIndex::Chunk& chunk, bin.getChunks()) {
                     if (chunk.getStart() < chunk.getEnd() && maxOffset < chunk.getStart()) {
                         maxOffset = chunk.getStart();

--- a/src/plugins/dna_export/src/ExportProjectViewItems.cpp
+++ b/src/plugins/dna_export/src/ExportProjectViewItems.cpp
@@ -254,8 +254,8 @@ bool hasNucleicForAll(const QList<GObject*>& set) {
 QList<SharedAnnotationData> getAllRelatedAnnotations(const U2SequenceObject* so, const QList<GObject*>& annotationTables) {
     QList<GObject*> relatedAnnotationTables = GObjectUtils::findObjectsRelatedToObjectByRole(so, GObjectTypes::ANNOTATION_TABLE, ObjectRole_Sequence, annotationTables, UOF_LoadedOnly);
     QList<SharedAnnotationData> anns;
-    foreach (GObject* aObj, relatedAnnotationTables) {
-        AnnotationTableObject* annObj = qobject_cast<AnnotationTableObject*>(aObj);
+    for (GObject* aObj : qAsConst(relatedAnnotationTables)) {
+        auto annObj = qobject_cast<AnnotationTableObject*>(aObj);
         foreach (Annotation* ann, annObj->getAnnotations()) {
             anns.append(ann->getData());
         }

--- a/src/plugins/dna_export/src/ExportSelectedSeqRegionsTask.cpp
+++ b/src/plugins/dna_export/src/ExportSelectedSeqRegionsTask.cpp
@@ -96,7 +96,8 @@ QList<SharedAnnotationData> CreateExportItemsFromSeqRegionsTask::findAnnotations
             stateInfo.setError(tr("Invalid annotation table detected"));
             return result;
         }
-        foreach (Annotation* a, aobj->getAnnotationsByRegion(region)) {
+        QList<Annotation*> regionAnnotations = aobj->getAnnotationsByRegion(region);
+        for (Annotation* a : qAsConst(regionAnnotations)) {
             result.append(a->getData());
         }
     }

--- a/src/plugins/dna_export/src/ExportSequenceTask.cpp
+++ b/src/plugins/dna_export/src/ExportSequenceTask.cpp
@@ -604,7 +604,7 @@ void ExportAnnotationSequenceSubTask::run() {
             coreLog.info(tr("Exported sequence has been deleted unexpectedly"));
             continue;
         }
-        foreach (const SharedAnnotationData& ad, ei.annotations) {
+        for (const SharedAnnotationData& ad : qAsConst(ei.annotations)) {
             QVector<U2Region> resultRegions;
             const U2Sequence annSeqDbiObject = importAnnotatedSeq2Dbi(ad, ei, dbiRef, resultRegions, stateInfo);
             CHECK_OP(stateInfo, );

--- a/src/plugins/dna_export/src/ExportSequenceViewItems.cpp
+++ b/src/plugins/dna_export/src/ExportSequenceViewItems.cpp
@@ -601,7 +601,8 @@ void ADVExportContext::prepareMAFromSequences(MultipleSequenceAlignment& ma, boo
         }
         const DNAAlphabet* seqAl = seqCtx->getAlphabet();
         DNATranslation* aminoTT = ((translate || forceTranslation) && seqAl->isNucleic()) ? seqCtx->getAminoTT() : nullptr;
-        foreach (const U2Region& r, seqCtx->getSequenceSelection()->getSelectedRegions()) {
+        QVector<U2Region> regions = seqCtx->getSequenceSelection()->getSelectedRegions();
+        for (const U2Region& r : qAsConst(regions)) {
             maxLen = qMax(maxLen, r.length);
             CHECK_EXT(maxLen * ma->getRowCount() <= MAX_ALI_MODEL, os.setError(tr("Alignment is too large")), );
             QByteArray seq = seqCtx->getSequenceData(r, os);

--- a/src/plugins/dna_export/src/ImportAnnotationsFromCSVTask.cpp
+++ b/src/plugins/dna_export/src/ImportAnnotationsFromCSVTask.cpp
@@ -77,7 +77,8 @@ static void adjustRelations(AnnotationTableObject* ao) {
     foreach (U2SequenceObject* seqObj, seqView->getSequenceObjectsWithContexts()) {
         U2Region seqRegion(0, seqObj->getSequenceLength());
         bool outOfRange = false;
-        foreach (Annotation* ann, ao->getAnnotations()) {
+        QList<Annotation*> annotations = ao->getAnnotations();
+        for (Annotation* ann : qAsConst(annotations)) {
             const QVector<U2Region>& locations = ann->getRegions();
             if (!seqRegion.contains(locations.last())) {
                 outOfRange = true;
@@ -153,7 +154,8 @@ QMap<QString, QList<SharedAnnotationData>> ImportAnnotationsFromCSVTask::prepare
     SAFE_POINT(readTask != nullptr && readTask->isFinished(), "Invalid read annotations task!", result);
     QMap<QString, QList<SharedAnnotationData>> datas = readTask->getResult();
     foreach (const QString& groupName, datas.keys()) {
-        foreach (const SharedAnnotationData& d, datas[groupName]) {
+        QList<SharedAnnotationData> annotations = datas[groupName];
+        for (const SharedAnnotationData& d : qAsConst(annotations)) {
             result[groupName] << d;
         }
     }

--- a/src/plugins/dotplot/src/DotPlotFilterDialog.cpp
+++ b/src/plugins/dotplot/src/DotPlotFilterDialog.cpp
@@ -104,7 +104,7 @@ QSet<QString> DotPlotFilterDialog::getUniqueAnnotationNames(ADVSequenceObjectCon
     QSet<AnnotationTableObject*> annotationObjects = seq->getAnnotationObjects(true);
     foreach (AnnotationTableObject* atObj, annotationObjects) {
         QList<Annotation*> annotations = atObj->getAnnotations();
-        foreach (Annotation* a, annotations) {
+        for (Annotation* a : qAsConst(annotations)) {
             uniqueAnnotationNames.insert(a->getName());
         }
     }

--- a/src/plugins/dotplot/src/DotPlotTasks.cpp
+++ b/src/plugins/dotplot/src/DotPlotTasks.cpp
@@ -365,7 +365,7 @@ void DotPlotFilterTask::createSuperRegionsList(ADVSequenceObjectContext* seq, Fi
     }
 
     foreach (const QString& aName, cursequenceAnnotationNames) {
-        foreach (AnnotationTableObject* at, aTableSet) {
+        for (AnnotationTableObject* at : qAsConst(aTableSet)) {
             selectedAnnotations << at->getAnnotationsByName(aName);
         }
     }

--- a/src/plugins/dotplot/src/DotPlotWidget.cpp
+++ b/src/plugins/dotplot/src/DotPlotWidget.cpp
@@ -99,7 +99,7 @@ DotPlotWidget::DotPlotWidget(AnnotatedDNAView* dnaView)
     connect(timer, SIGNAL(timeout()), this, SLOT(sl_timer()));
 
     exitButton = new QToolButton(this);
-    connect(exitButton, &QToolButton::clicked, this, [this]{ sl_showDeleteDialog(true); });
+    connect(exitButton, &QToolButton::clicked, this, [this] { sl_showDeleteDialog(true); });
     exitButton->setToolTip("Close");
     QIcon exitIcon = QIcon(QString(":dotplot/images/exit.png"));
     exitButton->setIcon(exitIcon);
@@ -1210,7 +1210,8 @@ void DotPlotWidget::drawSelection(QPainter& p) const {
         drawRectCorrect(p, QRectF(xLeft + shiftX, yBottom + shiftY, xLen, yLen));
     } else {
         if (selectionX) {
-            foreach (const U2Region& rx, selectionX->getSelectedRegions()) {
+            QVector<U2Region> selectedXRegions = selectionX->getSelectedRegions();
+            for (const U2Region& rx : qAsConst(selectedXRegions)) {
                 xLeft = rx.startPos / (float)xSeqLen * w * zoom.x();
                 xLen = rx.length / (float)xSeqLen * w * zoom.x();
 
@@ -1428,7 +1429,8 @@ void DotPlotWidget::sequencesCoordsSelection(const QPointF& start, const QPointF
     SAFE_POINT(dnaView, "dnaView is NULL", );
     foreach (ADVSequenceWidget* w, dnaView->getSequenceWidgets()) {
         SAFE_POINT(w, "w is NULL", );
-        foreach (ADVSequenceObjectContext* s, w->getSequenceContexts()) {
+        QList<ADVSequenceObjectContext*> sequenceContexts = w->getSequenceContexts();
+        for (ADVSequenceObjectContext* s : qAsConst(sequenceContexts)) {
             SAFE_POINT(s, "s is NULL", );
 
             if (((int)(endX - startX) > 0) && (s == sequenceX)) {
@@ -1488,7 +1490,8 @@ void DotPlotWidget::selectNearestRepeat(const QPointF& p) {
         QPoint(nearestRepeat->x + nearestRepeat->len, nearestRepeat->y + nearestRepeat->len));
 
     foreach (ADVSequenceWidget* w, dnaView->getSequenceWidgets()) {
-        foreach (ADVSequenceObjectContext* s, w->getSequenceContexts()) {
+        QList<ADVSequenceObjectContext*> sequenceContexts = w->getSequenceContexts();
+        for (ADVSequenceObjectContext* s : qAsConst(sequenceContexts)) {
             if (s == sequenceX) {
                 w->centerPosition(nearestRepeat->x);
             }
@@ -1498,7 +1501,7 @@ void DotPlotWidget::selectNearestRepeat(const QPointF& p) {
 }
 
 float DotPlotWidget::calculateDistance(float x, float y, DotPlotResults r, bool isReverse) const {
-    //apply ratio to every coordinate
+    // apply ratio to every coordinate
     SAFE_POINT(r.x >= 0 && r.y >= 0 && r.len >= 0, "Wrong DotPlotResults, data member(s) have negative value!", 0.0);
     if (isReverse) {
         r = DotPlotResults(r.x, r.y + r.len, r.len);
@@ -1800,7 +1803,8 @@ void DotPlotWidget::sequenceClearSelection() {
     SAFE_POINT(dnaView, "dnaView is NULL", );
     foreach (ADVSequenceWidget* w, dnaView->getSequenceWidgets()) {
         SAFE_POINT(w, "w is NULL", );
-        foreach (ADVSequenceObjectContext* s, w->getSequenceContexts()) {
+        QList<ADVSequenceObjectContext*> sequenceContexts = w->getSequenceContexts();
+        for (ADVSequenceObjectContext* s : qAsConst(sequenceContexts)) {
             SAFE_POINT(s, "s is NULL", );
             s->getSequenceSelection()->clear();
         }

--- a/src/plugins/enzymes/src/CloningUtilTasks.cpp
+++ b/src/plugins/enzymes/src/CloningUtilTasks.cpp
@@ -143,19 +143,20 @@ void DigestSequenceTask::findCutSites() {
             return;
         }
 
-        QList<Annotation*> anns;
-        foreach (Annotation* a, sourceObj->getAnnotations()) {
+        QList<Annotation*> enzymeAnnotations;
+        QList<Annotation*> annotations = sourceObj->getAnnotations();
+        for (Annotation* a : qAsConst(annotations)) {
             if (a->getName() == enzyme->id) {
-                anns.append(a);
+                enzymeAnnotations.append(a);
             }
         }
 
-        if (anns.isEmpty()) {
+        if (enzymeAnnotations.isEmpty()) {
             stateInfo.setError(QString("Restriction site %1 is not found").arg(enzyme->id));
             continue;
         }
 
-        foreach (Annotation* a, anns) {
+        for (Annotation* a : qAsConst(enzymeAnnotations)) {
             const QVector<U2Region>& location = a->getRegions();
             int cutPos = location.first().startPos;
             cutSiteMap.insertMulti(GenomicPosition(cutPos, a->getStrand().isDirect()), enzyme);
@@ -326,7 +327,7 @@ QString DigestSequenceTask::generateReport() const {
     res += tr("<h3><br>Digest into fragments %1 (%2)</h3>").arg(dnaObj->getDocument()->getName()).arg(topology);
     res += tr("<br>Generated %1 fragments.").arg(results.count());
     int counter = 1;
-    foreach (const SharedAnnotationData& sdata, results) {
+    for (const SharedAnnotationData& sdata : qAsConst(results)) {
         const int startPos = sdata->location->regions.first().startPos + 1;
         const int endPos = sdata->location->regions.last().endPos();
         int len = 0;
@@ -478,7 +479,8 @@ void LigateFragmentsTask::prepare() {
 
         // handle fragment annotations
         int resultLen = resultSeq.length() + overhangAddition.length();
-        foreach (AnnotationTableObject* aObj, dnaFragment.getRelatedAnnotations()) {
+        QList<AnnotationTableObject*> relatedAnnotations = dnaFragment.getRelatedAnnotations();
+        for (AnnotationTableObject* aObj : qAsConst(relatedAnnotations)) {
             QList<SharedAnnotationData> toSave = cloneAnnotationsInFragmentRegion(dnaFragment, aObj, resultLen);
             annotations.append(toSave);
         }
@@ -558,8 +560,8 @@ QList<SharedAnnotationData> LigateFragmentsTask::cloneAnnotationsInRegion(const 
     // TODO: consider optimizing the code below using AnnotationTableObject::getAnnotationsByRegion()
     foreach (Annotation* a, source->getAnnotations()) {
         bool ok = true;
-        const QVector<U2Region>& location = a->getRegions();
-        foreach (const U2Region& region, location) {
+        QVector<U2Region> location = a->getRegions();
+        for (const U2Region& region : qAsConst(location)) {
             if (!fragmentRegion.contains(region) || fragmentRegion == region) {
                 ok = false;
                 break;
@@ -569,7 +571,7 @@ QList<SharedAnnotationData> LigateFragmentsTask::cloneAnnotationsInRegion(const 
             int newPos = globalOffset + location.first().startPos - fragmentRegion.startPos;
             SharedAnnotationData cloned(new AnnotationData(*a->getData()));
             QVector<U2Region> newLocation;
-            foreach (const U2Region& region, a->getRegions()) {
+            for (const U2Region& region : qAsConst(location)) {
                 U2Region newRegion(region);
                 newRegion.startPos = newPos;
                 newLocation.append(newRegion);
@@ -625,7 +627,7 @@ QList<SharedAnnotationData> LigateFragmentsTask::cloneAnnotationsInFragmentRegio
         }
 
         bool ok = true;
-        foreach (const U2Region& r, location) {
+        for (const U2Region& r : qAsConst(location)) {
             // sneaky annotations shall not pass!
             if (!fragmentContainsRegion(fragment, r)) {
                 ok = false;
@@ -636,7 +638,7 @@ QList<SharedAnnotationData> LigateFragmentsTask::cloneAnnotationsInFragmentRegio
         if (ok) {
             SharedAnnotationData cloned(new AnnotationData(*a->getData()));
             QVector<U2Region> newLocation;
-            foreach (const U2Region& region, location) {
+            for (const U2Region& region : qAsConst(location)) {
                 int startPos = getRelativeStartPos(fragment, region);
                 if (fragment.isInverted()) {
                     startPos = fragment.getLength() - startPos - region.length;

--- a/src/plugins/enzymes/src/DNAFragment.cpp
+++ b/src/plugins/enzymes/src/DNAFragment.cpp
@@ -72,7 +72,7 @@ QList<DNAFragment> DNAFragment::findAvailableFragments() {
 
 QList<DNAFragment> DNAFragment::findAvailableFragments(const QList<GObject*>& aObjects, const QList<GObject*>& sObjects) {
     QList<DNAFragment> fragments;
-    foreach (GObject* obj, aObjects) {
+    for (GObject* obj : qAsConst(aObjects)) {
         AnnotationTableObject* aObj = qobject_cast<AnnotationTableObject*>(obj);
         assert(aObj != nullptr);
         foreach (Annotation* a, aObj->getAnnotations()) {
@@ -80,7 +80,7 @@ QList<DNAFragment> DNAFragment::findAvailableFragments(const QList<GObject*>& aO
                 // Find related sequence object
                 U2SequenceObject* dnaObj = nullptr;
                 QList<GObjectRelation> relations = aObj->getObjectRelations();
-                foreach (const GObjectRelation& relation, relations) {
+                for (const GObjectRelation& relation : qAsConst(relations)) {
                     if (relation.role != ObjectRole_Sequence) {
                         continue;
                     }
@@ -96,7 +96,7 @@ QList<DNAFragment> DNAFragment::findAvailableFragments(const QList<GObject*>& aO
                 DNAFragment fragment;
                 fragment.annotatedFragment = a->getData();
                 fragment.dnaObj = dnaObj;
-                foreach (GObject* relAnn, relatedAnns) {
+                for (GObject* relAnn : qAsConst(relatedAnns)) {
                     AnnotationTableObject* related = qobject_cast<AnnotationTableObject*>(relAnn);
                     fragment.relatedAnnotations.append(related);
                 }

--- a/src/plugins/enzymes/src/DigestSequenceDialog.cpp
+++ b/src/plugins/enzymes/src/DigestSequenceDialog.cpp
@@ -338,7 +338,7 @@ void DigestSequenceDialog::sl_addAnnBtnClicked() {
     QSet<AnnotationTableObject*> aObjs = seqCtx->getAnnotationObjects(false);
     foreach (AnnotationTableObject* aObj, aObjs) {
         QList<Annotation*> anns = aObj->getAnnotations();
-        foreach (Annotation* a, anns) {
+        for (Annotation* a : qAsConst(anns)) {
             const SharedAnnotationData& d = a->getData();
             auto location = U1AnnotationUtils::buildLocationString(d);
             auto itemText = QString("%1 %2").arg(d->name).arg(location);

--- a/src/plugins/enzymes/src/EnzymesQuery.cpp
+++ b/src/plugins/enzymes/src/EnzymesQuery.cpp
@@ -83,10 +83,10 @@ Task* QDEnzymesActor::getAlgorithmTask(const QVector<U2Region>& location) {
 }
 
 void QDEnzymesActor::sl_onAlgorithmTaskFinished() {
-    foreach (FindEnzymesTask* st, enzymesTasks) {
+    for (FindEnzymesTask* st : qAsConst(enzymesTasks)) {
         foreach (const QString& id, ids) {
-            QList<SharedAnnotationData> dataz = st->getResultsAsAnnotations(id);
-            foreach (const SharedAnnotationData& ad, dataz) {
+            QList<SharedAnnotationData> resultAnnotations = st->getResultsAsAnnotations(id);
+            for (const SharedAnnotationData& ad : qAsConst(resultAnnotations)) {
                 QDResultUnit ru(new QDResultUnitData);
                 ru->strand = ad->getStrand();
                 ru->quals = ad->qualifiers;

--- a/src/plugins/external_tool_support/src/cutadapt/CutadaptWorker.cpp
+++ b/src/plugins/external_tool_support/src/cutadapt/CutadaptWorker.cpp
@@ -294,7 +294,7 @@ void CutAdaptParser::parseErrOutput(const QString& partOfLog) {
 }
 
 QString CutAdaptParser::parseTextForErrors(const QStringList& lastPartOfLog) {
-    foreach (const QString& buf, lastPartOfLog) {
+    for (const QString& buf : qAsConst(lastPartOfLog)) {
         bool ignoredStringFound = false;
         foreach (const QString& ignoredStr, stringsToIgnore) {
             if (buf.contains(ignoredStr, Qt::CaseInsensitive)) {

--- a/src/plugins/external_tool_support/src/spades/SpadesTask.cpp
+++ b/src/plugins/external_tool_support/src/spades/SpadesTask.cpp
@@ -154,10 +154,10 @@ void SpadesTask::writeYamlReads() {
     }
     QString res = "";
     res.append("[\n");
-    foreach (const AssemblyReads& r, settings.reads) {
+    for (const AssemblyReads& r : qAsConst(settings.reads)) {
         res.append("{\n");
 
-        const bool isLibraryPaired = GenomeAssemblyUtils::isLibraryPaired(r.libName);
+        bool isLibraryPaired = GenomeAssemblyUtils::isLibraryPaired(r.libName);
 
         if (isLibraryPaired) {
             res.append(QString("orientation: \"%1\",\n").arg(r.orientation));

--- a/src/plugins/external_tool_support/src/spades/SpadesTaskTest.cpp
+++ b/src/plugins/external_tool_support/src/spades/SpadesTaskTest.cpp
@@ -314,7 +314,7 @@ void GTest_CheckYAMLFile::prepare() {
     }
     f.close();
 
-    foreach (const QString& el, desiredStrings) {
+    for (const QString& el : qAsConst(desiredStrings)) {
         foreach (const QString& fileLane, fileLines) {
             if (fileLane.contains(el.trimmed())) {
                 desiredStrings.removeAll(el);

--- a/src/plugins/external_tool_support/src/spades/SpadesTaskTest.cpp
+++ b/src/plugins/external_tool_support/src/spades/SpadesTaskTest.cpp
@@ -314,9 +314,9 @@ void GTest_CheckYAMLFile::prepare() {
     }
     f.close();
 
-    for (const QString& el : qAsConst(desiredStrings)) {
-        foreach (const QString& fileLane, fileLines) {
-            if (fileLane.contains(el.trimmed())) {
+    foreach (const QString& el, desiredStrings) {
+        for (const QString& fileLine : qAsConst(fileLines)) {
+            if (fileLine.contains(el.trimmed())) {
                 desiredStrings.removeAll(el);
             }
         }

--- a/src/plugins/external_tool_support/src/stringtie/StringtieGeneAbundanceReportTask.cpp
+++ b/src/plugins/external_tool_support/src/stringtie/StringtieGeneAbundanceReportTask.cpp
@@ -189,7 +189,7 @@ bool StringtieGeneAbundanceReportTask::mergeFpkmToReportUrl(QMap<QString, QStrin
     foreach (const QString& key, map.keys()) {
         QVector<QString> values = map[key];
         out << key;
-        foreach (const QString val, values) {
+        for (const QString& val : qAsConst(values)) {
             out << outputDelimiter << val;
         }
         out << "\n";

--- a/src/plugins/genome_aligner/src/GenomeAlignerCMDLineTask.cpp
+++ b/src/plugins/genome_aligner/src/GenomeAlignerCMDLineTask.cpp
@@ -73,7 +73,7 @@ GenomeAlignerCMDLineTask::GenomeAlignerCMDLineTask()
             resultPath = opt.second;
         } else if (opt.first == OPTION_SHORTREADS) {
             QStringList urls = opt.second.split(";");
-            foreach (const QString& url, urls) {
+            for (const QString& url : qAsConst(urls)) {
                 shortReadUrls.append(url);
             }
         } else if (opt.first == OPTION_USE_OPENCL) {

--- a/src/plugins/genome_aligner/src/GenomeAlignerWorker.cpp
+++ b/src/plugins/genome_aligner/src/GenomeAlignerWorker.cpp
@@ -246,8 +246,8 @@ public:
         QString slot1Val = busMap.value<StrStrMap>().value(READS_URL_SLOT_ID);
         QString slot2Val = busMap.value<StrStrMap>().value(READS_PAIRED_URL_SLOT_ID);
         U2OpStatusImpl os;
-        const QList<IntegralBusSlot>& slots1 = IntegralBusSlot::listFromString(slot1Val, os);
-        const QList<IntegralBusSlot>& slots2 = IntegralBusSlot::listFromString(slot2Val, os);
+        QList<IntegralBusSlot> slots1 = IntegralBusSlot::listFromString(slot1Val, os);
+        QList<IntegralBusSlot> slots2 = IntegralBusSlot::listFromString(slot2Val, os);
 
         bool hasCommonElements = false;
 
@@ -255,7 +255,7 @@ public:
             if (hasCommonElements) {
                 break;
             }
-            foreach (const IntegralBusSlot& ibsl2, slots2) {
+            for (const IntegralBusSlot& ibsl2 : qAsConst(slots2)) {
                 if (ibsl1 == ibsl2) {
                     hasCommonElements = true;
                     break;

--- a/src/plugins/pcr/src/InSilicoPcrTask.cpp
+++ b/src/plugins/pcr/src/InSilicoPcrTask.cpp
@@ -129,8 +129,8 @@ void InSilicoPcrTask::run() {
     algoLog.details(tr("Forward primers found: %1").arg(forwardResults.size()));
     algoLog.details(tr("Reverse primers found: %1").arg(reverseResults.size()));
 
-    foreach (const FindAlgorithmResult& forward, forwardResults) {
-        foreach (const FindAlgorithmResult& reverse, reverseResults) {
+    for (const FindAlgorithmResult& forward : qAsConst(forwardResults)) {
+        for (const FindAlgorithmResult& reverse : qAsConst(reverseResults)) {
             CHECK(!isCanceled(), );
             if (forward.strand == reverse.strand) {
                 continue;

--- a/src/plugins/pcr/src/InSilicoPcrWorker.cpp
+++ b/src/plugins/pcr/src/InSilicoPcrWorker.cpp
@@ -259,7 +259,7 @@ QList<Message> InSilicoPcrWorker::fetchResult(Task* task, U2OpStatus& os) {
         QList<InSilicoPcrWorkflowTask::Result> pcrResults = pcrTask->takeResult();
         tableRow.productsNumber[pairNumber] = pcrResults.size();
 
-        foreach (const InSilicoPcrWorkflowTask::Result& pcrResult, pcrResults) {
+        for (const InSilicoPcrWorkflowTask::Result& pcrResult : qAsConst(pcrResults)) {
             QVariant sequence = fetchSequence(pcrResult.doc);
             QVariant annotations = fetchAnnotations(pcrResult.doc);
             pcrResult.doc->setDocumentOwnsDbiResources(false);

--- a/src/plugins/pcr/src/PrimersGrouperWorker.cpp
+++ b/src/plugins/pcr/src/PrimersGrouperWorker.cpp
@@ -263,7 +263,7 @@ void PrimerGrouperTask::fillReportTable(const QList<QList<int>>& correctPrimersG
     int index = 1;
     foreach (const QList<int>& curGroup, correctPrimersGroups) {
         QString column1, column2, column3, column4;
-        foreach (int curIndex, curGroup) {
+        for (int curIndex : qAsConst(curGroup)) {
             const PrimersPair& currentPair = primerPairs.at(curIndex);
             column1 += currentPair.first.getName();
             column1 += "<br>";

--- a/src/plugins/query_designer/src/QDGroupsEditor.cpp
+++ b/src/plugins/query_designer/src/QDGroupsEditor.cpp
@@ -68,7 +68,8 @@ void QDGroupsEditor::rebuild() {
     QDScheme* scheme = view->getScheme();
     foreach (const QString& group, scheme->getActorGroups()) {
         QStringList grpItemTexts;
-        int grpSize = scheme->getActors(group).size();
+        QList<QDActor*> actors = scheme->getActors(group);
+        int grpSize = actors.size();
         int reqNum = grpSize ? scheme->getRequiredNumber(group) : 0;
         QString countLbl = QString("%1/%2")
                                .arg(reqNum)
@@ -76,7 +77,7 @@ void QDGroupsEditor::rebuild() {
         grpItemTexts << group << countLbl;
         QTreeWidgetItem* groupItem = new QTreeWidgetItem(this, grpItemTexts);
         addTopLevelItem(groupItem);
-        foreach (QDActor const* actor, scheme->getActors(group)) {
+        for (const QDActor* actor : qAsConst(actors)) {
             const QString& actorLabel = actor->getParameters()->getLabel();
             /*QTreeWidgetItem* actorItem = */ new QTreeWidgetItem(groupItem, QStringList(actorLabel));
         }

--- a/src/plugins/query_designer/src/QDSamples.cpp
+++ b/src/plugins/query_designer/src/QDSamples.cpp
@@ -39,7 +39,7 @@ QList<QDSample> QDSamplesRegistry::data;
 
 QDLoadSamplesTask::QDLoadSamplesTask(const QStringList& _dirs)
     : Task(tr("Load query samples"), TaskFlag_NoRun) {
-    foreach (const QString& s, _dirs) {
+    for (const QString& s : qAsConst(_dirs)) {
         QDir dir(s);
         QStringList names(QString("*.%1").arg(QUERY_SCHEME_EXTENSION));
         foreach (const QFileInfo& fi, dir.entryInfoList(names, QDir::Files | QDir::NoSymLinks)) {

--- a/src/plugins/query_designer/src/QDSceneIOTasks.cpp
+++ b/src/plugins/query_designer/src/QDSceneIOTasks.cpp
@@ -233,7 +233,7 @@ bool QDSceneSerializer::doc2scheme(const QList<QDDocument*>& docs, QMap<QDElemen
         QString group;
         if (!definedIn.isEmpty()) {
             QDElementStatement* actualStmt = nullptr;
-            foreach (QDDocument* importedDoc, docs) {
+            for (QDDocument* importedDoc : qAsConst(docs)) {
                 if (importedDoc->getName() == definedIn) {
                     actualStmt = importedDoc->getElement(grpStmt->getId());
                 }
@@ -302,8 +302,8 @@ QDDocument* QDSceneSerializer::scene2doc(QueryScene* scene) {
     QDDocument* doc = new QDDocument;
     QMap<QDSchemeUnit*, QDElementStatement*> unit2stmt;
     QDScheme* scheme = scene->getScheme();
-    const QList<QDActor*>& sceneActors = scheme->getActors();
-    foreach (QDActor* actor, sceneActors) {
+    QList<QDActor*> sceneActors = scheme->getActors();
+    for (QDActor* actor : qAsConst(sceneActors)) {
         QDElementStatement* actorElement = QDSchemeSerializer::saveActor(actor, doc);
         foreach (QDSchemeUnit* su, actor->getSchemeUnits()) {
             QString name = actorElement->getId() + ".";

--- a/src/plugins/query_designer/src/QueryViewAdapter.cpp
+++ b/src/plugins/query_designer/src/QueryViewAdapter.cpp
@@ -32,7 +32,8 @@ QueryViewAdapter::QueryViewAdapter(QDScheme* scheme, const QPointF& topLeftCorne
     QMap<QDSchemeUnit*, QDElement*> unitMap;
     QList<QDConstraint*> constraints = scheme->getConstraints();
     foreach (QDActor const* a, scheme->getActors()) {
-        foreach (QDSchemeUnit* su, a->getSchemeUnits()) {
+        QList<QDSchemeUnit*> units = a->getSchemeUnits();
+        for (QDSchemeUnit* su : qAsConst(units)) {
             QDElement* uv = new QDElement(su);
             uv->moveBy(topLeftCorner.x(), topLeftCorner.y());
             createdElements.append(uv);

--- a/src/plugins/query_designer/src/QueryViewController.cpp
+++ b/src/plugins/query_designer/src/QueryViewController.cpp
@@ -403,18 +403,18 @@ void QueryScene::dragMoveEvent(QGraphicsSceneDragDropEvent* event) {
 
         QRectF leftArea = sceneRect();
         leftArea.setRight(mousePos.x());
-        const QList<QGraphicsItem*>& annItemsToLeft = getElements(leftArea);
+        QList<QGraphicsItem*> annItemsToLeft = getElements(leftArea);
 
         QRectF rightArea = sceneRect();
         rightArea.setLeft(mousePos.x());
-        const QList<QGraphicsItem*>& annItemsToRight = getElements(rightArea);
+        QList<QGraphicsItem*> annItemsToRight = getElements(rightArea);
 
         qreal delta = sceneRect().width() * sceneRect().width() + sceneRect().height() * sceneRect().height();
         QDElement *src = nullptr, *dst = nullptr;
-        foreach (QGraphicsItem* itLeft, annItemsToLeft) {
+        for (QGraphicsItem* itLeft : qAsConst(annItemsToLeft)) {
             QDElement* leftAnn = qgraphicsitem_cast<QDElement*>(itLeft);
             assert(leftAnn);
-            foreach (QGraphicsItem* itRight, annItemsToRight) {
+            for (QGraphicsItem* itRight : qAsConst(annItemsToRight)) {
                 QDElement* rightAnn = qgraphicsitem_cast<QDElement*>(itRight);
                 assert(rightAnn);
                 QLineF srcToPos(leftAnn->getRightConnector(), mousePos);

--- a/src/plugins/query_designer/src/QueryViewItems.cpp
+++ b/src/plugins/query_designer/src/QueryViewItems.cpp
@@ -435,8 +435,8 @@ void QDElement::contextMenuEvent(QGraphicsSceneContextMenuEvent* event) {
     scheme->setOrder(getActor(), newSerialNum);
     for (int i = from; i <= to; i++) {
         QDActor* a = actors.at(i);
-        const QList<QDSchemeUnit*>& suList = a->getSchemeUnits();
-        foreach (QDSchemeUnit* su, suList) {
+        QList<QDSchemeUnit*> suList = a->getSchemeUnits();
+        for (QDSchemeUnit* su : qAsConst(suList)) {
             foreach (QGraphicsItem* it, qs->getElements()) {
                 QDElement* uv = qgraphicsitem_cast<QDElement*>(it);
                 assert(uv);

--- a/src/plugins/remote_blast/src/BlastQuery.cpp
+++ b/src/plugins/remote_blast/src/BlastQuery.cpp
@@ -125,7 +125,7 @@ void QDCDDActor::sl_onAlgorithmTaskFinished() {
     int minLen = cfg->getParameter(MIN_RES_LEN)->getAttributeValueWithoutScript<int>();
     int maxLen = cfg->getParameter(MAX_RES_LEN)->getAttributeValueWithoutScript<int>();
     const QString& qualVal = cfg->getParameter(QUAL_ATTR)->getAttributeValueWithoutScript<QString>();
-    foreach (const SharedAnnotationData& ad, res) {
+    for (const SharedAnnotationData& ad : qAsConst(res)) {
         const U2Region& reg = ad->location->regions.first();
         if (reg.length < minLen || reg.length > maxLen) {
             continue;

--- a/src/plugins/remote_blast/src/RemoteBLASTPluginTests.cpp
+++ b/src/plugins/remote_blast/src/RemoteBLASTPluginTests.cpp
@@ -216,8 +216,8 @@ Task::ReportResult GTest_RemoteBLAST::report() {
         return ReportResult_Finished;
     }
     if (ao != nullptr) {
-        QList<Annotation*> alist(ao->getAnnotations());
-        foreach (Annotation* an, alist) {
+        QList<Annotation*> alist = ao->getAnnotations();
+        for (Annotation* an : qAsConst(alist)) {
             foreach (const U2Qualifier& q, an->getQualifiers()) {
                 if (q.name == "accession") {
                     if (!result.contains(q.value))  // Don't count different hsp

--- a/src/plugins/remote_blast/src/RemoteBLASTTask.cpp
+++ b/src/plugins/remote_blast/src/RemoteBLASTTask.cpp
@@ -295,7 +295,7 @@ QList<SharedAnnotationData> CreateAnnotationsFromHttpBlastResultTask::filterAnno
 
     if (cfg.filterResult & FilterResultByAccession) {
         QStringList accessions;
-        foreach (const SharedAnnotationData& ann, annotations) {
+        for (const SharedAnnotationData& ann : qAsConst(annotations)) {
             QString acc = ann->findFirstQualifierValue("accession");
             if (accessions.contains(acc)) {
                 QString eval = ann->findFirstQualifierValue(selectiveQual);
@@ -319,7 +319,7 @@ QList<SharedAnnotationData> CreateAnnotationsFromHttpBlastResultTask::filterAnno
     if (cfg.filterResult & FilterResultByDef) {
         resultList.clear();
         QStringList defs;
-        foreach (const SharedAnnotationData& ann, annotations) {
+        for (const SharedAnnotationData& ann : qAsConst(annotations)) {
             QString def = ann->findFirstQualifierValue("def");
             if (defs.contains(def)) {
                 QString eval = ann->findFirstQualifierValue(selectiveQual);
@@ -343,7 +343,7 @@ QList<SharedAnnotationData> CreateAnnotationsFromHttpBlastResultTask::filterAnno
     if (cfg.filterResult & FilterResultById) {
         resultList.clear();
         QStringList ids;
-        foreach (const SharedAnnotationData& ann, annotations) {
+        for (const SharedAnnotationData& ann : qAsConst(annotations)) {
             QString id = ann->findFirstQualifierValue("id");
             if (ids.contains(id)) {
                 QString eval = ann->findFirstQualifierValue(selectiveQual);

--- a/src/plugins/repeat_finder/src/FindRepeatsDialog.cpp
+++ b/src/plugins/repeat_finder/src/FindRepeatsDialog.cpp
@@ -166,9 +166,9 @@ void FindRepeatsDialog::prepareAMenu(QToolButton* tb, QLineEdit* le, const QStri
 
 QStringList FindRepeatsDialog::getAvailableAnnotationNames() const {
     QStringList res;
-    const QSet<AnnotationTableObject*>& objs = sc->getAnnotationObjects();
+    QSet<AnnotationTableObject*> objs = sc->getAnnotationObjects();
     QSet<QString> names;
-    foreach (AnnotationTableObject* o, objs) {
+    for (AnnotationTableObject* o : qAsConst(objs)) {
         foreach (Annotation* a, o->getAnnotations()) {
             names.insert(a->getName());
         }
@@ -209,8 +209,8 @@ bool FindRepeatsDialog::getRegions(QCheckBox* cb, QLineEdit* le, QVector<U2Regio
         return true;
     }
     QSet<QString> aNames = names.split(',', QString::SkipEmptyParts).toSet();
-    const QSet<AnnotationTableObject*> aObjs = sc->getAnnotationObjects();
-    foreach (AnnotationTableObject* obj, aObjs) {
+    QSet<AnnotationTableObject*> aObjs = sc->getAnnotationObjects();
+    for (AnnotationTableObject* obj : qAsConst(aObjs)) {
         foreach (Annotation* a, obj->getAnnotations()) {
             if (aNames.contains(a->getName())) {
                 res << a->getRegions();

--- a/src/plugins/repeat_finder/src/FindRepeatsTask.cpp
+++ b/src/plugins/repeat_finder/src/FindRepeatsTask.cpp
@@ -120,8 +120,8 @@ void FindRepeatsTask::filterTandems(const QList<SharedAnnotationData>& tandems, 
     QByteArray gap;
 
     foreach (const SharedAnnotationData& d, tandems) {
-        const QVector<U2Region>& regs = d->getRegions();
-        foreach (const U2Region& r, regs) {
+        QVector<U2Region> regs = d->getRegions();
+        for (const U2Region& r : qAsConst(regs)) {
             gap.fill(unknownChar, r.length);
             seq.seq.replace(r.startPos, r.length, gap);
         }

--- a/src/plugins/repeat_finder/src/FindTandemsDialog.cpp
+++ b/src/plugins/repeat_finder/src/FindTandemsDialog.cpp
@@ -105,9 +105,9 @@ FindTandemsDialog::FindTandemsDialog(ADVSequenceObjectContext* _sc)
 
 QStringList FindTandemsDialog::getAvailableAnnotationNames() const {
     QStringList res;
-    const QSet<AnnotationTableObject*> objs = sc->getAnnotationObjects();
+    QSet<AnnotationTableObject*> objs = sc->getAnnotationObjects();
     QSet<QString> names;
-    foreach (const AnnotationTableObject* o, objs) {
+    for (const AnnotationTableObject* o : qAsConst(objs)) {
         foreach (Annotation* a, o->getAnnotations()) {
             names.insert(a->getName());
         }
@@ -160,8 +160,8 @@ bool FindTandemsDialog::getRegions(QCheckBox* cb, QLineEdit* le, QVector<U2Regio
         return true;
     }
     QSet<QString> aNames = names.split(',', QString::SkipEmptyParts).toSet();
-    const QSet<AnnotationTableObject*> aObjs = sc->getAnnotationObjects();
-    foreach (AnnotationTableObject* obj, aObjs) {
+    QSet<AnnotationTableObject*> aObjs = sc->getAnnotationObjects();
+    for (AnnotationTableObject* obj : qAsConst(aObjs)) {
         foreach (Annotation* a, obj->getAnnotations()) {
             if (aNames.contains(a->getName())) {
                 res << a->getRegions();

--- a/src/plugins/repeat_finder/src/TandemQuery.cpp
+++ b/src/plugins/repeat_finder/src/TandemQuery.cpp
@@ -101,7 +101,7 @@ void QDTandemActor::sl_onAlgorithmTaskFinished() {
         }
     }
     subTasks.clear();
-    foreach (const SharedAnnotationData& annotation, annotations) {
+    for (const SharedAnnotationData& annotation : qAsConst(annotations)) {
         QDResultGroup* group = new QDResultGroup(QDStrand_Both);
         foreach (U2Region region, annotation->location->regions) {
             QDResultUnit resultUnit(new QDResultUnitData);

--- a/src/plugins/smith_waterman/src/SWWorker.cpp
+++ b/src/plugins/smith_waterman/src/SWWorker.cpp
@@ -521,7 +521,7 @@ void SWWorker::sl_taskFinished(Task* t) {
     QList<Task*> subs = multiSw->getTasks();
     SAFE_POINT(!subs.isEmpty(), "Invalid task is encountered", );
     QStringList ptrns;
-    foreach (Task* sub, subs) {
+    for (Task* sub : qAsConst(subs)) {
         SAFE_POINT(nullptr != sub, "Invalid task is encountered", );
         if (sub->isCanceled()) {
             return;

--- a/src/plugins/test_runner/src/TestRunnerPlugin.cpp
+++ b/src/plugins/test_runner/src/TestRunnerPlugin.cpp
@@ -118,7 +118,7 @@ void TestRunnerPlugin::sl_startTestRunner() {
 
                     return;
                 }
-                foreach (GTestSuite* testSuite, testSuiteList) {
+                for (GTestSuite* testSuite : qAsConst(testSuiteList)) {
                     QString testSuiteUrl = testSuite->getURL();
                     if (testRunnerService->findTestSuiteByURL(testSuiteUrl) != nullptr) {
                         delete testSuite;  // duplicate.

--- a/src/plugins/test_runner/src/TestViewController.cpp
+++ b/src/plugins/test_runner/src/TestViewController.cpp
@@ -564,7 +564,7 @@ void TestViewController::sl_saveSelectedSuitesAction() {
             }
             foreach (GTestRef* t, tlItem->ts->getExcludedTests().keys()) {  // get one of the old excluded tests
                 bool flag = true;
-                foreach (GTestState* ttr, testsToRun) {  // get one by one new enabled tests
+                for (GTestState* ttr : qAsConst(testsToRun)) {  // get one by one new enabled tests
                     if (t->getShortName() == ttr->getTestRef()->getShortName()) {
                         flag = false;
                         break;
@@ -575,7 +575,8 @@ void TestViewController::sl_saveSelectedSuitesAction() {
                         oldToAdd.insert(t, tlItem->ts->getExcludedTests().value(t));
                     } else {
                         bool flag2 = true;
-                        foreach (GTestRef* tte, testsToEx.keys()) {
+                        QList<GTestRef*> excludedTestKeys = testsToEx.keys();
+                        for (GTestRef* tte : qAsConst(excludedTestKeys)) {
                             if (tte->getShortName() == t->getShortName()) {
                                 flag2 = false;
                                 break;

--- a/src/plugins/weight_matrix/src/PMatrixFormat.cpp
+++ b/src/plugins/weight_matrix/src/PMatrixFormat.cpp
@@ -51,7 +51,7 @@ PFMatrixFormat::PFMatrixFormat(QObject* p)
 
 FormatCheckResult PFMatrixFormat::checkRawTextData(const QString& dataPrefix, const GUrl&) const {
     QString dataPrefixCopy = dataPrefix;
-    QStringList qsl = dataPrefixCopy.replace("\r\n","\n").split("\n");
+    QStringList qsl = dataPrefixCopy.replace("\r\n", "\n").split("\n");
     qsl.removeAll("");
 
     if (qsl.size() > 5 || qsl.size() < 4) {  // actually can be 4 or 5
@@ -59,7 +59,7 @@ FormatCheckResult PFMatrixFormat::checkRawTextData(const QString& dataPrefix, co
     }
     foreach (QString str, qsl) {
         QStringList line = str.split(QRegExp("\\s+"));
-        foreach (QString word, line) {
+        for (const QString& word : qAsConst(line)) {
             if (!word.isEmpty()) {
                 bool isInt;
                 word.toInt(&isInt);
@@ -159,7 +159,7 @@ PWMatrixFormat::PWMatrixFormat(QObject* p)
 
 FormatCheckResult PWMatrixFormat::checkRawTextData(const QString& dataPrefix, const GUrl&) const {
     QString dataPrefixCopy = dataPrefix;
-    QStringList qsl = dataPrefixCopy.replace("\r\n","\n").split("\n");
+    QStringList qsl = dataPrefixCopy.replace("\r\n", "\n").split("\n");
     qsl.removeAll("");
 
     if (qsl.size() > 5 || qsl.size() < 4) {  // actually can be 5 or 6
@@ -171,10 +171,10 @@ FormatCheckResult PWMatrixFormat::checkRawTextData(const QString& dataPrefix, co
         CHECK(!words.isEmpty(), FormatDetection_NotMatched);
 
         QString firstWord = words.takeFirst();
-        CHECK(2 == firstWord.size(), FormatDetection_NotMatched);
-        CHECK(':' == firstWord[1], FormatDetection_NotMatched);
+        CHECK(firstWord.size() == 2, FormatDetection_NotMatched);
+        CHECK(firstWord[1] == ':', FormatDetection_NotMatched);
 
-        foreach (QString word, words) {
+        for (const QString& word : qAsConst(words)) {
             if (!word.isEmpty()) {
                 bool isFloat;
                 word.toFloat(&isFloat);

--- a/src/plugins/workflow_designer/src/ActorCfgModel.cpp
+++ b/src/plugins/workflow_designer/src/ActorCfgModel.cpp
@@ -83,7 +83,7 @@ void dumpDescriptors(const QList<Descriptor>& descriptors) {
 }
 
 void ActorCfgModel::setupAttributesScripts() {
-    foreach (Attribute* attribute, attrs) {
+    for (Attribute* attribute : qAsConst(attrs)) {
         assert(attribute != nullptr);
         attribute->getAttributeScript().clearScriptVars();
 
@@ -93,7 +93,8 @@ void ActorCfgModel::setupAttributesScripts() {
             continue;
         }
 
-        foreach (const PortDescriptor* descr, subject->getProto()->getPortDesciptors()) {
+        QList<PortDescriptor*> portDesciptors = subject->getProto()->getPortDesciptors();
+        for (const PortDescriptor* descr : qAsConst(portDesciptors)) {
             if (descr->isInput()) {
                 DataTypePtr dataTypePtr = descr->getType();
                 if (dataTypePtr->isMap()) {
@@ -355,11 +356,13 @@ QMap<Attribute*, bool> ActorCfgModel::getAttributeRelatedVisibility(Attribute* c
     QMap<Attribute*, bool> relatedAttributesVisibility = foundRelatedAttrs;
     foreach (Attribute* a, attrs) {
         if (a != changedAttr && !relatedAttributesVisibility.contains(a)) {
-            foreach (const AttributeRelation* rel, a->getRelations()) {
+            QVector<const AttributeRelation*> relations = a->getRelations();
+            for (const AttributeRelation* rel : qAsConst(relations)) {
                 if (rel->getRelatedAttrId() == changedAttr->getId()) {
                     relatedAttributesVisibility.insert(a, isVisible(a));
-                    const QMap<Attribute*, bool> dependentAttributeVisibility = getAttributeRelatedVisibility(a, relatedAttributesVisibility);
-                    foreach (Attribute* dependentAttr, dependentAttributeVisibility.keys()) {
+                    QMap<Attribute*, bool> dependentAttributeVisibility = getAttributeRelatedVisibility(a, relatedAttributesVisibility);
+                    QList<Attribute*> dependentAttributes = dependentAttributeVisibility.keys();
+                    for (Attribute* dependentAttr : qAsConst(dependentAttributes)) {
                         relatedAttributesVisibility[dependentAttr] = dependentAttributeVisibility[dependentAttr];
                     }
                 }

--- a/src/plugins/workflow_designer/src/SchemaAliasesConfigurationDialogImpl.cpp
+++ b/src/plugins/workflow_designer/src/SchemaAliasesConfigurationDialogImpl.cpp
@@ -70,7 +70,8 @@ void SchemaAliasesConfigurationDialogImpl::initializeModel(const Schema& schema)
         assert(actor != nullptr);
         QMap<Descriptor, QString> aliasMap;
         QMap<Descriptor, QString> helpMap;
-        foreach (Attribute* attr, actor->getParameters().values()) {
+        QList<Attribute*> attributes = actor->getParameters().values();
+        for (Attribute* attr : qAsConst(attributes)) {
             assert(attr != nullptr);
             QString alias = actor->getParamAliases().value(attr->getId());
             QString help = actor->getAliasHelp().value(alias);
@@ -85,7 +86,8 @@ void SchemaAliasesConfigurationDialogImpl::initializeModel(const Schema& schema)
 
 SchemaAliasesCfgDlgModel SchemaAliasesConfigurationDialogImpl::getModel() const {
     SchemaAliasesCfgDlgModel ret;
-    foreach (const ActorId& id, model.aliases.keys()) {
+    QList<ActorId> actorIds = model.aliases.keys();
+    for (const ActorId& id : qAsConst(actorIds)) {
         QMap<Descriptor, QString> aliases;
         foreach (const Descriptor& d, model.aliases.value(id).keys()) {
             QString aliasStr = model.aliases.value(id).value(d);
@@ -110,7 +112,8 @@ bool SchemaAliasesConfigurationDialogImpl::validateModel() const {
     SchemaAliasesCfgDlgModel m = getModel();
     QStringList allAliases;
     foreach (const ActorId& id, m.aliases.keys()) {
-        foreach (const Descriptor& d, m.aliases.value(id).keys()) {
+        QList<Descriptor> descriptors = m.aliases.value(id).keys();
+        for (const Descriptor& d : qAsConst(descriptors)) {
             allAliases << m.aliases.value(id).value(d);
         }
     }

--- a/src/plugins/workflow_designer/src/WorkflowViewController.cpp
+++ b/src/plugins/workflow_designer/src/WorkflowViewController.cpp
@@ -1593,7 +1593,8 @@ void WorkflowView::sl_configureParameterAliases() {
             }
             SchemaAliasesCfgDlgModel model = dlg->getModel();
             foreach (const ActorId& id, model.aliases.keys()) {
-                foreach (const Descriptor& d, model.aliases.value(id).keys()) {
+                QList<Descriptor> descriptors = model.aliases.value(id).keys();
+                for (const Descriptor& d : qAsConst(descriptors)) {
                     Actor* actor = schema->actorById(id);
                     assert(actor != nullptr);
                     QString alias = model.aliases.value(id).value(d);
@@ -2253,7 +2254,8 @@ const Workflow::Metadata& WorkflowView::getMeta() {
 const Workflow::Metadata& WorkflowView::updateMeta() {
     meta.setSampleMark(false);
     meta.resetVisual();
-    foreach (QGraphicsItem* it, scene->items()) {
+    QList<QGraphicsItem*> sceneItems = scene->items();
+    for (QGraphicsItem* it : qAsConst(sceneItems)) {
         switch (it->type()) {
             case WorkflowProcessItemType: {
                 WorkflowProcessItem* proc = qgraphicsitem_cast<WorkflowProcessItem*>(it);
@@ -2299,12 +2301,13 @@ Workflow::Metadata WorkflowView::getMeta(const QList<WorkflowProcessItem*>& item
     result.url = meta.url;
     result.comment = meta.comment;
 
-    foreach (WorkflowProcessItem* proc, items) {
+    for (WorkflowProcessItem* proc : qAsConst(items)) {
         bool contains = false;
         ActorVisualData visual = meta.getActorVisualData(proc->getProcess()->getId(), contains);
         assert(contains);
         result.setActorVisualData(visual);
-        foreach (WorkflowPortItem* port1, proc->getPortItems()) {
+        QList<WorkflowPortItem*> portItems = proc->getPortItems();
+        for (WorkflowPortItem* port1 : qAsConst(portItems)) {
             foreach (WorkflowBusItem* bus, port1->getDataFlows()) {
                 WorkflowPortItem* port2 = (bus->getInPort() == port1) ? bus->getOutPort() : bus->getInPort();
                 WorkflowProcessItem* proc2 = port2->getOwner();
@@ -2364,7 +2367,7 @@ static bool canDrop(const QMimeData* m, QList<ActorPrototype*>& lst) {
         }
     } else {
         foreach (QList<ActorPrototype*> l, WorkflowEnv::getProtoRegistry()->getProtos().values()) {
-            foreach (ActorPrototype* proto, l) {
+            for (ActorPrototype* proto : qAsConst(l)) {
                 if (proto->isAcceptableDrop(m)) {
                     lst << proto;
                 }
@@ -2716,7 +2719,8 @@ WorkflowScene* SceneCreator::createScene() {
     foreach (Actor* actor, schema->getProcesses()) {
         WorkflowProcessItem* procItem = createProcess(actor);
         scene->addItem(procItem);
-        foreach (WorkflowPortItem* portItem, procItem->getPortItems()) {
+        QList<WorkflowPortItem*> portItems = procItem->getPortItems();
+        for (WorkflowPortItem* portItem : qAsConst(portItems)) {
             ports[portItem->getPort()] = portItem;
         }
     }

--- a/src/plugins/workflow_designer/src/WorkflowViewItems.cpp
+++ b/src/plugins/workflow_designer/src/WorkflowViewItems.cpp
@@ -283,7 +283,7 @@ void WorkflowProcessItem::paint(QPainter* painter, const QStyleOptionGraphicsIte
 }
 
 void WorkflowProcessItem::updatePorts() {
-    foreach (WorkflowPortItem* pit, ports) {
+    for (WorkflowPortItem* pit : qAsConst(ports)) {
         pit->setPos(pos());
         foreach (WorkflowBusItem* bit, pit->getDataFlows()) {
             bit->updatePos();
@@ -621,8 +621,9 @@ static bool checkTypes(Port* p1, Port* p2) {
     Port* op = p1->isInput() ? p2 : p1;
     DataTypePtr idt = ip->getType();
     DataTypePtr odt = op->getType();
+    QList<Descriptor> odtDescriptors = odt->getAllDescriptors();
     if (idt->isSingle() && odt->isMap()) {
-        foreach (Descriptor d, odt->getAllDescriptors()) {
+        foreach (Descriptor d, odtDescriptors) {
             if (idt == odt->getDatatypeByDescriptor(d))
                 return true;
         }
@@ -633,7 +634,7 @@ static bool checkTypes(Port* p1, Port* p2) {
             return proto->isAllowsEmptyPorts();
         }
         foreach (Descriptor d1, idt->getAllDescriptors()) {
-            foreach (Descriptor d2, odt->getAllDescriptors()) {
+            for (const Descriptor& d2 : qAsConst(odtDescriptors)) {
                 if (idt->getDatatypeByDescriptor(d1) == odt->getDatatypeByDescriptor(d2))
                     return true;
             }

--- a/src/plugins/workflow_designer/src/debug_messages_translation/AnnotationsMessageTranslator.cpp
+++ b/src/plugins/workflow_designer/src/debug_messages_translation/AnnotationsMessageTranslator.cpp
@@ -49,7 +49,7 @@ QString AnnotationsMessageTranslator::getTranslation() const {
         QVector<U2Region> annotatedRegions = data->getRegions();
         if (!annotatedRegions.isEmpty()) {
             result += QObject::tr(REGION_LIST_LABEL);
-            foreach (const U2Region& region, annotatedRegions) {
+            for (const U2Region& region : qAsConst(annotatedRegions)) {
                 result += region.toString() + INFO_FEATURES_SEPARATOR;
             }
             result = result.left(result.size() - INFO_FEATURES_SEPARATOR.size());

--- a/src/plugins/workflow_designer/src/debug_messages_translation/WorkflowDebugMessageParserImpl.cpp
+++ b/src/plugins/workflow_designer/src/debug_messages_translation/WorkflowDebugMessageParserImpl.cpp
@@ -93,7 +93,8 @@ WorkflowInvestigationData WorkflowDebugMessageParserImpl::getAllMessageValues() 
         }
         initParsedInfo();
         foreach (const QVariantMap& messageContent, sourceMessages) {
-            foreach (const QString& key, messageContent.keys()) {
+            QList<QString> keys = messageContent.keys();
+            for (const QString& key : qAsConst(keys)) {
                 SAFE_POINT(messageTypes.contains(key), "Unexpected message type encountered!", parsedInfo);
                 parsedInfo[key].enqueue(convertToString(key, messageContent[key]));
             }

--- a/src/plugins/workflow_designer/src/library/ExternalProcessWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/ExternalProcessWorker.cpp
@@ -233,7 +233,8 @@ void ExternalProcessWorker::applySpecialInternalEnvvars(QString& execString,
 }
 
 void ExternalProcessWorker::applyAttributes(QString& execString) {
-    foreach (Attribute* a, actor->getAttributes()) {
+    QList<Attribute*> actorAttributes = actor->getAttributes();
+    for (Attribute* a : qAsConst(actorAttributes)) {
         QString attrValue = a->getAttributePureValue().toString();
         DataTypePtr attrType = a->getAttributeType();
         if (attrType == BaseTypes::STRING_TYPE()) {
@@ -574,9 +575,9 @@ void ExternalProcessWorker::sl_onTaskFinishied() {
         U2OpStatus2Log os;
 
         foreach (const QString& slotId, seqsForMergingBySlotId.keys()) {
-            const QList<U2EntityRef>& refs = seqsForMergingBySlotId.value(slotId);
+            QList<U2EntityRef> refs = seqsForMergingBySlotId.value(slotId);
             bool first = true;
-            foreach (const U2EntityRef& eRef, refs) {
+            for (const U2EntityRef& eRef : qAsConst(refs)) {
                 QScopedPointer<U2SequenceObject> obj(new U2SequenceObject("tmp_name", eRef));
                 if (first) {
                     seqImporter.startSequence(os, context->getDataStorage()->getDbiRef(), U2ObjectDbi::ROOT_FOLDER, slotId, false);
@@ -777,7 +778,8 @@ QString ExternalProcessWorkerPrompter::composeRichDoc() {
             QString destinations;
             QString unsetStr = "<font color='red'>" + tr("unset") + "</font>";
             if (!output->getLinks().isEmpty()) {
-                foreach (Port* p, output->getLinks().keys()) {
+                QList<Port*> ports = output->getLinks().keys();
+                for (Port* p : qAsConst(ports)) {
                     IntegralBusPort* ibp = qobject_cast<IntegralBusPort*>(p);
                     Actor* dest = ibp->owner();
                     destinations += tr("<u>%1</u>").arg(dest ? dest->getLabel() : unsetStr) + ",";

--- a/src/plugins/workflow_designer/src/library/FindWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/FindWorker.cpp
@@ -456,7 +456,7 @@ Task* FindWorker::tick() {
 
 void FindWorker::sl_taskFinished(Task* t) {
     MultiTask* multiFind = qobject_cast<MultiTask*>(t);
-    SAFE_POINT(nullptr != multiFind, "Invalid task encountered!", );
+    SAFE_POINT(multiFind != nullptr, "Invalid task encountered!", );
     QList<Task*> subs = multiFind->getTasks();
     SAFE_POINT(!subs.isEmpty(), "No subtasks found!", );
     QStringList ptrns;
@@ -464,7 +464,7 @@ void FindWorker::sl_taskFinished(Task* t) {
     QList<SharedAnnotationData> result;
     bool isCircular = false;
     int seqLen = -1;
-    foreach (Task* sub, subs) {
+    for (Task* sub : qAsConst(subs)) {
         FindAlgorithmTask* findTask = qobject_cast<FindAlgorithmTask*>(sub);
         if (nullptr != findTask) {
             if (findTask->isCanceled() || findTask->hasError()) {
@@ -486,20 +486,20 @@ void FindWorker::sl_taskFinished(Task* t) {
                         patternName = resultName;
                     }
                 }
-                const QList<SharedAnnotationData> tmpResult = FindAlgorithmResult::toTable(findTask->popResults(), useNames ? patternName : resultName);
-                foreach (SharedAnnotationData annotation, tmpResult) {
+                QList<SharedAnnotationData> tmpResult = FindAlgorithmResult::toTable(findTask->popResults(), useNames ? patternName : resultName);
+                for (SharedAnnotationData annotation : qAsConst(tmpResult)) {
                     if (!patternName.isEmpty()) {
                         const U2Qualifier patternNameQual(patternNameQualName, patternName);
                         annotation->qualifiers.push_back(patternNameQual);
                     }
                     result << annotation;
                 }
-                foreach (const SharedAnnotationData& annotation, result) {
+                for (const SharedAnnotationData& annotation : qAsConst(result)) {
                     foreach (const U2Qualifier& qual, annotation->qualifiers) {
                         qDebug() << annotation->name << "---" << qual.name << " : " << qual.value;
                     }
                 }
-                if (nullptr != output) {
+                if (output != nullptr) {
                     algoLog.info(tr("Found %1 matches of pattern '%2'").arg(result.size()).arg(QString(filePatterns.value(findTask).second)));
                 }
             }
@@ -538,7 +538,8 @@ FindAllRegionsTask::FindAllRegionsTask(const FindAlgorithmTaskSettings& s, const
 
 void FindAllRegionsTask::prepare() {
     foreach (AnnotationData d, regions) {
-        foreach (U2Region lr, d.getRegions()) {
+        QVector<U2Region> regions = d.getRegions();
+        for (const U2Region& lr : qAsConst(regions)) {
             cfg.searchRegion = lr;
             addSubTask(new FindAlgorithmTask(cfg));
         }

--- a/src/plugins/workflow_designer/src/library/GenericReadWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/GenericReadWorker.cpp
@@ -357,8 +357,8 @@ void LoadSeqTask::run() {
         QList<GObject*> seqObjs = doc->findGObjectByType(GObjectTypes::SEQUENCE);
         QList<GObject*> annObjs = doc->findGObjectByType(GObjectTypes::ANNOTATION_TABLE);
         QList<GObject*> allLoadedAnnotations = doc->findGObjectByType(GObjectTypes::ANNOTATION_TABLE);
-        foreach (GObject* go, seqObjs) {
-            SAFE_POINT(nullptr != go, "Invalid object encountered!", );
+        for (GObject* go: qAsConst(seqObjs)) {
+            SAFE_POINT(go != nullptr, "Invalid object encountered!", );
             if (!selector->objectMatches(static_cast<U2SequenceObject*>(go))) {
                 continue;
             }
@@ -370,7 +370,7 @@ void LoadSeqTask::run() {
             QList<GObject*> annotations = GObjectUtils::findObjectsRelatedToObjectByRole(go, GObjectTypes::ANNOTATION_TABLE, ObjectRole_Sequence, allLoadedAnnotations, UOF_LoadedOnly);
             if (!annotations.isEmpty()) {
                 QList<SharedAnnotationData> l;
-                foreach (GObject* annGObj, annotations) {
+                for (GObject* annGObj : qAsConst(annotations)) {
                     AnnotationTableObject* att = qobject_cast<AnnotationTableObject*>(annGObj);
                     foreach (Annotation* a, att->getAnnotations()) {
                         l << a->getData();
@@ -384,7 +384,7 @@ void LoadSeqTask::run() {
         }
 
         // if there are annotations that are not connected to a sequence -> put them  independently
-        foreach (GObject* annObj, annObjs) {
+        for (GObject* annObj : qAsConst(annObjs)) {
             AnnotationTableObject* att = qobject_cast<AnnotationTableObject*>(annObj);
             if (att->findRelatedObjectsByRole(ObjectRole_Sequence).isEmpty()) {
                 SAFE_POINT(nullptr != att, "Invalid annotation table object encountered!", );

--- a/src/plugins/workflow_designer/src/library/GroupWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/GroupWorker.cpp
@@ -121,7 +121,8 @@ Task* GroupWorker::tick() {
         groupSize[foundId] = groupSize[foundId] + 1;
     }
     if (inChannel->isEnded()) {
-        foreach (int id, groupedData.keys()) {
+        QList<int> groupKeys = groupedData.keys();
+        for (int id : qAsConst(groupKeys)) {
             QMap<QString, ActionPerformer*> perfs = groupedData[id];
 
             QVariantMap data;
@@ -155,7 +156,8 @@ Task* GroupWorker::tick() {
 }
 
 void GroupWorker::cleanup() {
-    foreach (const PerformersMap& perfs, groupedData.values()) {
+    QList<PerformersMap> performers = groupedData.values();
+    for (const PerformersMap& perfs : qAsConst(performers)) {
         foreach (ActionPerformer* p, perfs.values()) {
             delete p;
         }

--- a/src/plugins/workflow_designer/src/library/ImportAnnotationsWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/ImportAnnotationsWorker.cpp
@@ -104,7 +104,7 @@ static QList<SharedAnnotationData> getAnnsFromDoc(Document* doc) {
         return ret;
     }
     QList<GObject*> objs = doc->findGObjectByType(GObjectTypes::ANNOTATION_TABLE);
-    foreach (GObject* obj, objs) {
+    for (GObject* obj : qAsConst(objs)) {
         AnnotationTableObject* annObj = qobject_cast<AnnotationTableObject*>(obj);
         if (nullptr == annObj) {
             continue;

--- a/src/plugins/workflow_designer/src/library/IncludedProtoFactoryImpl.cpp
+++ b/src/plugins/workflow_designer/src/library/IncludedProtoFactoryImpl.cpp
@@ -214,7 +214,7 @@ ActorPrototype* IncludedProtoFactoryImpl::_getSchemaActorProto(Schema* schema, c
 
     QMap<QString, PropertyDelegate*> delegateMap;
     QList<Actor*> procs = schema->getProcesses();
-    foreach (Actor* proc, procs) {
+    for (Actor* proc : qAsConst(procs)) {
         if (proc->hasParamAliases()) {
             DelegateEditor* ed = (DelegateEditor*)(proc->getProto()->getEditor());
             QMap<QString, QString> paramAliases = proc->getParamAliases();

--- a/src/plugins/workflow_designer/src/library/RemoteDBFetcherWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/RemoteDBFetcherWorker.cpp
@@ -167,13 +167,14 @@ void RemoteDBFetcherWorker::sl_taskFinished() {
     }
 
     Document* doc = loadTask->getDocument();
-    SAFE_POINT(nullptr != doc, "NULL document", );
+    SAFE_POINT(doc != nullptr, "NULL document", );
     doc->setDocumentOwnsDbiResources(false);
     monitor()->addOutputFile(doc->getURLString(), getActorId());
 
-    foreach (GObject* gobj, doc->findGObjectByType(GObjectTypes::SEQUENCE)) {
-        U2SequenceObject* dnao = qobject_cast<U2SequenceObject*>(gobj);
-        SAFE_POINT(nullptr != dnao, "NULL sequence", );
+    QList<GObject*> sequences = doc->findGObjectByType(GObjectTypes::SEQUENCE);
+    for (GObject* gobj : qAsConst(sequences)) {
+        auto dnao = qobject_cast<U2SequenceObject*>(gobj);
+        SAFE_POINT(dnao != nullptr, "NULL sequence", );
 
         QList<GObject*> allLoadedAnnotations = doc->findGObjectByType(GObjectTypes::ANNOTATION_TABLE);
         QList<GObject*> annotations = GObjectUtils::findObjectsRelatedToObjectByRole(gobj,
@@ -461,9 +462,10 @@ void FetchSequenceByIdFromAnnotationWorker::sl_taskFinished() {
     doc->setDocumentOwnsDbiResources(false);
     monitor()->addOutputFile(doc->getURLString(), getActorId());
 
-    foreach (GObject* gobj, doc->findGObjectByType(GObjectTypes::SEQUENCE)) {
-        U2SequenceObject* dnao = qobject_cast<U2SequenceObject*>(gobj);
-        SAFE_POINT(nullptr != dnao, "NULL sequence", );
+    QList<GObject*> sequences = doc->findGObjectByType(GObjectTypes::SEQUENCE);
+    for (GObject* gobj : qAsConst(sequences)) {
+        auto dnao = qobject_cast<U2SequenceObject*>(gobj);
+        SAFE_POINT(dnao != nullptr, "NULL sequence", );
 
         QList<GObject*> allLoadedAnnotations = doc->findGObjectByType(GObjectTypes::ANNOTATION_TABLE);
         QList<GObject*> annotations = GObjectUtils::findObjectsRelatedToObjectByRole(gobj,

--- a/src/plugins/workflow_designer/src/library/ScriptWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/ScriptWorker.cpp
@@ -140,7 +140,8 @@ void ScriptWorker::bindPortVariables() {
         }
 
         QVariantMap busData = bus->lookMessage().getData().toMap();
-        foreach (const QString& slotId, busData.keys()) {
+        QList<QString> slotIds = busData.keys();
+        for (const QString& slotId : slotIds) {
             QString attrId = "in_" + slotId;
             if (script->hasVarWithId(attrId)) {
                 script->setVarValueWithId(attrId, busData.value(slotId));

--- a/src/plugins/workflow_designer/src/library/WriteAnnotationsWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/WriteAnnotationsWorker.cpp
@@ -231,10 +231,10 @@ void WriteAnnotationsWorker::fetchIncomingAnnotations(const QVariantMap& incomin
     QList<AnnotationTableObject*> annTables = StorageUtils::getAnnotationTableObjects(context->getDataStorage(), annVar);
     annotationsByUrl[resultPath] << annTables;
 
-    const QString seqObjName = fetchIncomingSequenceName(incomingData);
+    QString seqObjName = fetchIncomingSequenceName(incomingData);
     bool isWriteNames = getValue<bool>(WRITE_NAMES);
     if (isWriteNames && !seqObjName.isEmpty()) {
-        foreach (AnnotationTableObject* annTable, annTables) {
+        for (AnnotationTableObject* annTable : qAsConst(annTables)) {
             foreach (Annotation* annotation, annTable->getAnnotations()) {
                 U2Qualifier seqNameQual;
                 seqNameQual.name = ExportAnnotations2CSVTask::SEQUENCE_NAME;
@@ -248,8 +248,8 @@ void WriteAnnotationsWorker::fetchIncomingAnnotations(const QVariantMap& incomin
 void WriteAnnotationsWorker::mergeAnnTablesIfNecessary(QList<AnnotationTableObject*>& annTables) const {
     CHECK(getMergeAttribute() == true, );
 
-    AnnotationTableObject* mergedTable = new AnnotationTableObject(getAnnotationTableName(), context->getDataStorage()->getDbiRef());
-    foreach (AnnotationTableObject* annTable, annTables) {
+    auto mergedTable = new AnnotationTableObject(getAnnotationTableName(), context->getDataStorage()->getDbiRef());
+    for (AnnotationTableObject* annTable : qAsConst(annTables)) {
         QList<SharedAnnotationData> anns;
         foreach (Annotation* annotation, annTable->getAnnotations()) {
             anns.append(annotation->getData());
@@ -277,7 +277,7 @@ Task* WriteAnnotationsWorker::getSaveObjTask(const U2DbiRef& dstDbiRef) const {
     foreach (const QString& path, annotationsByUrl.keys()) {
         QList<AnnotationTableObject*> annTables = annotationsByUrl.value(path);
         mergeAnnTablesIfNecessary(annTables);
-        foreach (AnnotationTableObject* annTable, annTables) {
+        for (AnnotationTableObject* annTable : qAsConst(annTables)) {
             taskList << new ImportObjectToDatabaseTask(annTable, dstDbiRef, path);
         }
     }
@@ -322,7 +322,7 @@ Task* WriteAnnotationsWorker::getSaveDocTask(const QString& formatId, SaveDocFla
             }
 
             QList<Annotation*> annotations;
-            foreach (AnnotationTableObject* annTable, annTables) {
+            for (AnnotationTableObject* annTable : qAsConst(annTables)) {
                 annotations << annTable->getAnnotations();
             }
 
@@ -341,7 +341,7 @@ Task* WriteAnnotationsWorker::getSaveDocTask(const QString& formatId, SaveDocFla
             doc->setDocumentOwnsDbiResources(false);
 
             QSet<QString> usedNames;
-            foreach (AnnotationTableObject* annTable, annTables) {
+            for (AnnotationTableObject* annTable : qAsConst(annTables)) {
                 updateAnnotationsName(annTable, usedNames);
                 annTable->setModified(false);
                 doc->addObject(annTable);  // savedoc task will delete doc -> doc will delete att

--- a/src/plugins/workflow_designer/src/library/create_cmdline_based_worker/CreateCmdlineBasedWorkerWizard.cpp
+++ b/src/plugins/workflow_designer/src/library/create_cmdline_based_worker/CreateCmdlineBasedWorkerWizard.cpp
@@ -344,20 +344,20 @@ bool CreateCmdlineBasedWorkerWizardGeneralSettingsPage::validatePage() {
     QStringList reservedNames;
     QStringList reservedIds;
 
-    foreach (const QList<ActorPrototype*>& group, groups) {
+    for (const QList<ActorPrototype*>& group : qAsConst(groups)) {
         foreach (ActorPrototype* proto, group) {
             reservedNames << proto->getDisplayName();
             reservedIds << proto->getId();
         }
     }
 
-    if (nullptr == initialConfig || initialConfig->name != name) {
+    if (initialConfig == nullptr || initialConfig->name != name) {
         name = WorkflowUtils::createUniqueString(name, " ", reservedNames);
         setField(CreateCmdlineBasedWorkerWizard::WORKER_NAME_FIELD, name);
     }
 
     QString id;
-    if (nullptr == initialConfig) {
+    if (initialConfig == nullptr) {
         id = WorkflowUtils::createUniqueString(WorkflowUtils::generateIdFromName(name), "-", reservedIds);
     } else {
         id = initialConfig->id;
@@ -383,7 +383,7 @@ void CreateCmdlineBasedWorkerWizardGeneralSettingsPage::makeUniqueWorkerName(QSt
     const QMap<Descriptor, QList<ActorPrototype*>> groups = Workflow::WorkflowEnv::getProtoRegistry()->getProtos();
     QStringList reservedNames;
     foreach (const QList<ActorPrototype*>& group, groups) {
-        foreach (ActorPrototype* proto, group) {
+        for (ActorPrototype* proto : qAsConst(group)) {
             reservedNames << proto->getDisplayName();
         }
     }
@@ -927,7 +927,7 @@ void ExternalToolSelectComboBox::addSupportedToolsPopupMenu() {
             cbDelegate->addUngroupedItem(standardModel, tool->getName(), tool->getId());
         } else {
             cbDelegate->addParentItem(standardModel, toolKitName, false, false);
-            foreach (ExternalTool* tool, currentToolKitTools) {
+            for (ExternalTool* tool : qAsConst(currentToolKitTools)) {
                 cbDelegate->addChildItem(standardModel, tool->getName(), tool->getId());
             }
         }

--- a/src/plugins/workflow_designer/src/util/GrouperActionUtils.cpp
+++ b/src/plugins/workflow_designer/src/util/GrouperActionUtils.cpp
@@ -409,7 +409,7 @@ bool MergeAnnotationPerformer::applyAction(const QVariant& newData) {
     }
 
     if (unique) {
-        foreach (SharedAnnotationData newD, newAnns) {
+        for (SharedAnnotationData newD : qAsConst(newAnns)) {
             bool found = false;
             foreach (const SharedAnnotationData& d, result) {
                 if (*newD == *d) {

--- a/src/plugins_3rdparty/hmm2/src/u_search/HMMSearchQDActor.cpp
+++ b/src/plugins_3rdparty/hmm2/src/u_search/HMMSearchQDActor.cpp
@@ -87,7 +87,7 @@ Task* HMM2QDActor::getAlgorithmTask(const QVector<U2Region>& location) {
     stngs.domT = (float)cfg->getParameter(DOM_T_ATTR)->getAttributeValueWithoutScript<double>();
     stngs.eValueNSeqs = cfg->getParameter(NSEQ_ATTR)->getAttributeValueWithoutScript<int>();
 
-    foreach (QString hmmFile, hmmFiles) {
+    for (const QString& hmmFile : qAsConst(hmmFiles)) {
         foreach (U2Region r, location) {
             DNASequence sequence;
             sequence.seq = QByteArray(seq + r.startPos, r.length);
@@ -109,7 +109,7 @@ void HMM2QDActor::sl_onTaskFinished(Task*) {
     foreach (HMMSearchTask* t, offsets.keys()) {
         QList<SharedAnnotationData> annotations = t->getResultsAsAnnotations(U2FeatureTypes::MiscSignal, aname);
         int offset = offsets.value(t);
-        foreach (const SharedAnnotationData& d, annotations) {
+        for (const SharedAnnotationData& d : qAsConst(annotations)) {
             U2Region r = d->location->regions.first();
             if (r.length < getMinResultLen() || r.length > getMaxResultLen()) {
                 continue;

--- a/src/plugins_3rdparty/kalign/src/kalign2/kalign2_distance_calculation.c
+++ b/src/plugins_3rdparty/kalign/src/kalign2/kalign2_distance_calculation.c
@@ -364,7 +364,7 @@ struct alignment* protein_wu_sw(struct node* hash[],struct alignment* aln,int a,
 					n = malloc(sizeof(struct feature));
 					n->next = 0;
 					n->color = 0;
-					n->type = malloc(sizeof(char)*8);
+					n->type = malloc(sizeof(char)*9);
 					n->type[0] = 'w';
 					n->type[1] = 'u';
 					n->type[2] = 'm';
@@ -414,7 +414,7 @@ struct alignment* protein_wu_sw(struct node* hash[],struct alignment* aln,int a,
 					n->next = 0;
 					n->color = 0;
 					
-					n->type = malloc(sizeof(char)*8);
+					n->type = malloc(sizeof(char)*9);
 					n->type[0] = 'w';
 					n->type[1] = 'u';
 					n->type[2] = 'm';
@@ -481,7 +481,7 @@ struct alignment* protein_wu_sw(struct node* hash[],struct alignment* aln,int a,
 				n->next = 0;
 				n->color = 0;
 				
-				n->type = malloc(sizeof(char)*8);
+				n->type = malloc(sizeof(char)*9);
 				n->type[0] = 'w';
 				n->type[1] = 'u';
 				n->type[2] = 'm';
@@ -530,7 +530,7 @@ struct alignment* protein_wu_sw(struct node* hash[],struct alignment* aln,int a,
 				n->next = 0;
 				n->color = 0;
 				
-				n->type = malloc(sizeof(char)*8);
+				n->type = malloc(sizeof(char)*9);
 				n->type[0] = 'w';
 				n->type[1] = 'u';
 				n->type[2] = 'm';

--- a/src/plugins_3rdparty/kalign/src/kalign2/kalign2_tree.c
+++ b/src/plugins_3rdparty/kalign/src/kalign2/kalign2_tree.c
@@ -457,8 +457,8 @@ struct ntree_data* find_best_topology(struct ntree_data* ntree_data,int* leaves,
 	//for (i = 0; i < local_ntree-1;i++){
 	//	k_printf("nodes:%d\n",nodes[i]);
 	//}
-	
 
+    assert(local_ntree>0);
 	tmp_tree = malloc(sizeof(int)*(local_ntree+local_ntree-1)*3);
 	for (c = 0; c < (local_ntree+local_ntree-1)*3;c++){
 		tmp_tree[c] = 0;

--- a/src/plugins_3rdparty/kalign/src/kalign_tests/KalignTests.cpp
+++ b/src/plugins_3rdparty/kalign/src/kalign_tests/KalignTests.cpp
@@ -200,9 +200,9 @@ void Kalign_Load_Align_Compare_Task::run() {
     const QList<MultipleSequenceAlignmentRow> alignedSeqs1 = ma1->getMsa()->getMsaRows();
     const QList<MultipleSequenceAlignmentRow> alignedSeqs2 = ma2->getMsa()->getMsaRows();
 
-    foreach (const MultipleSequenceAlignmentRow& maItem1, alignedSeqs1) {
+    for (const MultipleSequenceAlignmentRow& maItem1 : qAsConst(alignedSeqs1)) {
         bool nameFound = false;
-        foreach (const MultipleSequenceAlignmentRow& maItem2, alignedSeqs2) {
+        for (const MultipleSequenceAlignmentRow& maItem2 : qAsConst(alignedSeqs2)) {
             if (maItem1->getName() == maItem2->getName()) {
                 nameFound = true;
                 if (maItem2->getCoreEnd() != maItem1->getCoreEnd()) {

--- a/src/plugins_3rdparty/primer3/src/FindExonRegionsTask.cpp
+++ b/src/plugins_3rdparty/primer3/src/FindExonRegionsTask.cpp
@@ -96,10 +96,11 @@ Task::ReportResult FindExonRegionsTask::report() {
 
     foreach (GObject* a, relAnns) {
         AnnotationTableObject* att = qobject_cast<AnnotationTableObject*>(a);
-        const QList<Annotation*> anns = att->getAnnotations();
-        foreach (Annotation* ann, anns) {
+        QList<Annotation*> anns = att->getAnnotations();
+        for (Annotation* ann : qAsConst(anns)) {
             if (ann->getName() == exonAnnName) {
-                foreach (const U2Region& r, ann->getRegions()) {
+                QVector<U2Region> regions = ann->getRegions();
+                for (const U2Region& r : qAsConst(regions)) {
                     exonRegions.append(r);
                 }
             }

--- a/src/plugins_3rdparty/primer3/src/Primer3Task.cpp
+++ b/src/plugins_3rdparty/primer3/src/Primer3Task.cpp
@@ -107,32 +107,32 @@ double Primer::getEndStabilyty() const {
     return endStability;
 }
 
-void Primer::setStart(int start) {
-    this->start = start;
+void Primer::setStart(int newStart) {
+    start = newStart;
 }
 
-void Primer::setLength(int length) {
-    this->length = length;
+void Primer::setLength(int newLength) {
+    length = newLength;
 }
 
-void Primer::setMeltingTemperature(double meltingTemperature) {
-    this->meltingTemperature = meltingTemperature;
+void Primer::setMeltingTemperature(double newMeltingTemperature) {
+    meltingTemperature = newMeltingTemperature;
 }
 
-void Primer::setGcContent(double gcContent) {
-    this->gcContent = gcContent;
+void Primer::setGcContent(double newGcContent) {
+    gcContent = newGcContent;
 }
 
-void Primer::setSelfAny(short selfAny) {
-    this->selfAny = selfAny;
+void Primer::setSelfAny(short newSelfAny) {
+    selfAny = newSelfAny;
 }
 
-void Primer::setSelfEnd(short selfEnd) {
-    this->selfEnd = selfEnd;
+void Primer::setSelfEnd(short newSelfEnd) {
+    selfEnd = newSelfEnd;
 }
 
-void Primer::setEndStability(double endStability) {
-    this->endStability = endStability;
+void Primer::setEndStability(double newEndStability) {
+    endStability = newEndStability;
 }
 
 // PrimerPair
@@ -231,28 +231,28 @@ int PrimerPair::getProductSize() const {
     return productSize;
 }
 
-void PrimerPair::setLeftPrimer(Primer* leftPrimer) {
-    this->leftPrimer.reset((nullptr == leftPrimer) ? nullptr : new Primer(*leftPrimer));
+void PrimerPair::setLeftPrimer(Primer* newLeftPrimer) {
+    this->leftPrimer.reset(newLeftPrimer == nullptr ? nullptr : new Primer(*leftPrimer));
 }
 
-void PrimerPair::setRightPrimer(Primer* rightPrimer) {
-    this->rightPrimer.reset((nullptr == rightPrimer) ? nullptr : new Primer(*rightPrimer));
+void PrimerPair::setRightPrimer(Primer* newRightPrimer) {
+    this->rightPrimer.reset(newRightPrimer == nullptr ? nullptr : new Primer(*rightPrimer));
 }
 
-void PrimerPair::setInternalOligo(Primer* internalOligo) {
-    this->internalOligo.reset((nullptr == internalOligo) ? nullptr : new Primer(*internalOligo));
+void PrimerPair::setInternalOligo(Primer* newInternalOligo) {
+    this->internalOligo.reset(newInternalOligo == nullptr ? nullptr : new Primer(*internalOligo));
 }
 
-void PrimerPair::setComplAny(short complAny) {
-    this->complAny = complAny;
+void PrimerPair::setComplAny(short newComplAny) {
+    complAny = newComplAny;
 }
 
-void PrimerPair::setComplEnd(short complEnd) {
-    this->complEnd = complEnd;
+void PrimerPair::setComplEnd(short newComplEnd) {
+    complEnd = newComplEnd;
 }
 
-void PrimerPair::setProductSize(int productSize) {
-    this->productSize = productSize;
+void PrimerPair::setProductSize(int newProductSize) {
+    productSize = newProductSize;
 }
 
 bool PrimerPair::operator<(const PrimerPair& pair) const {
@@ -625,38 +625,26 @@ void Primer3SWTask::prepare() {
     }
 }
 
-inline int getIntersectingRegionIndex(const U2Region& reg, const QList<U2Region>& regions) {
-    for (int i = 0; i < regions.size(); ++i) {
-        const U2Region& targetRegion = regions.at(i);
-        if (targetRegion.contains(reg.startPos)) {
-            return i;
-        }
-    }
-    return -1;
-}
-
 Task::ReportResult Primer3SWTask::report() {
-    foreach (Primer3Task* task, regionTasks) {
+    for (Primer3Task* task : qAsConst(regionTasks)) {
         bestPairs.append(task->getBestPairs());
         singlePrimers.append(task->getSinglePrimers());
     }
 
-    foreach (Primer3Task* task, circRegionTasks) {
-        // relocate primers that were found for sequence splitted in the center
-        QList<PrimerPair> pairs = task->getBestPairs();
-        for (const PrimerPair& p : qAsConst(pairs)) {
+    for (Primer3Task* task : qAsConst(circRegionTasks)) {
+        // Relocate primers that were found for sequence split in the center.
+        foreach (PrimerPair p, task->getBestPairs()) {
             relocatePrimerOverMedian(p.getLeftPrimer());
             relocatePrimerOverMedian(p.getRightPrimer());
-            if (!pairs.contains(p)) {
-                pairs.append(p);
+            if (!bestPairs.contains(p)) {
+                bestPairs.append(p);
             }
         }
 
-        QList<Primer> singles = task->getSinglePrimers();
-        for (Primer p : qAsConst(singles)) {
+        foreach (Primer p, task->getSinglePrimers()) {
             relocatePrimerOverMedian(&p);
-            if (!singles.contains(p)) {
-                singles.append(p);
+            if (!singlePrimers.contains(p)) {
+                singlePrimers.append(p);
             }
         }
     }
@@ -674,14 +662,14 @@ Task::ReportResult Primer3SWTask::report() {
     return Task::ReportResult_Finished;
 }
 
-void Primer3SWTask::addPrimer3Subtasks(const Primer3TaskSettings& settings, const U2Region& rangeToSplit, QList<Primer3Task*>& list) {
+void Primer3SWTask::addPrimer3Subtasks(const Primer3TaskSettings& taskSettings, const U2Region& rangeToSplit, QList<Primer3Task*>& list) {
     QVector<U2Region> regions = SequenceWalkerTask::splitRange(rangeToSplit,
                                                                CHUNK_SIZE,
                                                                0,
                                                                CHUNK_SIZE / 2,
                                                                false);
     foreach (const U2Region& region, regions) {
-        Primer3TaskSettings regionSettings = settings;
+        Primer3TaskSettings regionSettings = taskSettings;
         regionSettings.setIncludedRegion(region);
         Primer3Task* task = new Primer3Task(regionSettings);
         list.append(task);
@@ -689,8 +677,8 @@ void Primer3SWTask::addPrimer3Subtasks(const Primer3TaskSettings& settings, cons
     }
 }
 
-void Primer3SWTask::addPrimer3Subtasks(const Primer3TaskSettings& settings, QList<Primer3Task*>& list) {
-    addPrimer3Subtasks(settings, settings.getIncludedRegion(), list);
+void Primer3SWTask::addPrimer3Subtasks(const Primer3TaskSettings& taskSettings, QList<Primer3Task*>& list) {
+    addPrimer3Subtasks(taskSettings, taskSettings.getIncludedRegion(), list);
 }
 
 void Primer3SWTask::relocatePrimerOverMedian(Primer* primer) {

--- a/src/plugins_3rdparty/primer3/src/Primer3Task.cpp
+++ b/src/plugins_3rdparty/primer3/src/Primer3Task.cpp
@@ -643,18 +643,20 @@ Task::ReportResult Primer3SWTask::report() {
 
     foreach (Primer3Task* task, circRegionTasks) {
         // relocate primers that were found for sequence splitted in the center
-        foreach (PrimerPair p, task->getBestPairs()) {
+        QList<PrimerPair> pairs = task->getBestPairs();
+        for (const PrimerPair& p : qAsConst(pairs)) {
             relocatePrimerOverMedian(p.getLeftPrimer());
             relocatePrimerOverMedian(p.getRightPrimer());
-            if (!bestPairs.contains(p)) {
-                bestPairs.append(p);
+            if (!pairs.contains(p)) {
+                pairs.append(p);
             }
         }
 
-        foreach (Primer p, task->getSinglePrimers()) {
+        QList<Primer> singles = task->getSinglePrimers();
+        for (Primer p : qAsConst(singles)) {
             relocatePrimerOverMedian(&p);
-            if (!singlePrimers.contains(p)) {
-                singlePrimers.append(p);
+            if (!singles.contains(p)) {
+                singles.append(p);
             }
         }
     }

--- a/src/plugins_3rdparty/primer3/src/Primer3Task.cpp
+++ b/src/plugins_3rdparty/primer3/src/Primer3Task.cpp
@@ -103,7 +103,7 @@ short Primer::getSelfEnd() const {
     return selfEnd;
 }
 
-double Primer::getEndStabilyty() const {
+double Primer::getEndStability() const {
     return endStability;
 }
 
@@ -232,15 +232,15 @@ int PrimerPair::getProductSize() const {
 }
 
 void PrimerPair::setLeftPrimer(Primer* newLeftPrimer) {
-    this->leftPrimer.reset(newLeftPrimer == nullptr ? nullptr : new Primer(*leftPrimer));
+    leftPrimer.reset(newLeftPrimer == nullptr ? nullptr : new Primer(*newLeftPrimer));
 }
 
 void PrimerPair::setRightPrimer(Primer* newRightPrimer) {
-    this->rightPrimer.reset(newRightPrimer == nullptr ? nullptr : new Primer(*rightPrimer));
+    rightPrimer.reset(newRightPrimer == nullptr ? nullptr : new Primer(*newRightPrimer));
 }
 
 void PrimerPair::setInternalOligo(Primer* newInternalOligo) {
-    this->internalOligo.reset(newInternalOligo == nullptr ? nullptr : new Primer(*internalOligo));
+    internalOligo.reset(newInternalOligo == nullptr ? nullptr : new Primer(*newInternalOligo));
 }
 
 void PrimerPair::setComplAny(short newComplAny) {

--- a/src/plugins_3rdparty/primer3/src/Primer3Task.h
+++ b/src/plugins_3rdparty/primer3/src/Primer3Task.h
@@ -50,7 +50,7 @@ public:
     double getGcContent() const;
     short getSelfAny() const;
     short getSelfEnd() const;
-    double getEndStabilyty() const;
+    double getEndStability() const;
 
     void setStart(int start);
     void setLength(int length);

--- a/src/plugins_3rdparty/primer3/src/Primer3Task.h
+++ b/src/plugins_3rdparty/primer3/src/Primer3Task.h
@@ -150,8 +150,8 @@ public:
     }
 
 private:
-    void addPrimer3Subtasks(const Primer3TaskSettings& settings, const U2Region& rangeToSplit, QList<Primer3Task*>& listToRemember);
-    void addPrimer3Subtasks(const Primer3TaskSettings& settings, QList<Primer3Task*>& listToRemember);
+    void addPrimer3Subtasks(const Primer3TaskSettings& taskSettings, const U2Region& rangeToSplit, QList<Primer3Task*>& listToRemember);
+    void addPrimer3Subtasks(const Primer3TaskSettings& taskSettings, QList<Primer3Task*>& listToRemember);
     void relocatePrimerOverMedian(Primer* primer);
 
     static const int CHUNK_SIZE = 1024 * 256;

--- a/src/plugins_3rdparty/primer3/src/Primer3Tests.cpp
+++ b/src/plugins_3rdparty/primer3/src/Primer3Tests.cpp
@@ -507,7 +507,7 @@ bool GTest_Primer3::checkPrimer(const Primer* primer, const Primer* expectedPrim
         return false;
     }
     if (!internalOligo) {
-        if (!checkDoubleProperty(primer->getEndStabilyty(), expectedPrimer->getEndStabilyty(), prefix + "_END_STABILITY")) {
+        if (!checkDoubleProperty(primer->getEndStability(), expectedPrimer->getEndStability(), prefix + "_END_STABILITY")) {
             return false;
         }
     }

--- a/src/plugins_3rdparty/ptools/src/PToolsAligner.cpp
+++ b/src/plugins_3rdparty/ptools/src/PToolsAligner.cpp
@@ -48,11 +48,11 @@ static PTools::Rigidbody* createRigidBody(const BioStruct3DReference& subset) {
             region = U2Region(0, biostruct.moleculeMap.value(chainId)->residueMap.size());
         }
 
-        // built in assumtion that order of atoms in BioStruct3D matches order of residues
+        // built in assumption that order of atoms in BioStruct3D matches order of residues
         int i = 0;
-        foreach (const SharedAtom& atom, model.atoms) {
+        for (const SharedAtom& atom : qAsConst(model.atoms)) {
             // take into account only CA atoms (backbone) because subsets may have different residues,
-            // i.e. different number of atoms on the same nuber of residues
+            // i.e. different number of atoms on the same number of residues
             if (atom->name == "CA") {
                 if (i >= region.startPos && i < region.endPos()) {
                     PTools::Atomproperty pproperty;

--- a/src/plugins_3rdparty/sitecon/src/SiteconAlgorithmTests.cpp
+++ b/src/plugins_3rdparty/sitecon/src/SiteconAlgorithmTests.cpp
@@ -135,7 +135,7 @@ void GTest_CalculateDispersionAndAverage::init(XMLTestFormat*, const QDomElement
             stateInfo.setError(QString("Wrong conversion to the integer for one of the %1").arg(DINUCLEOTIDE_POSITIONS));
             return;
         }
-        foreach (QString propStr, propsList) {
+        for (const QString& propStr : qAsConst(propsList)) {
             int propIndex = propStr.toInt(&isOk);
             if (!isOk) {
                 stateInfo.setError(QString("Wrong conversion to the integer for one of the %1").arg(PROPERTIES_INDEXES));
@@ -529,7 +529,7 @@ Task::ReportResult GTest_SiteconSearchTask::report() {
     }
     /**/
     foreach (SiteconSearchResult exp, expectedResults) {
-        foreach (SiteconSearchResult act, results) {
+        for (SiteconSearchResult act : qAsConst(results)) {
             int ePsum = qRound(exp.psum * 10), aPsum = qRound(act.psum * 10);
             if (exp.region == act.region && aPsum == ePsum && exp.strand == act.strand) {
                 matchesCount++;

--- a/src/plugins_3rdparty/sitecon/src/SiteconQuery.cpp
+++ b/src/plugins_3rdparty/sitecon/src/SiteconQuery.cpp
@@ -224,7 +224,7 @@ QList<Task*> QDSiteconTask::onSubTaskFinished(Task* subTask) {
         QList<SiteconModel> models = loadModelsTask->getResult();
         foreach (const U2Region& r, searchRegion) {
             QByteArray seq = dnaSeq.seq.mid(r.startPos, r.length);
-            foreach (const SiteconModel& m, models) {
+            for (const SiteconModel& m : qAsConst(models)) {
                 st.append(new SiteconSearchTask(m, seq, cfg, r.startPos));
             }
         }

--- a/src/plugins_3rdparty/umuscle/src/umuscle_tests/umuscleTests.cpp
+++ b/src/plugins_3rdparty/umuscle/src/umuscle_tests/umuscleTests.cpp
@@ -253,15 +253,15 @@ Task::ReportResult GTest_CompareMAlignment::report() {
     for (int i = 0; i < listSize; i++) {
         MultipleSequenceAlignmentObject* ma1 = qobject_cast<MultipleSequenceAlignmentObject*>(objs1.at(i));
         MultipleSequenceAlignmentObject* ma2 = qobject_cast<MultipleSequenceAlignmentObject*>(objs2.at(i));
-        const QList<MultipleSequenceAlignmentRow> alignedSeqs1 = ma1->getMsa()->getMsaRows();
-        const QList<MultipleSequenceAlignmentRow> alignedSeqs2 = ma2->getMsa()->getMsaRows();
+        QList<MultipleSequenceAlignmentRow> alignedSeqs1 = ma1->getMsa()->getMsaRows();
+        QList<MultipleSequenceAlignmentRow> alignedSeqs2 = ma2->getMsa()->getMsaRows();
         if (ma1->objectName() != ma2->objectName()) {
             stateInfo.setError(QString("MAlignmentObjects name not matched \"%1\", expected \"%2\"").arg(ma1->objectName()).arg(ma2->objectName()));
             return ReportResult_Finished;
         }
         foreach (const MultipleSequenceAlignmentRow& maItem1, alignedSeqs1) {
             bool nameFound = false;
-            foreach (const MultipleSequenceAlignmentRow& maItem2, alignedSeqs2) {
+            for (const MultipleSequenceAlignmentRow& maItem2 : qAsConst(alignedSeqs2)) {
                 if (maItem1->getName() == maItem2->getName()) {
                     nameFound = true;
                     int l1 = maItem1->getCoreEnd();
@@ -304,7 +304,7 @@ void GTest_uMuscleAddUnalignedSequenceToProfile::init(XMLTestFormat* /*tf*/, con
     foreach (const QString& s, gapsPerSeq) {
         QList<int> seqGaps;
         QStringList nums = s.split(',');
-        foreach (const QString& n, nums) {
+        for (const QString& n : qAsConst(nums)) {
             if (n.isEmpty()) {
                 continue;
             }
@@ -737,12 +737,12 @@ QList<Task*> Muscle_Load_Align_Compare_Task::onSubTaskFinished(Task* subTask) {
 }
 
 void Muscle_Load_Align_Compare_Task::run() {
-    const QList<MultipleSequenceAlignmentRow> alignedSeqs1 = ma1->getMsa()->getMsaRows();
-    const QList<MultipleSequenceAlignmentRow> alignedSeqs2 = ma2->getMsa()->getMsaRows();
+    QList<MultipleSequenceAlignmentRow> alignedSeqs1 = ma1->getMsa()->getMsaRows();
+    QList<MultipleSequenceAlignmentRow> alignedSeqs2 = ma2->getMsa()->getMsaRows();
 
-    foreach (const MultipleSequenceAlignmentRow& maItem1, alignedSeqs1) {
+    for (const MultipleSequenceAlignmentRow& maItem1 : qAsConst(alignedSeqs1)) {
         bool nameFound = false;
-        foreach (const MultipleSequenceAlignmentRow& maItem2, alignedSeqs2) {
+        for (const MultipleSequenceAlignmentRow& maItem2 : qAsConst(alignedSeqs2)) {
             if (maItem1->getName() == maItem2->getName()) {
                 nameFound = true;
                 int l1 = maItem1->getCoreLength();

--- a/src/ugene_globals.pri
+++ b/src/ugene_globals.pri
@@ -68,6 +68,9 @@ linux-g++ {
     # See https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
     QMAKE_CXXFLAGS += -Wall
 
+    # TODO: a lot of deprecated declarations after the migration to Qt 5.15.2
+    QMAKE_CXXFLAGS +=-Wno-deprecated-declarations
+
     # To enable 'ugene-warnings-as-errors' block below add the following qmake params:
     # QMAKE_DEFAULT_INCDIRS+="<path-to>/gcc_64/include" QMAKE_PROJECT_DEPTH=0 CONFIG+=ugene-warnings-as-errors
     #

--- a/src/ugenecl/src/DumpHelpTask.cpp
+++ b/src/ugenecl/src/DumpHelpTask.cpp
@@ -110,12 +110,12 @@ void DumpHelpTask::dumpHelp() {
 
     printStringToConsole("%s", "\nAvailable tasks:\n");
     QStringList dataDirs = QDir::searchPaths(PATH_PREFIX_DATA);
-    foreach (const QString& url, dataDirs) {
+    for (const QString& url : qAsConst(dataDirs)) {
         QString dirUrl = url + "/cmdline/";
         QDir dir(dirUrl);
         if (dir.exists()) {
             QStringList entries = dir.entryList(QDir::Files | QDir::Readable);
-            foreach (const QString& file, entries) {
+            for (const QString& file : qAsConst(entries)) {
                 foreach (const QString& ext, WorkflowUtils::WD_FILE_EXTENSIONS) {
                     if (file.endsWith(ext)) {
                         dumpTaskName(file.mid(0, file.size() - ext.size() - 1));  // 1 comes from "."

--- a/src/ugenecl/src/TestStarter.cpp
+++ b/src/ugenecl/src/TestStarter.cpp
@@ -55,7 +55,7 @@ void TestStarter::prepare() {
                 if (!errs.isEmpty()) {
                     ioLog.error("Error reading test suites: \n" + errs.join("\n"));
                 } else {
-                    foreach (GTestSuite* ts, tsl) {
+                    for (GTestSuite* ts : qAsConst(tsl)) {
                         addTestSuite(ts);
                     }
                 }
@@ -214,7 +214,7 @@ TestRunnerTask* TestStarter::createRunTask() {
         return nullptr;
     }
     QList<GTestState*> testsToRun;
-    foreach (GTestSuite* ts, suites) {
+    for (GTestSuite* ts : qAsConst(suites)) {
         foreach (GTestRef* tref, ts->getTests()) {
             testsToRun << new GTestState(tref);
         }
@@ -231,8 +231,7 @@ TestRunnerTask* TestStarter::createRunTask() {
     if (!ok || numberTestsToRun <= 0) {
         numberTestsToRun = 5;
     }
-    TestRunnerTask* ttask = new TestRunnerTask(testsToRun, getEnv(), numberTestsToRun);
-    return ttask;
+    return new TestRunnerTask(testsToRun, getEnv(), numberTestsToRun);
 }
 
 Task::ReportResult TestStarter::report() {

--- a/src/ugeneui/src/Main.cpp
+++ b/src/ugeneui/src/Main.cpp
@@ -383,9 +383,8 @@ static QString findKey(const QStringList& envList, const QString& key) {
     return result;
 }
 
-namespace {
 #ifdef Q_OS_DARWIN
-void fixMacFonts() {
+static void fixMacFonts() {
     if (QSysInfo::MacintoshVersion > QSysInfo::MV_10_8) {
         // fix Mac OS X 10.9 (mavericks) font issue
         // https://bugreports.qt-project.org/browse/QTBUG-32789
@@ -394,7 +393,6 @@ void fixMacFonts() {
     }
 }
 #endif
-}  // namespace
 
 int main(int argc, char** argv) {
     if (CrashHandler::isEnabled()) {
@@ -404,8 +402,6 @@ int main(int argc, char** argv) {
     if (qgetenv(ENV_SEND_CRASH_REPORTS) == "0") {
         CrashHandler::setSendCrashReports(false);
     }
-
-    QT_REQUIRE_VERSION(argc, argv, QT_VERSION_STR);
 
     GTIMER(c1, t1, "main()->QApp::exec");
 

--- a/src/ugeneui/src/plugin_viewer/PluginViewerController.cpp
+++ b/src/ugeneui/src/plugin_viewer/PluginViewerController.cpp
@@ -143,11 +143,11 @@ void PluginViewerController::buildItems() {
         QTreeWidget* treeWidget = ui.treeWidget;
         PlugViewPluginItem* pluginItem = new PlugViewPluginItem(nullptr, p, showServices);
         if (showServices) {
-            const QList<Service*>& services = p->getServices();
+            QList<Service*> services = p->getServices();
             // this method is called for default state init also -> look for registered plugin services
             ServiceRegistry* sr = AppContext::getServiceRegistry();
             QList<Service*> registered = sr->getServices();
-            foreach (Service* s, services) {
+            for (Service* s : qAsConst(services)) {
                 if (registered.contains(s)) {
                     PlugViewTreeItem* serviceItem = new PlugViewServiceItem(pluginItem, s);
                     pluginItem->addChild(serviceItem);

--- a/src/ugeneui/src/project_support/ProjectImpl.cpp
+++ b/src/ugeneui/src/project_support/ProjectImpl.cpp
@@ -73,7 +73,7 @@ void ProjectImpl::makeClean() {
 
 void ProjectImpl::sl_removeAllrelationsWithObject(GObject* obj) {
     QList<GObject*> allObjs;
-    for (Document *d : qAsConst(getDocuments())) {
+    for (Document* d : qAsConst(getDocuments())) {
         allObjs << d->getObjects();
     }
     for (GObject* object : qAsConst(allObjs)) {
@@ -238,7 +238,7 @@ void ProjectImpl::sl_onObjectRelationChanged(const QList<GObjectRelation>& previ
     foreach (Document* d, getDocuments()) {
         allObjs << d->getObjects();
     }
-    foreach (GObject* obj, allObjs) {
+    for (GObject* obj : qAsConst(allObjs)) {
         foreach (const GObjectRelation& rel, relationsSet) {
             if (obj->getEntityRef() == rel.ref.entityRef) {
                 obj->relatedObjectRelationChanged();
@@ -297,7 +297,7 @@ int ProjectImpl::updateReferenceFields(const QString& stateName, QVariantMap& ma
             int nBefore = n;
             QList<GObjectReference> refList = v.value<QList<GObjectReference>>();
             QList<GObjectReference> newRefList;
-            foreach (const GObjectReference& ref, refList) {
+            for (const GObjectReference& ref : qAsConst(refList)) {
                 if (ref == from) {
                     coreLog.trace(QString("Renaming reference in [] state '%1': %2 -> %3").arg(stateName).arg(from.objName).arg(to.objName));
                     newRefList << to;
@@ -338,14 +338,16 @@ void ProjectImpl::updateObjectRelations(const GObjectReference& oldRef, const GO
 }
 void ProjectImpl::removeRelations(const QString& removedDocUrl) {
     foreach (Document* d, getDocuments()) {
-        foreach (GObject* obj, d->getObjects()) {
+        QList<GObject*> objects = d->getObjects();
+        for (GObject* obj : qAsConst(objects)) {
             obj->removeRelations(removedDocUrl);
         }
     }
 }
 
 void ProjectImpl::updateDocInRelations(const QString& oldDocUrl, const QString& newDocUrl) {
-    foreach (Document* d, getDocuments()) {
+    QList<Document*> documents = getDocuments();
+    for (Document* d : qAsConst(documents)) {
         foreach (GObject* obj, d->getObjects()) {
             obj->updateDocInRelations(oldDocUrl, newDocUrl);
         }

--- a/src/ugeneui/src/project_support/ProjectTasksGui.cpp
+++ b/src/ugeneui/src/project_support/ProjectTasksGui.cpp
@@ -237,7 +237,7 @@ void SaveOnlyProjectTask::prepare() {
                 phantomDocs.append(d);
             }
         } else {  // merged document
-            foreach (QString url, urls) {
+            for (const QString& url : qAsConst(urls)) {
                 QFile pathToDoc(url);
                 if (!pathToDoc.exists()) {
                     phantomDocs.append(d);

--- a/src/ugeneui/src/project_view/ProjectViewImpl.cpp
+++ b/src/ugeneui/src/project_view/ProjectViewImpl.cpp
@@ -376,7 +376,7 @@ void DocumentUpdater::reloadDocuments(QList<Document*> docs2Reload) {
     QList<GObjectViewState*> states;
     QList<GObjectViewWindow*> viewWindows;
 
-    foreach (Document* doc, docs2Reload) {
+    for (Document* doc : qAsConst(docs2Reload)) {
         QList<GObjectViewWindow*> viewWnds = GObjectViewUtils::findViewsWithAnyOfObjects(doc->getObjects());
         foreach (GObjectViewWindow* vw, viewWnds) {
             viewWindows.append(vw);
@@ -826,9 +826,9 @@ QList<QAction*> ProjectViewImpl::selectOpenViewActions(GObjectViewFactory* f, co
             if (ov->getViewFactoryId() != f->getId()) {
                 continue;
             }
-            const QList<GObject*>& viewObjects = ov->getObjects();
+            QList<GObject*> viewObjects = ov->getObjects();
             bool contains = false;
-            foreach (GObject* o, viewObjects) {
+            for (GObject* o : qAsConst(viewObjects)) {
                 if (objectsInSelection.contains(o) && !projectTreeController->isObjectInRecycleBin(o)) {
                     contains = true;
                     break;
@@ -878,7 +878,7 @@ QList<QAction*> ProjectViewImpl::selectOpenViewActions(GObjectViewFactory* f, co
 
 void ProjectViewImpl::buildOpenViewMenu(const MultiGSelection& ms, QMenu* m) {
     QList<GObjectViewFactory*> fs = AppContext::getObjectViewFactoryRegistry()->getAllFactories();
-    foreach (GObjectViewFactory* f, fs) {
+    for (GObjectViewFactory* f : qAsConst(fs)) {
         QList<QAction*> openActions = selectOpenViewActions(f, ms, m);
         if (openActions.isEmpty()) {
             continue;
@@ -889,7 +889,7 @@ void ProjectViewImpl::buildOpenViewMenu(const MultiGSelection& ms, QMenu* m) {
             m->addAction(openAction);
             continue;
         }
-        foreach (QAction* a, openActions) {
+        for (QAction* a : qAsConst(openActions)) {
             m->addAction(a);
         }
     }
@@ -939,7 +939,7 @@ void ProjectViewImpl::buildRelocateMenu(QMenu* m) {
                 allWritableFormats.append(format);
             }
         }
-        foreach (DocumentFormat* f, allWritableFormats) {
+        for (DocumentFormat* f : qAsConst(allWritableFormats)) {
             const QSet<GObjectType>& supportedObjectTypes = f->getSupportedObjectTypes();
             bool allObjectsWitable = true;
             foreach (GObject* gobj, doc->getObjects()) {


### PR DESCRIPTION
Most of the problems are with nested foreach-loop. Qt 5.15 in this case shadows parent loop variables.