### PR TITLE
Disable visualization of tree nodes by default.

### DIFF
--- a/src/corelibs/U2View/src/ov_phyltree/TreeViewer.cpp
+++ b/src/corelibs/U2View/src/ov_phyltree/TreeViewer.cpp
@@ -606,7 +606,7 @@ void TreeViewerUI::initializeSettings() {
     setOptionValue(BREADTH_SCALE_ADJUSTMENT_PERCENT, 100);
     setOptionValue(BRANCH_CURVATURE, 0);
 
-    setOptionValue(SHOW_NODE_SHAPE, true);
+    setOptionValue(SHOW_NODE_SHAPE, false);
     // TODO: these 2 options are not shown and not used. Make them used again & use correct defaults.
     setOptionValue(NODE_RADIUS, 2);
     setOptionValue(NODE_COLOR, QColor(0, 0, 0));

--- a/src/corelibs/U2View/src/ov_phyltree/item/TvNodeItem.cpp
+++ b/src/corelibs/U2View/src/ov_phyltree/item/TvNodeItem.cpp
@@ -58,6 +58,8 @@ TvNodeItem::TvNodeItem(const QString& _nodeName)
         QRectF rect = labelItem->boundingRect();
         labelItem->setPos(TvBranchItem::TEXT_SPACING, -rect.height() / 2);
         labelItem->setZValue(1);
+        // TODO: create a default tree viewer settings provider used both by TreeOptionsWidget and items.
+        //  Or pass initial settings into the every item constructor.
         labelItem->setVisible(false);
     }
 }

--- a/src/corelibs/U2View/src/ov_phyltree/item/TvNodeItem.h
+++ b/src/corelibs/U2View/src/ov_phyltree/item/TvNodeItem.h
@@ -39,7 +39,7 @@ class TvTextItem;
 
 class U2VIEW_EXPORT TvNodeItem : public QGraphicsEllipseItem {
 public:
-    TvNodeItem(const QString& nodeName = 0);
+    TvNodeItem(const QString& nodeName = nullptr);
 
     bool isPathToRootSelected() const;
 
@@ -74,7 +74,12 @@ protected:
     TreeViewerUI* getTreeViewerUI() const;
 
     bool isHovered = false;
-    bool isNodeShapeVisible = true;
+
+    /**
+     * TODO: create a default tree viewer settings provider used both by TreeOptionsWidget and items.
+     *  Or pass initial settings into the every item constructor.
+     */
+    bool isNodeShapeVisible = false;
 };
 
 }  // namespace U2

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/tree_viewer/GTTestsCommonScenariousTreeviewer.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/tree_viewer/GTTestsCommonScenariousTreeviewer.cpp
@@ -1133,30 +1133,30 @@ GUI_TEST_CLASS_DEFINITION(test_0031) {
 
     GTUtilsOptionPanelPhyTree::openTab(os);
 
-    GTCheckBox::checkState(os, "showNodeShapeCheck", true);
-    QImage imageWithNodes = GTUtilsPhyTree::captureTreeImage(os);
-
-    GTCheckBox::setChecked(os, "showNodeShapeCheck", false);
-    QImage imageWithoutNodes = GTUtilsPhyTree::captureTreeImage(os);
-    CHECK_SET_ERR(imageWithNodes != imageWithoutNodes, "Image with no nodes is the same with the image with nodes");
+    GTCheckBox::checkState(os, "showNodeShapeCheck", false);
+    QImage originalImage = GTUtilsPhyTree::captureTreeImage(os);
 
     GTCheckBox::setChecked(os, "showNodeShapeCheck", true);
-    QImage image = GTUtilsPhyTree::captureTreeImage(os);
-    CHECK_SET_ERR(image == imageWithNodes, "Image with no nodes does not match the original image");
+    QImage imageWithNodes = GTUtilsPhyTree::captureTreeImage(os);
+    CHECK_SET_ERR(imageWithNodes != originalImage, "imageWithNodes != originalImage failed");
 
-    // No check the same but with selected nodes.
+    GTCheckBox::setChecked(os, "showNodeShapeCheck", false);
+    QImage imageWithNoNodes = GTUtilsPhyTree::captureTreeImage(os);
+    CHECK_SET_ERR(imageWithNoNodes == originalImage, "imageWithNoNodes == originalImage failed");
+
+    // Now check the same but with selected nodes.
     GTUtilsPhyTree::clickNode(os, GTUtilsPhyTree::getNodeByBranchText(os, "0.003", "0.038"));
     GTMouseDriver::moveTo(GTMouseDriver::getMousePosition() + QPoint(20, 0));  // Remove hover effect from node.
-    QImage imageWithSelectionWithNodes = GTUtilsPhyTree::captureTreeImage(os);
-    CHECK_SET_ERR(imageWithSelectionWithNodes != imageWithNodes, "Image with selected node must be different");
-
-    GTCheckBox::setChecked(os, "showNodeShapeCheck", false);
-    QImage imageWithSelectionWithoutNodes = GTUtilsPhyTree::captureTreeImage(os);
-    CHECK_SET_ERR(imageWithSelectionWithNodes != imageWithSelectionWithoutNodes, "Image with selection not changed after hiding nodes");
+    QImage originalImageWithSelection = GTUtilsPhyTree::captureTreeImage(os);
+    CHECK_SET_ERR(originalImageWithSelection != originalImage, "imageWithSelection != originalImage failed");
 
     GTCheckBox::setChecked(os, "showNodeShapeCheck", true);
-    QImage imageWithSelectionWithNodesAfter = GTUtilsPhyTree::captureTreeImage(os);
-    CHECK_SET_ERR(imageWithSelectionWithNodesAfter == imageWithSelectionWithNodes, "Image with selection not matched original image");
+    QImage imageWithSelectionWithNodes = GTUtilsPhyTree::captureTreeImage(os);
+    CHECK_SET_ERR(imageWithSelectionWithNodes != originalImageWithSelection, "imageWithSelectionWithNodes != originalImageWithSelection failed");
+
+    GTCheckBox::setChecked(os, "showNodeShapeCheck", false);
+    QImage imageWithSelectionWithNoNodes = GTUtilsPhyTree::captureTreeImage(os);
+    CHECK_SET_ERR(imageWithSelectionWithNoNodes == originalImageWithSelection, "imageWithSelectionWithNoNodes == originalImageWithSelection failed");
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0032) {


### PR DESCRIPTION
This is same as in other tools: nodes are only shown on hover, but not on the static image by default.
User still can return the old behavior back using "Show nodes" settings in the option panel.

The new mode has some advantages: it is more familiar to users (google tree images) and has better scaling ranges (nodes are intractable fixed size elements and do not scale)

![image](https://user-images.githubusercontent.com/17791039/193724505-440c648e-f976-42cb-b89e-0d5264fdf5fa.png)
