### PR TITLE
Use unified icon size on toolbar-2

### DIFF
--- a/src/ugeneui/src/main_window/ToolBarManager.cpp
+++ b/src/ugeneui/src/main_window/ToolBarManager.cpp
@@ -29,7 +29,7 @@ MWToolBarManagerImpl::MWToolBarManagerImpl(QMainWindow* _mw)
     : QObject(_mw), mw(_mw) {
     QToolBar* tb = createToolBar(MWTOOLBAR_MAIN);
     tb->setToolButtonStyle(Qt::ToolButtonIconOnly);
-    createToolBar(MWTOOLBAR_ACTIVEMDI);
+    createToolBar(MWTOOLBAR_ACTIVEMDI)->setIconSize({20, 20});
 }
 
 MWToolBarManagerImpl::~MWToolBarManagerImpl() {


### PR DESCRIPTION
Left -- view in v44, right -- on the current branch.
![image](https://user-images.githubusercontent.com/39720063/201473037-b8e70f56-d6ad-476d-9336-977b759457e3.png)
![image](https://user-images.githubusercontent.com/39720063/201473053-e116c8af-1b67-40a4-9463-eb62a4060097.png)
I'm currently waiting for a Linux build to check out the view there. #1019 can be closed.
Can I create an issue in Jira and add it to the pre-release table?

P.S. Your icon looks perfect even if it's cropped and scaled down to 16x16.