### PR TITLE
Use unified icon size on toolbar

### DIFF
--- a/src/ugeneui/src/main_window/ToolBarManager.cpp
+++ b/src/ugeneui/src/main_window/ToolBarManager.cpp
@@ -29,6 +29,7 @@ MWToolBarManagerImpl::MWToolBarManagerImpl(QMainWindow* _mw)
     : QObject(_mw), mw(_mw) {
     QToolBar* tb = createToolBar(MWTOOLBAR_MAIN);
     tb->setToolButtonStyle(Qt::ToolButtonIconOnly);
+    tb->setIconSize({16, 16});
     createToolBar(MWTOOLBAR_ACTIVEMDI);
 }
 


### PR DESCRIPTION
Without this patch the icon on MacOS looks bigger.

@EvelinaBiserova could you please check this fix, because I have no access to MacOS today.