### PR TITLE
Rework PhyTree branches model & algorithms: use explicit parent/child…

### DIFF
--- a/src/corelibs/U2Core/src/datatype/PhyTree.cpp
+++ b/src/corelibs/U2Core/src/datatype/PhyTree.cpp
@@ -128,12 +128,14 @@ PhyNode* PhyNode::clone() const {
     collectNodesPreOrder(allNodesInTree);
 
     QList<PhyBranch*> allBranchesInTree;
-    QMap<const PhyNode*, PhyNode*> clonedNodeByOriginalNode;
+    QHash<const PhyNode*, PhyNode*> clonedNodeByOriginalNode;
     for (const PhyNode* originalNode : qAsConst(allNodesInTree)) {
         auto clonedNode = new PhyNode();
         clonedNode->name = originalNode->name;
         clonedNodeByOriginalNode[originalNode] = clonedNode;
-        allBranchesInTree.append(originalNode->parentBranch);
+        if (originalNode->parentBranch) {
+            allBranchesInTree.append(originalNode->parentBranch);
+        }
     }
     for (PhyBranch* originalBranch : qAsConst(allBranchesInTree)) {
         PhyNode* parentClonedNode = clonedNodeByOriginalNode[originalBranch->parentNode];

--- a/src/corelibs/U2Core/src/datatype/PhyTree.cpp
+++ b/src/corelibs/U2Core/src/datatype/PhyTree.cpp
@@ -62,203 +62,125 @@ PhyNode* PhyTreeData::getRootNode() const {
 }
 
 void PhyTreeData::print() const {
-    QList<PhyNode*> nodes;
-    int tab = 0;
-    int distance = 0;
-    rootNode->print(nodes, distance, tab);
+    rootNode->print();
 }
 
 QList<PhyNode*> PhyTreeData::getNodesPreOrder() const {
+    CHECK(rootNode != nullptr, {});
     QList<PhyNode*> nodes;
-    if (rootNode != nullptr) {
-        rootNode->addIfNotPreset(nodes);
-    }
+    rootNode->getNodesPreOrder(nodes);
     return nodes;
 }
 
-const QList<PhyBranch*>& PhyNode::getBranches() const {
-    return branches;
+const QList<PhyBranch*>& PhyNode::getChildBranches() const {
+    return childBranches;
 }
 
-const PhyNode* PhyNode::getSecondNodeOfBranch(int branchNumber) const {
-    SAFE_POINT(branchNumber < branches.size() && branchNumber >= 0, "Invalid branch number", nullptr);
-    return branches.at(branchNumber)->node2;
+const PhyBranch* PhyNode::getParentBranch() const {
+    return parentBranch;
 }
 
-void PhyNode::addIfNotPreset(QList<PhyNode*>& nodes) {
-    CHECK(!nodes.contains(this), );
+PhyBranch* PhyNode::getParentBranch() {
+    return parentBranch;
+}
+
+const PhyBranch* PhyNode::getChildBranchByIndex(int branchIndex) const {
+    SAFE_POINT(branchIndex >= 0 && branchIndex < childBranches.size(), "Invalid child branch index: " + QString::number(branchIndex), nullptr);
+    return childBranches.at(branchIndex);
+}
+
+void PhyNode::getNodesPreOrder(QList<PhyNode*>& nodes) {
     nodes.append(this);
-    for (PhyBranch* b : qAsConst(branches)) {
-        assert(b->node1 != nullptr && b->node2 != nullptr);
-        b->node1->addIfNotPreset(nodes);
-        b->node2->addIfNotPreset(nodes);
+    for (PhyBranch* branch : qAsConst(childBranches)) {
+        branch->childNode->getNodesPreOrder(nodes);
     }
 }
 
-void PhyNode::addIfNotPreset(QList<const PhyNode*>& nodes) const {
-    CHECK(!nodes.contains(this), );
+void PhyNode::getNodesPreOrder(QList<const PhyNode*>& nodes) const {
     nodes.append(this);
-    for (PhyBranch* b : qAsConst(branches)) {
-        assert(b->node1 != nullptr && b->node2 != nullptr);
-        b->node1->addIfNotPreset(nodes);
-        b->node2->addIfNotPreset(nodes);
+    for (PhyBranch* branch : qAsConst(childBranches)) {
+        branch->childNode->getNodesPreOrder(nodes);
     }
 }
 
 bool PhyNode::isConnected(const PhyNode* node) const {
-    foreach (PhyBranch* b, branches) {
-        if (b->node1 == node || b->node2 == node) {
-            return true;
-        }
-    }
-    return false;
-}
-
-PhyNode* PhyNode::parent() const {
-    foreach (PhyBranch* currentBrunch, branches) {
-        if (currentBrunch->node2 == this)
-            return currentBrunch->node1;
-    }
-    return nullptr;
+    CHECK(node != getParentNode(), true);
+    return std::any_of(childBranches.begin(), childBranches.end(), [node](auto branch) { return branch->childNode == node; });
 }
 
 const PhyNode* PhyNode::getParentNode() const {
-    return parent();
+    return parentBranch == nullptr ? nullptr : parentBranch->parentNode;
 }
 
 PhyNode* PhyNode::getParentNode() {
-    return parent();
+    return parentBranch == nullptr ? nullptr : parentBranch->parentNode;
 }
 
 bool PhyNode::isLeafNode() const {
-    return branches.size() == 1 && branches[0] == getParentBranch();
+    return childBranches.isEmpty();
 }
 
-void PhyNode::setParentNode(PhyNode* newParent, double distance) {
-    int branchesNumber = branches.size();
-    for (int i = 0; i < branchesNumber; i++) {
-        PhyBranch* currentBrunch = branches.at(i);
-
-        if (currentBrunch->node1 == newParent) {
-            return;
-        } else if (currentBrunch->node2 == newParent) {
-            // Invert branch nodes if newParent currently is a child
-            currentBrunch->node1 = newParent;
-            currentBrunch->node2 = this;
-            currentBrunch->distance = distance;
-            return;
-        } else if (currentBrunch->node2 == this) {
-            // Remove link between the node and previous parent
-            PhyNode* parentNode = currentBrunch->node1;
-            if (nullptr != parentNode) {
-                parentNode->branches.removeOne(currentBrunch);
-            }
-            // Link the node to the new parent
-            if (nullptr != newParent) {
-                currentBrunch->node1 = newParent;
-                currentBrunch->distance = distance;
-                newParent->branches.append(currentBrunch);
-            }
-            return;
-        }
-    }
-
-    auto branch = new PhyBranch();
-    branch->distance = distance;
-    branch->node1 = newParent;
-    branch->node2 = this;
-
-    newParent->branches.append(branch);
-    branches.append(branch);
+bool PhyNode::isRootNode() const {
+    return parentBranch == nullptr;
 }
 
 QList<PhyNode*> PhyNode::getChildNodes() const {
     QList<PhyNode*> childNodes;
-    for (PhyBranch* branch : qAsConst(branches)) {
-        if (branch->node1 == this) {
-            childNodes.append(branch->node2);
-        }
+    for (PhyBranch* childBranch : qAsConst(childBranches)) {
+        childNodes.append(childBranch->childNode);
     }
     return childNodes;
 }
 
-const PhyBranch* PhyNode::getParentBranch() const {
-    foreach (PhyBranch* branch, branches) {
-        if (branch->node2 == this) {
-            return branch;
-        }
-    }
-
-    return nullptr;
-}
-
 PhyNode::~PhyNode() {
-    for (PhyBranch* branch : branches) {
-        SAFE_POINT(branch != nullptr, "NULL pointer to PhyBranch", );
-        PhyNode* childNode = branch->node2;
-        SAFE_POINT(childNode != nullptr, "NULL pointer to PhyNode", );
-        if (childNode != this) {
-            childNode->branches.removeOne(branch);
-            delete childNode;
-        } else {
-            PhyNode* parentNode = branch->node1;
-            if (parentNode != nullptr) {
-                parentNode->branches.removeOne(branch);
-            }
-        }
-        delete branch;
+    // Delete branch connected to parent.
+    unlinkFromParent();
+
+    // Delete all child nodes. These nodes will auto-delete their parent branches first.
+    for (PhyBranch* childBranch : childBranches) {
+        PhyNode* childNode = childBranch->childNode;
+        SAFE_POINT(childNode->getParentNode() == this, "Child node has incorrect parent!", );
+        delete childNode;
     }
 }
 
 PhyNode* PhyNode::clone() const {
-    QList<const PhyNode*> nodesPreOrder;
-    addIfNotPreset(nodesPreOrder);
+    QList<const PhyNode*> allNodesInTree;
+    getNodesPreOrder(allNodesInTree);
 
-    QList<PhyBranch*> allBranches;
-    QMap<const PhyNode*, PhyNode*> nodeTable;
-    for (const PhyNode* n : qAsConst(nodesPreOrder)) {
-        auto n2 = new PhyNode();
-        n2->name = n->name;
-        nodeTable[n] = n2;
-        for (PhyBranch* b : qAsConst(n->branches)) {
-            if (!allBranches.contains(b)) {
-                allBranches.append(b);
-            }
-        }
+    QList<PhyBranch*> allBranchesInTree;
+    QMap<const PhyNode*, PhyNode*> clonedNodeByOriginalNode;
+    for (const PhyNode* originalNode : qAsConst(allNodesInTree)) {
+        auto clonedNode = new PhyNode();
+        clonedNode->name = originalNode->name;
+        clonedNodeByOriginalNode[originalNode] = clonedNode;
+        allBranchesInTree.append(originalNode->parentBranch);
     }
-    for (PhyBranch* b : qAsConst(allBranches)) {
-        PhyNode* node1 = nodeTable[b->node1];
-        PhyNode* node2 = nodeTable[b->node2];
-        assert(node1 != nullptr && node2 != nullptr);
-        PhyTreeUtils::addBranch(node1, node2, b->distance);
+    for (PhyBranch* originalBranch : qAsConst(allBranchesInTree)) {
+        PhyNode* parentClonedNode = clonedNodeByOriginalNode[originalBranch->parentNode];
+        PhyNode* childClonedNode = clonedNodeByOriginalNode[originalBranch->childNode];
+        SAFE_POINT(parentClonedNode != nullptr && childClonedNode != nullptr, "Cloned node not found!", nullptr);
+        PhyTreeUtils::addBranch(parentClonedNode, childClonedNode, originalBranch->distance);
     }
-    PhyNode* myClone = nodeTable.value(this);
-    assert(myClone != nullptr);
-    return myClone;
+    PhyNode* clonedNode = clonedNodeByOriginalNode.value(this);
+    SAFE_POINT(clonedNode != nullptr, "Cloned node not found for the current node", nullptr);
+    return clonedNode;
 }
 
-void PhyNode::print(QList<PhyNode*>& nodes, int tab, int distance) {
-    if (nodes.contains(this)) {
-        return;
-    }
-    nodes.append(this);
+void PhyNode::print(int tab, int distance) const {
     for (int i = 0; i < tab; i++) {
         std::cout << " ";
     }
     tab++;
     std::cout << "name: " << this->name.toLatin1().constData() << " distance: " << distance << std::endl;
-    QList<PhyBranch*> branchList = this->branches;
+    QList<PhyBranch*> branchList = this->childBranches;
     int s = branchList.size();
     for (int i = 0; i < s; i++) {
-        if (branchList[i]->node2 != nullptr) {
+        if (branchList[i]->childNode != nullptr) {
             int d = branchList[i]->distance;
-            branchList[i]->node2->print(nodes, tab, d);
+            branchList[i]->childNode->print(tab, d);
         }
     }
-}
-
-void PhyNode::swapBranches(int branchIndex1, int branchIndex2) {
-    branches.swap(branchIndex1, branchIndex2);
 }
 
 double PhyNode::getDistanceToRoot() const {
@@ -277,97 +199,57 @@ double PhyNode::getDistanceToRoot() const {
     return distanceToRoot;
 }
 
-int PhyTreeUtils::getNumSeqsFromNode(const PhyNode* node, const QSet<QString>& names) {
-    int size = node->branches.size();
-    if (size > 1) {
-        int s = 0;
-        for (int i = 0; i < size; ++i) {
-            if (node->branches[i]->node2 != node) {
-                int num = getNumSeqsFromNode(node->branches[i]->node2, names);
-                if (!num) {
-                    return 0;
-                }
-                s += num;
-            }
-        }
-        return s;
-    } else {
-        QString str = node->name;
-        return names.contains(str.replace('_', ' ')) ? 1 : 0;
+int PhyNode::countLeafNodesInSubtree() const {
+    int leafNodes = 0;
+    for (auto childBranch : qAsConst(childBranches)) {
+        leafNodes += childBranch->childNode->countLeafNodesInSubtree();
     }
+    return qMax(1, leafNodes);  // Count self (1) if there are no children.
+}
+
+void PhyNode::invertOrderOrChildBranches() {
+    std::reverse(childBranches.begin(), childBranches.end());
+}
+
+void PhyNode::makeRoot() {
+    CHECK(!isRootNode(), );
+    parentBranch->parentNode->makeRoot();
+    SAFE_POINT(parentBranch->parentNode->isRootNode(), "Parent branch must be a root branch.", );
+
+    parentBranch->parentNode->childBranches.removeOne(parentBranch);
+    parentBranch->parentNode->parentBranch = parentBranch;
+    parentBranch->childNode = parentBranch->parentNode;
+    parentBranch->parentNode = this;
+    childBranches.append(parentBranch);
+    parentBranch = nullptr;
 }
 
 void PhyTreeUtils::rerootPhyTree(PhyTree& phyTree, PhyNode* node) {
-    PhyNode* curRoot = phyTree->getRootNode();
-    SAFE_POINT(nullptr != curRoot, "Null pointer argument 'curRoot' were passed to PhyTreeUtils::rerootPhyTree(...)", );
-    SAFE_POINT(nullptr != node, "Null pointer argument 'node' were passed to PhyTreeUtils::rerootPhyTree(...)", );
-    CHECK(node != curRoot, );
-
-    PhyNode* centralNode = node->getParentNode();
-    if (centralNode == curRoot) {
-        if (centralNode->getChildNodes().at(0) != node) {
-            centralNode->swapBranches(0, 1);
-        }
-        return;
-    }
-    auto newRootNode = new PhyNode();
-    PhyNode* newParentNode = newRootNode;
-    double distance = node->getDistanceToRoot() - newRootNode->getDistanceToRoot();
-    node->setParentNode(newRootNode, distance);
-    PhyNode* oldParent = centralNode->getParentNode();
-    if (oldParent != nullptr) {
-        distance = centralNode->getDistanceToRoot() - newRootNode->getDistanceToRoot();
-        centralNode->setParentNode(newRootNode, distance);
-    }
-
-    const PhyNode* firstNode = oldParent;
-    while (oldParent != nullptr) {
-        PhyNode* s = oldParent->getParentNode();
-        SAFE_POINT(s != firstNode, "There is cyclic graph in the phylogenetic tree", );
-        distance = oldParent->getDistanceToRoot() - centralNode->getDistanceToRoot();
-        oldParent->setParentNode(centralNode, distance);
-
-        newParentNode = centralNode;
-        centralNode = oldParent;
-        oldParent = s;
-    }
-
-    if (centralNode->getChildNodes().size() == 1) {
-        /* remove old root */
-        oldParent = centralNode->getChildNodes().at(0);
-        distance = oldParent->getDistanceToRoot() - newParentNode->getDistanceToRoot();
-        oldParent->setParentNode(newParentNode, distance);
-        delete centralNode;
-    }
-
-    phyTree->setRootNode(newRootNode);
+    CHECK(!node->isRootNode(), );
+    node->makeRoot();
+    phyTree->setRootNode(node);
 }
 
-PhyBranch* PhyTreeUtils::addBranch(PhyNode* node1, PhyNode* node2, double distance) {
-    SAFE_POINT(!node1->isConnected(node2), "node1 is not connected to node2", nullptr);
+PhyBranch* PhyTreeUtils::addBranch(PhyNode* parentNode, PhyNode* childNode, double distance) {
+    SAFE_POINT(childNode->parentBranch == nullptr, "PhyTreeUtils::addBranch child branch must have no parent.", nullptr);
+    SAFE_POINT(!childNode->isConnected(parentNode), "PhyTreeUtils::addBranch nodes are already connected", nullptr);
 
     auto newBranch = new PhyBranch();
     newBranch->distance = distance;
-    newBranch->node1 = node1;
-    newBranch->node2 = node2;
+    newBranch->parentNode = parentNode;
+    newBranch->childNode = childNode;
 
-    node1->branches.append(newBranch);
-    node2->branches.append(newBranch);
+    parentNode->childBranches.append(newBranch);
+    childNode->parentBranch = newBranch;
 
     return newBranch;
 }
 
-void PhyTreeUtils::removeBranch(PhyNode* node1, PhyNode* node2) {
-    QList<PhyBranch*> node1BranchesBeforeRemove = node1->branches;
-    for (PhyBranch* branch : qAsConst(node1BranchesBeforeRemove)) {
-        if (branch->node1 == node1 && branch->node2 == node2) {
-            node1->branches.removeAll(branch);
-            node2->branches.removeAll(branch);
-            delete branch;
-            break;
-        }
-    }
-    SAFE_POINT(node1BranchesBeforeRemove.size() == node1->branches.size() + 1, "Branch is not found", );
+void PhyNode::unlinkFromParent() {
+    CHECK(parentBranch != nullptr, );
+    parentBranch->parentNode->childBranches.removeOne(parentBranch);
+    delete parentBranch;
+    parentBranch = nullptr;
 }
 
 }  // namespace U2

--- a/src/corelibs/U2Core/src/datatype/PhyTree.cpp
+++ b/src/corelibs/U2Core/src/datatype/PhyTree.cpp
@@ -84,11 +84,6 @@ PhyBranch* PhyNode::getParentBranch() {
     return parentBranch;
 }
 
-const PhyBranch* PhyNode::getChildBranchByIndex(int branchIndex) const {
-    SAFE_POINT(branchIndex >= 0 && branchIndex < childBranches.size(), "Invalid child branch index: " + QString::number(branchIndex), nullptr);
-    return childBranches.at(branchIndex);
-}
-
 void PhyNode::getNodesPreOrder(QList<PhyNode*>& nodes) {
     nodes.append(this);
     for (PhyBranch* branch : qAsConst(childBranches)) {

--- a/src/corelibs/U2Core/src/datatype/PhyTree.h
+++ b/src/corelibs/U2Core/src/datatype/PhyTree.h
@@ -87,36 +87,26 @@ public:
     PhyNode() = default;
     ~PhyNode();
 
+    PhyBranch* getParentBranch() const;
+
+    PhyNode* getParentNode() const;
+
     const QList<PhyBranch*>& getChildBranches() const;
 
-    const PhyBranch* getParentBranch() const;
-
-    PhyBranch* getParentBranch();
-
     /** Adds current node and all node children into the collection using pre-order algorithm. */
-    void getNodesPreOrder(QList<PhyNode*>& nodes);
-    void getNodesPreOrder(QList<const PhyNode*>& nodes) const;
+    void collectNodesPreOrder(QList<PhyNode*>& nodes);
+    void collectNodesPreOrder(QList<const PhyNode*>& nodes) const;
 
     bool isConnected(const PhyNode* node) const;
 
     /** Clones current node & sub-tree. */
     PhyNode* clone() const;
 
-    /* For distance matrix */
-    const PhyNode* getParentNode() const;
-
-    PhyNode* getParentNode();
-
     /** Prints sub-tree to stdout. */
     void print(int distance = 0, int tabSize = 0) const;
 
-    /** Returns direct child nodes of this node. To get all nodes use getNodesPreOrder(). */
-    QList<PhyNode*> getChildNodes() const;
-
     /**Inverts order of the child node branches. */
     void invertOrderOrChildBranches();
-
-    double getDistanceToRoot() const;
 
     /** Returns true if the node is a leaf (tip) node in the tree. */
     bool isLeafNode() const;

--- a/src/corelibs/U2Core/src/datatype/PhyTree.h
+++ b/src/corelibs/U2Core/src/datatype/PhyTree.h
@@ -93,8 +93,6 @@ public:
 
     PhyBranch* getParentBranch();
 
-    const PhyBranch* getChildBranchByIndex(int branchIndex) const;
-
     /** Adds current node and all node children into the collection using pre-order algorithm. */
     void getNodesPreOrder(QList<PhyNode*>& nodes);
     void getNodesPreOrder(QList<const PhyNode*>& nodes) const;

--- a/src/corelibs/U2Core/src/datatype/PhyTree.h
+++ b/src/corelibs/U2Core/src/datatype/PhyTree.h
@@ -70,8 +70,10 @@ public:
 
     void movingToAnotherAddress(PhyBranch* newAddress);
 
-    PhyNode* node1 = nullptr;
-    PhyNode* node2 = nullptr;
+    PhyNode* parentNode = nullptr;
+    PhyNode* childNode = nullptr;
+
+    /** Distance between child and parent nodes. */
     double distance = 0;
     double nodeValue = -1.0;
 };
@@ -85,16 +87,21 @@ public:
     PhyNode() = default;
     ~PhyNode();
 
-    const QList<PhyBranch*>& getBranches() const;
+    const QList<PhyBranch*>& getChildBranches() const;
 
-    const PhyNode* getSecondNodeOfBranch(int branchNumber) const;
+    const PhyBranch* getParentBranch() const;
+
+    PhyBranch* getParentBranch();
+
+    const PhyBranch* getChildBranchByIndex(int branchIndex) const;
 
     /** Adds current node and all node children into the collection using pre-order algorithm. */
-    void addIfNotPreset(QList<PhyNode*>& nodes);
-    void addIfNotPreset(QList<const PhyNode*>& nodes) const;
+    void getNodesPreOrder(QList<PhyNode*>& nodes);
+    void getNodesPreOrder(QList<const PhyNode*>& nodes) const;
 
     bool isConnected(const PhyNode* node) const;
 
+    /** Clones current node & sub-tree. */
     PhyNode* clone() const;
 
     /* For distance matrix */
@@ -102,39 +109,56 @@ public:
 
     PhyNode* getParentNode();
 
-    void print(QList<PhyNode*>& nodes, int distance, int tabSize);
+    /** Prints sub-tree to stdout. */
+    void print(int distance = 0, int tabSize = 0) const;
 
-    /* For reroot */
-    void setParentNode(PhyNode* newParent, double distance);
-
+    /** Returns direct child nodes of this node. To get all nodes use getNodesPreOrder(). */
     QList<PhyNode*> getChildNodes() const;
 
-    void swapBranches(int branchIndex1, int branchIndex2);
+    /**Inverts order of the child node branches. */
+    void invertOrderOrChildBranches();
 
     double getDistanceToRoot() const;
-
-    const PhyBranch* getParentBranch() const;
 
     /** Returns true if the node is a leaf (tip) node in the tree. */
     bool isLeafNode() const;
 
+    /** Returns true if the node is a root node in the tree. */
+    bool isRootNode() const;
+
     QString name;
 
-private:
-    PhyNode* parent() const;
+    int countLeafNodesInSubtree() const;
 
-    QList<PhyBranch*> branches;
+    /** Unlinks current node from the parent node: destroys branch between this node and parent node. */
+    void unlinkFromParent();
+
+private:
+    /** Make this node a root node in the hierarchy. Moves parent node to the children of the current node. */
+    void makeRoot();
+
+    /**
+     * Branch to the parent node.
+     * Null for the root node.
+     * Current node owns this branch: the branch is destroyed by the current node.
+     */
+    PhyBranch* parentBranch = nullptr;
+
+    /**
+     * Branches to child nodes.
+     * Empty for leaf nodes.
+     * Current node does not own these branches: branches are removed as a part of child node removal.
+     */
+    QList<PhyBranch*> childBranches;
 };
 
 class U2CORE_EXPORT PhyTreeUtils {
 public:
-    static int getNumSeqsFromNode(const PhyNode* node, const QSet<QString>& names);
-
+    /** Re-roots tree in-place: all nodes & branches are preserved, but some branches are inverted. */
     static void rerootPhyTree(PhyTree& phyTree, PhyNode* node);
 
-    static PhyBranch* addBranch(PhyNode* node1, PhyNode* node2, double distance);
-
-    static void removeBranch(PhyNode* node1, PhyNode* node2);
+    /** Adds new branch between 2 nodes. The child node must have no parent. */
+    static PhyBranch* addBranch(PhyNode* parentNode, PhyNode* childNode, double distance);
 };
 
 }  // namespace U2

--- a/src/corelibs/U2Core/src/gobjects/PhyTreeObject.cpp
+++ b/src/corelibs/U2Core/src/gobjects/PhyTreeObject.cpp
@@ -156,7 +156,7 @@ bool PhyTreeObject::treesAreAlike(const PhyTree& tree1, const PhyTree& tree2) {
             if (n2->name != n1->name) {
                 continue;
             }
-            if (n1->getBranches().size() != n2->getBranches().size()) {
+            if (n1->getChildNodes().size() != n2->getChildNodes().size()) {
                 return false;
             }
         }

--- a/src/corelibs/U2Core/src/gobjects/PhyTreeObject.cpp
+++ b/src/corelibs/U2Core/src/gobjects/PhyTreeObject.cpp
@@ -156,7 +156,7 @@ bool PhyTreeObject::treesAreAlike(const PhyTree& tree1, const PhyTree& tree2) {
             if (n2->name != n1->name) {
                 continue;
             }
-            if (n1->getChildNodes().size() != n2->getChildNodes().size()) {
+            if (n1->getChildBranches().size() != n2->getChildBranches().size()) {
                 return false;
             }
         }

--- a/src/corelibs/U2Core/src/gobjects/PhyTreeObject.h
+++ b/src/corelibs/U2Core/src/gobjects/PhyTreeObject.h
@@ -58,6 +58,7 @@ public:
 
     // Utility functions
     // Compares number of nodes and nodes with names (how many nodes etc.)
+    // TODO: document the algorithm and usage.
     static bool treesAreAlike(const PhyTree& tree1, const PhyTree& tree2);
 
 signals:

--- a/src/corelibs/U2Core/src/util/DatatypeSerializeUtils.cpp
+++ b/src/corelibs/U2Core/src/util/DatatypeSerializeUtils.cpp
@@ -337,8 +337,8 @@ QList<PhyTree> NewickPhyTreeSerializer::parseTrees(IOAdapterReader& reader, U2Op
                 }
                 state = RS_WEIGHT;
             } else if (ch == ',') {  // New sibling.
-                CHECK_EXT_BREAK(!nodeStack.isEmpty(), si.setError(DatatypeSerializers::tr("Tree node stack is empty")));
-                CHECK_EXT_BREAK(!branchStack.isEmpty(), si.setError(DatatypeSerializers::tr("Branch node stack is empty")));
+                CHECK_EXT_BREAK(!nodeStack.isEmpty(), si.setError(DatatypeSerializers::tr("Missing nodes in node stack")));
+                CHECK_EXT_BREAK(!branchStack.isEmpty(), si.setError(DatatypeSerializers::tr("Missing branches in branch stack")));
                 if (nodeStack.isEmpty() || branchStack.isEmpty()) {
                     si.setError(DatatypeSerializers::tr("Unexpected new sibling %1").arg(lastStr));
                     break;

--- a/src/corelibs/U2Core/src/util/DatatypeSerializeUtils.cpp
+++ b/src/corelibs/U2Core/src/util/DatatypeSerializeUtils.cpp
@@ -199,7 +199,6 @@ DNAChromatogram DNAChromatogramSerializer::deserialize(const QByteArray& binary,
 /************************************************************************/
 /* NewickPhyTreeSerializer */
 /************************************************************************/
-namespace {
 enum ReadState {
     RS_NAME,
     RS_WEIGHT,
@@ -207,45 +206,31 @@ enum ReadState {
     RS_AFTER_CLOSING_BRACE
 };
 
-void packTreeNode(QString& resultText, const PhyNode* node, U2OpStatus& os) {
-    const QList<PhyBranch*>& branches = node->getBranches();
-    int branchCount = branches.size();
-    QString nodeName = node->name;
-    if (branchCount == 1 && (nodeName.isEmpty() || nodeName == "ROOT")) {
-        const PhyNode* sibling = node->getSecondNodeOfBranch(0);
-        CHECK_EXT(node != sibling, os.setError(DatatypeSerializers::tr("Invalid tree topology")), );
-        packTreeNode(resultText, sibling, os);
-        CHECK_OP(os, );
-        return;
-    }
-    if (branchCount > 1) {
+static void packTreeNode(QString& resultText, const PhyNode* node, U2OpStatus& os) {
+    const QList<PhyBranch*>& childBranches = node->getChildBranches();
+    if (!childBranches.isEmpty()) {
         resultText.append("(");
-        bool first = true;
-        for (int i = 0; i < branchCount; ++i) {
-            if (node->getSecondNodeOfBranch(i) != node) {
-                if (first) {
-                    first = false;
-                } else {
-                    resultText.append(",");
-                }
-                packTreeNode(resultText, node->getSecondNodeOfBranch(i), os);
-                CHECK_OP(os, );
-                PhyBranch* branch = branches.at(i);
-                if (branch->nodeValue >= 0) {
-                    resultText.append(QString::number(branch->nodeValue));
-                }
-                resultText.append(":");
-                resultText.append(QString::number(branch->distance));
+        for (int i = 0; i < childBranches.size(); i++) {
+            PhyBranch* childBranch = childBranches[i];
+            if (i > 0) {
+                resultText.append(",");
             }
+            packTreeNode(resultText, childBranch->childNode, os);
+            CHECK_OP(os, );
+            if (childBranch->nodeValue >= 0) {
+                // TODO: this must be node name, not 'value'!
+                resultText.append(QString::number(childBranch->nodeValue));
+            }
+            resultText.append(":");
+            resultText.append(QString::number(childBranch->distance));
         }
         resultText.append(")");
-    } else if (nodeName.contains(QRegExp("\\s|[(]|[)]|[:]|[;]|[,]"))) {
-        resultText.append(QString("\'%1\'").arg(nodeName));
+    } else if (node->name.contains(QRegExp("\\s|[(]|[)]|[:]|[;]|[,]"))) {
+        resultText.append(QString("\'%1\'").arg(node->name));
     } else {
-        resultText.append(QString(nodeName));
+        resultText.append(node->name);
     }
 }
-}  // namespace
 
 #define BUFF_SIZE 1024
 /* TODO:

--- a/src/corelibs/U2Formats/src/NEXUSFormat.cpp
+++ b/src/corelibs/U2Formats/src/NEXUSFormat.cpp
@@ -846,34 +846,21 @@ void writeMAligment(const MultipleSequenceAlignment& ma, bool simpleName, IOAdap
 }
 
 static void writeNode(const PhyNode* node, IOAdapter* io) {
-    const QList<PhyBranch*>& branches = node->getBranches();
-    int branchCount = branches.size();
-
-    if (branchCount == 1 && (node->name.isEmpty() || node->name == "ROOT")) {
-        assert(node != node->getSecondNodeOfBranch(0));
-        writeNode(node->getSecondNodeOfBranch(0), io);
-        return;
-    }
-
-    if (branchCount > 1) {
+    const QList<PhyBranch*>& childBranches = node->getChildBranches();
+    if (!childBranches.isEmpty()) {
         io->writeBlock("(", 1);
-        bool first = true;
-        for (int i = 0; i < branchCount; ++i) {
-            if (node->getSecondNodeOfBranch(i) != node) {
-                if (first) {
-                    first = false;
-                } else {
-                    io->writeBlock(",", 1);
-                }
-                writeNode(node->getSecondNodeOfBranch(i), io);
-                io->writeBlock(":", 1);
-                io->writeBlock(QByteArray::number(branches.at(i)->distance));
+        for (int i = 0; i < childBranches.size(); i++) {
+            PhyBranch* childBranch = childBranches[i];
+            if (i > 0) {
+                io->writeBlock(",", 1);
             }
+            writeNode(childBranch->childNode, io);
+            io->writeBlock(":", 1);
+            io->writeBlock(QByteArray::number(childBranches.at(i)->distance));
         }
         io->writeBlock(")", 1);
     } else {
         bool containsSpaces = node->name.contains(QRegExp("\\s"));
-
         if (containsSpaces) {
             io->writeBlock("'", 1);
         }

--- a/src/corelibs/U2View/src/ov_phyltree/TreeViewer.cpp
+++ b/src/corelibs/U2View/src/ov_phyltree/TreeViewer.cpp
@@ -1037,9 +1037,10 @@ void TreeViewerUI::updateRect() {
 void TreeViewerUI::sl_swapTriggered() {
     QList<QGraphicsItem*> graphItems = items();
     for (auto graphItem : qAsConst(graphItems)) {
-        auto buttonItem = dynamic_cast<TvNodeItem*>(graphItem);
-        if (buttonItem != nullptr && buttonItem->isPathToRootSelected()) {
-            buttonItem->swapSiblings();
+        auto nodeItem = dynamic_cast<TvNodeItem*>(graphItem);
+        if (nodeItem != nullptr && nodeItem->isPathToRootSelected()) {
+            auto phyNode = nodeItem->getPhyNode();
+            phyNode->invertOrderOrChildBranches();
             phyObject->onTreeChanged();
             break;
         }
@@ -1063,7 +1064,8 @@ void TreeViewerUI::sl_rerootTriggered() {
     for (QGraphicsItem* graphItem : qAsConst(childItems)) {
         auto nodeItem = dynamic_cast<TvNodeItem*>(graphItem);
         if (nodeItem != nullptr && nodeItem->isPathToRootSelected()) {
-            nodeItem->rerootTree(phyObject);
+            auto phyNode = nodeItem->getPhyNode();
+            phyObject->rerootPhyTree(phyNode);
             break;
         }
     }

--- a/src/corelibs/U2View/src/ov_phyltree/item/TvBranchItem.cpp
+++ b/src/corelibs/U2View/src/ov_phyltree/item/TvBranchItem.cpp
@@ -25,6 +25,7 @@
 #include <QPainter>
 #include <QStack>
 
+#include <U2Core/PhyTree.h>
 #include <U2Core/U2SafePoints.h>
 
 #include "../TreeViewerUtils.h"
@@ -53,46 +54,37 @@ TvBranchItem::TvBranchItem(bool withNode, const TvBranchItem::Side& _side, const
     setPen(pen1);
 }
 
-TvBranchItem::TvBranchItem(const QString& nodeName) {
+TvBranchItem::TvBranchItem(const PhyBranch* branch, const QString& name)
+    : phyBranch(branch) {
+    distance = branch == nullptr ? 0.0 : branch->distance;
     settings[BRANCH_THICKNESS] = 1;
     setFlag(QGraphicsItem::ItemIsSelectable);
     setAcceptHoverEvents(false);
     setAcceptedMouseButtons(Qt::NoButton);
 
     QColor branchColor = qvariant_cast<QColor>(settings[BRANCH_COLOR]);
-    QPen pen1(branchColor);
-    pen1.setStyle(Qt::DotLine);
-    pen1.setCosmetic(true);
-    setPen(pen1);
+    setBrush(branchColor);
 
-    nameTextItem = new TvTextItem(this, nodeName);
-    nameTextItem->setFont(TreeViewerUtils::getFont());
-    nameTextItem->setBrush(Qt::darkGray);
-    setLabelPositions();
-    nameTextItem->setZValue(1);
-}
+    QPen pen(branchColor);
+    pen.setCosmetic(true);
+    setPen(pen);
 
-TvBranchItem::TvBranchItem(double _distance, bool withNode, const QString& nodeName)
-    : distance(_distance) {
-    settings[BRANCH_THICKNESS] = 1;
-    setFlag(QGraphicsItem::ItemIsSelectable);
-    setAcceptHoverEvents(false);
-    setAcceptedMouseButtons(Qt::NoButton);
-
-    if (withNode) {
-        nodeItem = new TvNodeItem(nodeName);
+    if (branch != nullptr && !branch->childNode->isLeafNode()) {
+        nodeItem = new TvNodeItem(branch->childNode->name);
         nodeItem->setParentItem(this);
     }
 
-    initText(distance);
-    QColor branchColor = qvariant_cast<QColor>(settings[BRANCH_COLOR]);
-    QPen pen1(branchColor);
-    pen1.setCosmetic(true);
-    if (distance < 0) {
-        pen1.setStyle(Qt::DashLine);
+    if (name.isEmpty()) {
+        addDistanceTextItem(distance);
+    } else {  // Not a real branch item, but the name label only with dotted alignment lines.
+        nameTextItem = new TvTextItem(this, name);
+        nameTextItem->setFont(TreeViewerUtils::getFont());
+        nameTextItem->setBrush(Qt::darkGray);
+        setLabelPositions();
+        nameTextItem->setZValue(1);
+        pen.setStyle(Qt::DotLine);
+        setPen(pen);
     }
-    setPen(pen1);
-    setBrush(branchColor);
 }
 
 void TvBranchItem::updateSettings(const OptionsMap& newSettings) {
@@ -217,7 +209,7 @@ void TvBranchItem::setSelectedRecursively(bool isSelected) {
     QAbstractGraphicsShapeItem::setSelected(isSelected);
 }
 
-void TvBranchItem::initText(double d) {
+void TvBranchItem::addDistanceTextItem(double d) {
     QString str = QString::number(d, 'f', 3);
     // Trim trailing zeros.
     int i = str.length() - 1;

--- a/src/corelibs/U2View/src/ov_phyltree/item/TvBranchItem.cpp
+++ b/src/corelibs/U2View/src/ov_phyltree/item/TvBranchItem.cpp
@@ -70,8 +70,8 @@ TvBranchItem::TvBranchItem(const PhyBranch* branch, const QString& name, bool is
     setPen(pen);
 
     if ((branch != nullptr && !branch->childNode->isLeafNode()) || isRoot) {
-        QString name = branch == nullptr ? "" : branch->childNode->name;
-        nodeItem = new TvNodeItem(name);
+        QString nodeName = branch == nullptr ? "" : branch->childNode->name;
+        nodeItem = new TvNodeItem(nodeName);
         nodeItem->setParentItem(this);
     }
 

--- a/src/corelibs/U2View/src/ov_phyltree/item/TvBranchItem.cpp
+++ b/src/corelibs/U2View/src/ov_phyltree/item/TvBranchItem.cpp
@@ -54,7 +54,7 @@ TvBranchItem::TvBranchItem(bool withNode, const TvBranchItem::Side& _side, const
     setPen(pen1);
 }
 
-TvBranchItem::TvBranchItem(const PhyBranch* branch, const QString& name)
+TvBranchItem::TvBranchItem(const PhyBranch* branch, const QString& name, bool isRoot)
     : phyBranch(branch) {
     distance = branch == nullptr ? 0.0 : branch->distance;
     settings[BRANCH_THICKNESS] = 1;
@@ -69,14 +69,15 @@ TvBranchItem::TvBranchItem(const PhyBranch* branch, const QString& name)
     pen.setCosmetic(true);
     setPen(pen);
 
-    if (branch != nullptr && !branch->childNode->isLeafNode()) {
-        nodeItem = new TvNodeItem(branch->childNode->name);
+    if ((branch != nullptr && !branch->childNode->isLeafNode()) || isRoot) {
+        QString name = branch == nullptr ? "" : branch->childNode->name;
+        nodeItem = new TvNodeItem(name);
         nodeItem->setParentItem(this);
     }
 
     if (name.isEmpty()) {
         addDistanceTextItem(distance);
-    } else {  // Not a real branch item, but the name label only with dotted alignment lines.
+    } else {  // 'this' is not a real branch item, but the name label only with dotted alignment lines.
         nameTextItem = new TvTextItem(this, name);
         nameTextItem->setFont(TreeViewerUtils::getFont());
         nameTextItem->setBrush(Qt::darkGray);

--- a/src/corelibs/U2View/src/ov_phyltree/item/TvBranchItem.h
+++ b/src/corelibs/U2View/src/ov_phyltree/item/TvBranchItem.h
@@ -33,6 +33,7 @@ namespace U2 {
 class TvNodeItem;
 class TvTextItem;
 class TvRectangularBranchItem;
+class PhyBranch;
 
 class U2VIEW_EXPORT TvBranchItem : public QObject, public QAbstractGraphicsShapeItem {
     Q_OBJECT
@@ -116,11 +117,7 @@ signals:
     void si_branchCollapsed(TvBranchItem* branch);
 
 protected:
-    /** Constructs leaf branch with the given node node. */
-    explicit TvBranchItem(const QString& nodeName);
-
-    /** Constructs non-leaf branch with TvNodeItem inside if 'withNode' is true. */
-    TvBranchItem(double distance, bool withNode, const QString& nodeName);
+    TvBranchItem(const PhyBranch* branch, const QString& name);
 
     virtual void setLabelPositions();
 
@@ -130,7 +127,10 @@ protected:
      */
     virtual void setUpPainter(QPainter* p);
 
-    void initText(double d);
+    void addDistanceTextItem(double d);
+
+    /** Phy-tree related branch. May be null for the root branch item. */
+    const PhyBranch* phyBranch = nullptr;
 
     TvTextItem* distanceTextItem = nullptr;
     TvTextItem* nameTextItem = nullptr;

--- a/src/corelibs/U2View/src/ov_phyltree/item/TvBranchItem.h
+++ b/src/corelibs/U2View/src/ov_phyltree/item/TvBranchItem.h
@@ -117,7 +117,7 @@ signals:
     void si_branchCollapsed(TvBranchItem* branch);
 
 protected:
-    TvBranchItem(const PhyBranch* branch, const QString& name);
+    TvBranchItem(const PhyBranch* branch, const QString& name, bool isRoot);
 
     virtual void setLabelPositions();
 

--- a/src/corelibs/U2View/src/ov_phyltree/item/TvNodeItem.cpp
+++ b/src/corelibs/U2View/src/ov_phyltree/item/TvNodeItem.cpp
@@ -26,7 +26,7 @@
 #include <QPen>
 #include <QStyleOptionGraphicsItem>
 
-#include <U2Core/PhyTreeObject.h>
+#include <U2Core/PhyTree.h>
 #include <U2Core/U2SafePoints.h>
 
 #include "../TreeViewer.h"
@@ -103,17 +103,6 @@ void TvNodeItem::toggleCollapsedState() {
     }
 }
 
-void TvNodeItem::swapSiblings() {
-    auto branchItem = dynamic_cast<TvBranchItem*>(parentItem());
-    CHECK(branchItem != nullptr, );
-    auto rectBranchItem = dynamic_cast<TvRectangularBranchItem*>(branchItem);
-    if (rectBranchItem == nullptr) {
-        SAFE_POINT(branchItem->correspondingRectangularBranchItem, "No correspondingRectangularBranchItem", );
-        rectBranchItem = branchItem->correspondingRectangularBranchItem;
-    }
-    rectBranchItem->swapSiblings();
-}
-
 bool TvNodeItem::isPathToRootSelected() const {
     CHECK(isSelected(), false);
 
@@ -129,25 +118,20 @@ bool TvNodeItem::isCollapsed() {
     return parent != nullptr && parent->isCollapsed();
 }
 
-void TvNodeItem::rerootTree(PhyTreeObject* treeObject) {
-    SAFE_POINT(treeObject != nullptr, "Null pointer argument 'treeObject' was passed to 'PhyTreeUtils::rerootPhyTree' function", );
-
+PhyNode* TvNodeItem::getPhyNode() const {
     auto parentBranchItem = dynamic_cast<TvBranchItem*>(parentItem());
-    CHECK(parentBranchItem != nullptr, );
+    CHECK(parentBranchItem != nullptr, nullptr);
 
     auto parentRectBranchItem = dynamic_cast<TvRectangularBranchItem*>(parentBranchItem);
     if (parentRectBranchItem == nullptr) {
-        SAFE_POINT(parentBranchItem->correspondingRectangularBranchItem, "No correspondingRectangularBranchItem", );
+        SAFE_POINT(parentBranchItem->correspondingRectangularBranchItem, "No correspondingRectangularBranchItem", nullptr);
         parentRectBranchItem = parentBranchItem->correspondingRectangularBranchItem;
     }
 
     const PhyBranch* nodeBranch = parentRectBranchItem->getPhyBranch();
-    CHECK(nodeBranch != nullptr, );
+    CHECK(nodeBranch != nullptr, nullptr);
 
-    PhyNode* newRoot = nodeBranch->node2;
-    CHECK(newRoot != nullptr, );
-
-    treeObject->rerootPhyTree(newRoot);
+    return nodeBranch->childNode;
 }
 
 void TvNodeItem::updateSettings(const OptionsMap& settings) {

--- a/src/corelibs/U2View/src/ov_phyltree/item/TvNodeItem.h
+++ b/src/corelibs/U2View/src/ov_phyltree/item/TvNodeItem.h
@@ -36,6 +36,7 @@ class TreeViewerUI;
 class PhyTreeObject;
 class TvBranchItem;
 class TvTextItem;
+class PhyNode;
 
 class U2VIEW_EXPORT TvNodeItem : public QGraphicsEllipseItem {
 public:
@@ -45,11 +46,9 @@ public:
 
     void toggleCollapsedState();
 
-    void swapSiblings();
-
     bool isCollapsed();
 
-    void rerootTree(PhyTreeObject* treeObject);
+    PhyNode* getPhyNode() const;
 
     void updateSettings(const OptionsMap& settings);
 

--- a/src/corelibs/U2View/src/ov_phyltree/item/TvRectangularBranchItem.cpp
+++ b/src/corelibs/U2View/src/ov_phyltree/item/TvRectangularBranchItem.cpp
@@ -33,8 +33,8 @@
 
 namespace U2 {
 
-TvRectangularBranchItem::TvRectangularBranchItem(const PhyBranch* branch, const QString& name)
-    : TvBranchItem(branch, name) {
+TvRectangularBranchItem::TvRectangularBranchItem(const PhyBranch* branch, const QString& name, bool isRoot)
+    : TvBranchItem(branch, name, isRoot) {
 }
 
 void TvRectangularBranchItem::toggleCollapsedState() {

--- a/src/corelibs/U2View/src/ov_phyltree/item/TvRectangularBranchItem.cpp
+++ b/src/corelibs/U2View/src/ov_phyltree/item/TvRectangularBranchItem.cpp
@@ -33,26 +33,8 @@
 
 namespace U2 {
 
-TvRectangularBranchItem::TvRectangularBranchItem(const QString& nodeName, TvRectangularBranchItem* parentBranchItem)
-    : TvBranchItem(nodeName) {
-    setParentItem(parentBranchItem);
-    setPos(0, 0);
-}
-
-TvRectangularBranchItem::TvRectangularBranchItem(double x, double y, const QString& name)
-    : TvBranchItem(false, Side::Left, "") {
-    new TvRectangularBranchItem(name, this);
-    setPos(x, y);
-}
-
-TvRectangularBranchItem::TvRectangularBranchItem(double x, double y, const QString& name, double distance, PhyBranch* branch)
-    : TvBranchItem(distance, false, ""), phyBranch(branch) {
-    new TvRectangularBranchItem(name, this);
-    setPos(x, y);
-}
-
-TvRectangularBranchItem::TvRectangularBranchItem(double distance, PhyBranch* branch, const QString& nodeName)
-    : TvBranchItem(distance, true, nodeName), phyBranch(branch) {
+TvRectangularBranchItem::TvRectangularBranchItem(const PhyBranch* branch, const QString& name)
+    : TvBranchItem(branch, name) {
 }
 
 void TvRectangularBranchItem::toggleCollapsedState() {
@@ -208,15 +190,6 @@ void TvRectangularBranchItem::setBreathScaleAdjustment(double newBreadthScaleAdj
 
 void TvRectangularBranchItem::setCurvature(double newCurvature) {
     curvature = newCurvature;
-}
-
-void TvRectangularBranchItem::swapSiblings() {
-    CHECK(phyBranch != nullptr, );
-    PhyNode* nodeTo = phyBranch->node2;
-    int branchCount = nodeTo->getBranches().size();
-    if (branchCount > 2) {
-        nodeTo->swapBranches(0, 2);
-    }
 }
 
 TvRectangularBranchItem::Side TvRectangularBranchItem::getSide() const {

--- a/src/corelibs/U2View/src/ov_phyltree/item/TvRectangularBranchItem.h
+++ b/src/corelibs/U2View/src/ov_phyltree/item/TvRectangularBranchItem.h
@@ -38,10 +38,7 @@ public:
     static constexpr double EPSILON = 0.0000000001;
     static constexpr int DEFAULT_HEIGHT = 25;
 
-    TvRectangularBranchItem(const QString& nodeName, TvRectangularBranchItem* parentBranchItem);
-    TvRectangularBranchItem(double distance, PhyBranch* branch, const QString& nodeName);
-    TvRectangularBranchItem(double x, double y, const QString& name, double distance, PhyBranch* branch);
-    TvRectangularBranchItem(double x, double y, const QString& name);
+    TvRectangularBranchItem(const PhyBranch* branch, const QString& name);
 
     QRectF boundingRect() const override;
 
@@ -61,8 +58,6 @@ public:
 
     void toggleCollapsedState() override;
 
-    void swapSiblings();
-
     const PhyBranch* getPhyBranch() const;
 
     void drawCollapsedRegion();
@@ -77,8 +72,6 @@ private:
 
     /** See BREADTH_SCALE_ADJUSTMENT doc. */
     double breadthScaleAdjustment = 1;
-
-    PhyBranch* phyBranch = nullptr;
 
     /**
      * Leaf branches have additional UI element to show selected state.

--- a/src/corelibs/U2View/src/ov_phyltree/item/TvRectangularBranchItem.h
+++ b/src/corelibs/U2View/src/ov_phyltree/item/TvRectangularBranchItem.h
@@ -38,7 +38,7 @@ public:
     static constexpr double EPSILON = 0.0000000001;
     static constexpr int DEFAULT_HEIGHT = 25;
 
-    TvRectangularBranchItem(const PhyBranch* branch, const QString& name);
+    TvRectangularBranchItem(const PhyBranch* branch, const QString& name, bool isRoot);
 
     QRectF boundingRect() const override;
 

--- a/src/corelibs/U2View/src/ov_phyltree/layout/TvRectangularLayoutAlgorithm.cpp
+++ b/src/corelibs/U2View/src/ov_phyltree/layout/TvRectangularLayoutAlgorithm.cpp
@@ -33,10 +33,10 @@ namespace U2 {
 
 static TvRectangularBranchItem* createBranch(const PhyNode* phyNode) {
     const PhyBranch* parentPhyBranch = phyNode->getParentBranch();
-    auto parentTvBranch = new TvRectangularBranchItem(parentPhyBranch, "");
+    auto parentTvBranch = new TvRectangularBranchItem(parentPhyBranch, "", phyNode->isRootNode());
     if (phyNode->isLeafNode()) {
         // TODO: do not use branches to draw names.
-        auto branchTvItemForName = new TvRectangularBranchItem(nullptr, phyNode->name);
+        auto branchTvItemForName = new TvRectangularBranchItem(nullptr, phyNode->name, false);
         branchTvItemForName->setParentItem(parentTvBranch);
     }
 

--- a/src/corelibs/U2View/src/ov_phyltree/layout/TvRectangularLayoutAlgorithm.cpp
+++ b/src/corelibs/U2View/src/ov_phyltree/layout/TvRectangularLayoutAlgorithm.cpp
@@ -32,40 +32,20 @@
 namespace U2 {
 
 static TvRectangularBranchItem* createBranch(const PhyNode* phyNode) {
-    const QList<PhyBranch*> branches = phyNode->getBranches();
-    int branchCount = branches.size();
-    if (branchCount == 1 && (phyNode->name.isEmpty() || phyNode->name == "ROOT")) {
-        SAFE_POINT(phyNode != phyNode->getSecondNodeOfBranch(0), "Invalid getSecondNodeOfBranch", nullptr);
-        return createBranch(phyNode->getSecondNodeOfBranch(0));
+    const PhyBranch* parentPhyBranch = phyNode->getParentBranch();
+    auto parentTvBranch = new TvRectangularBranchItem(parentPhyBranch, "");
+    if (phyNode->isLeafNode()) {
+        // TODO: do not use branches to draw names.
+        auto branchTvItemForName = new TvRectangularBranchItem(nullptr, phyNode->name);
+        branchTvItemForName->setParentItem(parentTvBranch);
     }
-    if (branchCount == 0) {
-        return new TvRectangularBranchItem(0.0, 0.0, phyNode->name);
+
+    const QList<PhyBranch*>& childPhyBranches = phyNode->getChildBranches();
+    for (auto childPhyBranch : qAsConst(childPhyBranches)) {
+        auto childTvBranch = createBranch(childPhyBranch->childNode);
+        childTvBranch->setParentItem(parentTvBranch);
     }
-    if (branchCount == 1) {
-        PhyBranch* firstBranch = branches.at(0);
-        return new TvRectangularBranchItem(0.0, 0.0, phyNode->name, firstBranch->distance, firstBranch);
-    }
-    QList<TvRectangularBranchItem*> childRectBranches;
-    int branchIndex = -1;
-    for (int i = 0; i < branchCount; i++) {
-        if (phyNode->getSecondNodeOfBranch(i) == phyNode) {
-            branchIndex = i;
-            continue;
-        }
-        childRectBranches.append(createBranch(phyNode->getSecondNodeOfBranch(i)));
-    }
-    PhyBranch* phyBranch = nullptr;
-    if (branchIndex >= 0) {
-        const PhyBranch* parentPhyBranch = phyNode->getParentBranch();
-        SAFE_POINT(parentPhyBranch != nullptr, "An internal error: a tree is in an incorrect state, can't create a branch", nullptr);
-        phyBranch = branches.at(branchIndex);
-    }
-    double distance = phyBranch == nullptr ? 0.0 : phyBranch->distance;
-    auto rectBranch = new TvRectangularBranchItem(distance, phyBranch, phyNode->name);
-    for (auto childRectBranch : qAsConst(childRectBranches)) {
-        childRectBranch->setParentItem(rectBranch);
-    }
-    return rectBranch;
+    return parentTvBranch;
 }
 
 TvRectangularBranchItem* TvRectangularLayoutAlgorithm::buildTreeLayout(const PhyNode* phyRoot) {
@@ -87,40 +67,31 @@ static TvRectangularBranchItem* getChildItemByPhyBranch(TvRectangularBranchItem*
 }
 
 void static recalculateBranches(TvRectangularBranchItem* branch, const PhyNode* rootPhyNode, int& currentRow) {
-    const PhyNode* phyNode = branch->getPhyBranch() != nullptr ? branch->getPhyBranch()->node2 : rootPhyNode;
+    const PhyNode* phyNode = branch->getPhyBranch() != nullptr ? branch->getPhyBranch()->childNode : rootPhyNode;
     CHECK(phyNode != nullptr, );
 
-    const QList<PhyBranch*> branches = phyNode->getBranches();
-    if (branches.size() <= 1) {
+    const QList<PhyBranch*>& childPhyBranches = phyNode->getChildBranches();
+    if (childPhyBranches.isEmpty()) {
         double y = (currentRow + 0.5) * TvRectangularBranchItem::DEFAULT_HEIGHT;
         branch->setPos(0, y);
         currentRow++;
         return;
     }
-    QList<TvRectangularBranchItem*> childBranches;
-    for (int i = 0; i < branches.size(); ++i) {
-        if (phyNode->getSecondNodeOfBranch(i) != phyNode) {
-            TvRectangularBranchItem* childBranch = getChildItemByPhyBranch(branch, branches.at(i));
-            if (childBranch->isVisible()) {
-                recalculateBranches(childBranch, nullptr, currentRow);
-            }
-            childBranches.append(childBranch);
-        } else {
-            childBranches.append(nullptr);
+    QList<TvRectangularBranchItem*> childTvBranches;
+    for (const PhyBranch* childPhyBranch : qAsConst(childPhyBranches)) {
+        TvRectangularBranchItem* childTvBranch = getChildItemByPhyBranch(branch, childPhyBranch);
+        if (childTvBranch->isVisible()) {
+            recalculateBranches(childTvBranch, nullptr, currentRow);
         }
+        childTvBranches.append(childTvBranch);
     }
 
-    SAFE_POINT(childBranches.size() == branches.size(), "Invalid count of child branches", );
-
-    QPointF firstPos = childBranches[0] ? childBranches[0]->pos() : childBranches[1]->pos();
+    QPointF firstPos = childTvBranches.first()->pos();
     double xMin = firstPos.x();
     double yMin = firstPos.y();
     double yMax = firstPos.y();
-    for (int i = 1; i < childBranches.size(); ++i) {
-        if (childBranches[i] == nullptr) {
-            continue;
-        }
-        QPointF pos1 = childBranches[i]->pos();
+    for (int i = 1; i < childTvBranches.size(); ++i) {
+        QPointF pos1 = childTvBranches[i]->pos();
         xMin = qMin(xMin, pos1.x());
         yMin = qMin(yMin, pos1.y());
         yMax = qMax(yMax, pos1.y());
@@ -137,23 +108,20 @@ void static recalculateBranches(TvRectangularBranchItem* branch, const PhyNode* 
         branch->setPos(xMin, y);
     }
 
-    for (int i = 0; i < childBranches.size(); ++i) {
-        TvRectangularBranchItem* childBranch = childBranches[i];
-        if (childBranch == nullptr) {
-            continue;
-        }
-        double dist = qAbs(branches.at(i)->distance);
-        auto side = childBranch->pos().y() > y
+    for (auto childTvBranch : qAsConst(childTvBranches)) {
+        double dist = qAbs(childTvBranch->getDist());
+        auto side = childTvBranch->pos().y() > y
                         ? TvBranchItem::Side::Right
                         : TvBranchItem::Side::Left;
-        childBranch->setSide(side);
-        childBranch->setWidthW(dist);
-        childBranch->setDist(dist);
-        childBranch->setParentItem(branch);
+        childTvBranch->setSide(side);
+        childTvBranch->setWidthW(dist);
+        childTvBranch->setDist(dist);
+        childTvBranch->setParentItem(branch);
 
-        QRectF rect = childBranch->getDistanceTextItem()->boundingRect();
-        double textX = -(childBranch->getWidth() + rect.width()) / 2;
-        childBranch->getDistanceTextItem()->setPos(textX, 0);
+        TvTextItem* distanceTextItem = childTvBranch->getDistanceTextItem();
+        QRectF rect = distanceTextItem->boundingRect();
+        double textX = -(childTvBranch->getWidth() + rect.width()) / 2;
+        distanceTextItem->setPos(textX, 0);
     }
 }
 

--- a/src/plugins/CoreTests/src/PhyTreeObjectTests.cpp
+++ b/src/plugins/CoreTests/src/PhyTreeObjectTests.cpp
@@ -149,14 +149,14 @@ Task::ReportResult GTest_CheckPhyNodeHasSibling::report() {
 
     bool foundSibling = false;
 
-    SAFE_POINT(node->getBranches().size() == 1, "Expected node to have 1 branch", ReportResult_Finished);
-    const PhyBranch* parentBranch = node->getBranches().first();
-    const PhyNode* parent = parentBranch->node1 == node ? parentBranch->node2 : parentBranch->node1;
+    const PhyBranch* parentBranch = node->getParentBranch();
+    SAFE_POINT(parentBranch != nullptr, "Expected node to have a parent branch", ReportResult_Finished);
+    const PhyNode* parentNode = parentBranch->parentNode;
 
-    const QList<PhyBranch*> parentBranches = parent->getBranches();
+    const QList<PhyBranch*> parentBranches = parentNode->getChildBranches();
     for (PhyBranch* branch : qAsConst(parentBranches)) {
-        if ((parent == branch->node1 && branch->node2->name == siblingName) ||
-            (branch->node1->name == siblingName && node == branch->node1)) {
+        if ((parentNode == branch->parentNode && branch->childNode->name == siblingName) ||
+            (branch->parentNode->name == siblingName && node == branch->parentNode)) {
             foundSibling = true;
             break;
         }
@@ -215,8 +215,8 @@ Task::ReportResult GTest_CheckPhyNodeBranchDistance::report() {
         return ReportResult_Finished;
     }
 
-    SAFE_POINT(node->getBranches().size() == 1, "Expected node to have 1 branch", ReportResult_Finished);
-    const PhyBranch* parentBranch = node->getBranches().first();
+    const PhyBranch* parentBranch = node->getParentBranch();
+    SAFE_POINT(parentBranch != nullptr, "Expected node to have a parent branch", ReportResult_Finished);
     double chkDistance = parentBranch->distance;
     if (distance - chkDistance > EPS) {
         stateInfo.setError(QString("Distances don't match! Expected %1, real dist is %2").arg(distance).arg(chkDistance));

--- a/tests/doc_format/newick/negative/test_0001.xml
+++ b/tests/doc_format/newick/negative/test_0001.xml
@@ -1,4 +1,4 @@
 <multi-test>
-    <!-- Multiple nodes have empty names. -->
-    <load-broken-document index="doc" url="newick/sample8.newick" io="local_file" format="newick"/>
+    <!-- 2 sets of branches to connected into a single tree. -->
+    <load-broken-document index="doc" url="newick/broken.nwk" io="local_file" format="newick"/>
 </multi-test>


### PR DESCRIPTION
… node fields in PhyNode.

The patch is very sensitive and risky but I will try to fix all possible known regressions until merge.

The patch contains rewrite/simplification of the most tree related algorithms. As the result the changed code was reduced twice in size.