### PR TITLE
Add libxcb-xinerama.so.0 to the Linux release bundle

### DIFF
--- a/etc/script/linux/copy_qt_files_to_ugene.sh
+++ b/etc/script/linux/copy_qt_files_to_ugene.sh
@@ -33,6 +33,8 @@ mkdir "${UGENE_DIR}/platforms"
 cp "${QT_DIR}/plugins/platforms/libqxcb.so" "${UGENE_DIR}/platforms"
 # shellcheck disable=SC2016
 patchelf --force-rpath --set-rpath '$ORIGIN/..' "${UGENE_DIR}/platforms"/*.so
+# Qt 5.15 requires external libxcb-xinerama.so.0 library.
+cp "${QT_DIR}/libxcb-xinerama.so.0" "${UGENE_DIR}/"
 
 # Image formats.
 rm -rf "${UGENE_DIR}/imageformats"

--- a/etc/script/linux/copy_qt_files_to_ugene.sh
+++ b/etc/script/linux/copy_qt_files_to_ugene.sh
@@ -34,7 +34,7 @@ cp "${QT_DIR}/plugins/platforms/libqxcb.so" "${UGENE_DIR}/platforms"
 # shellcheck disable=SC2016
 patchelf --force-rpath --set-rpath '$ORIGIN/..' "${UGENE_DIR}/platforms"/*.so
 # Qt 5.15 requires external libxcb-xinerama.so.0 library.
-cp "${QT_DIR}/libxcb-xinerama.so.0" "${UGENE_DIR}/"
+cp "${QT_DIR}/lib_extra/libxcb-xinerama.so.0" "${UGENE_DIR}/"
 
 # Image formats.
 rm -rf "${UGENE_DIR}/imageformats"

--- a/etc/script/linux/release-bundle.txt
+++ b/etc/script/linux/release-bundle.txt
@@ -1229,7 +1229,6 @@ imageformats/libqtiff.so
 imageformats/libqwbmp.so
 imageformats/libqwebp.so
 libbreakpad.so
-libxcb-xinerama.so.0
 libQt5Core.so.5
 libQt5DBus.so.5
 libQt5Gui.so.5
@@ -1253,6 +1252,7 @@ libU2Script.so
 libU2Test.so
 libU2View.so
 libugenedb.so
+libxcb-xinerama.so.0
 LICENSE.3rd_party.txt
 LICENSE.txt
 platforms

--- a/etc/script/linux/release-bundle.txt
+++ b/etc/script/linux/release-bundle.txt
@@ -1229,6 +1229,7 @@ imageformats/libqtiff.so
 imageformats/libqwbmp.so
 imageformats/libqwebp.so
 libbreakpad.so
+libxcb-xinerama.so.0
 libQt5Core.so.5
 libQt5DBus.so.5
 libQt5Gui.so.5


### PR DESCRIPTION
QT 5.15 dropped built-in version support for this library so we need to add it into our distribution.
Right now I'm testing that the library added works on all Linuxes I have locally (via Virtual Box)