### PR TITLE
Enable antialiasing for tree nodes

### DIFF
--- a/src/corelibs/U2View/src/ov_phyltree/GraphicsButtonItem.cpp
+++ b/src/corelibs/U2View/src/ov_phyltree/GraphicsButtonItem.cpp
@@ -39,14 +39,14 @@ namespace U2 {
 /** Button radius in pixels. */
 static constexpr double radius = 5;
 
-static const QBrush normalStateBrush(Qt::gray);
+static const QBrush normalStateBrush(Qt::lightGray);
 static const QBrush selectedStateBrush(QColor("#EA9700"));
 static const QBrush hoveredStateBrush(QColor("#FFA500"));  // The same hue as selected but lighter.
 
 GraphicsButtonItem::GraphicsButtonItem(double nodeValue)
     : QGraphicsEllipseItem(QRectF(-radius, -radius, 2 * radius, 2 * radius)),
       nodeValue(nodeValue) {
-    setPen(QColor(0, 0, 0));
+    setPen(QColor(Qt::black));
     setAcceptHoverEvents(true);
     setZValue(2);
     setFlag(QGraphicsItem::ItemIsSelectable);
@@ -196,7 +196,7 @@ GraphicsBranchItem* GraphicsButtonItem::getRightBranchItem() const {
 
 void GraphicsButtonItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) {
     setBrush(isHovered ? hoveredStateBrush : (isSelected() ? selectedStateBrush : normalStateBrush));
-
+    painter->setRenderHint(QPainter::Antialiasing);
     // Drop the default 'selected' & 'focused' decoration: we draw these states by ourselves using a custom brush.
     QStyleOptionGraphicsItem clonedStyleOption(*option);
     clonedStyleOption.state.setFlag(QStyle::State_Selected, false);


### PR DESCRIPTION
I tried to enable a full-scene anti-aliasing and got non obvious result for branches: they look blurry and it is better to ask user directly if they want or not use anti-aliasing globally.

But for the nodes the result is clear: anti-aliasing results to a cleaner image with less artifacts.

I attached screenshots. Please check them in full resolution because image resize also runs anti-aliasing.

Before:
![no-antialiasing](https://user-images.githubusercontent.com/17791039/192391023-d00abc0a-c05c-40ef-a9e1-03433db18798.png)

After:
![with-antialiasing](https://user-images.githubusercontent.com/17791039/192391027-e9f14f67-a60a-419a-9c68-0b6276992182.png)

Light-gray color (less accent on nodes)
![with-antialiasing-lightGray](https://user-images.githubusercontent.com/17791039/192391028-3587dff8-febb-4031-a293-174263250c8a.png)

TODO: I still need to check it on MacOS and Windows.
