### PR TITLE
UGENE-6176 update maximum primers value

### DIFF
--- a/src/plugins/pcr/src/InSilicoPcrOptionPanelWidget.ui
+++ b/src/plugins/pcr/src/InSilicoPcrOptionPanelWidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>203</width>
+    <width>230</width>
     <height>656</height>
    </rect>
   </property>
@@ -124,10 +124,10 @@
             <number>1</number>
            </property>
            <property name="maximum">
-            <number>999999</number>
+            <number>2500</number>
            </property>
            <property name="value">
-            <number>5000</number>
+            <number>2500</number>
            </property>
           </widget>
          </item>
@@ -165,11 +165,7 @@
           </widget>
          </item>
          <item row="3" column="1">
-          <widget class="QComboBox" name="annsComboBox">
-           <property name="sizeAdjustPolicy">
-            <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-           </property>
-          </widget>
+          <widget class="QComboBox" name="annsComboBox"/>
          </item>
          <item row="2" column="0">
           <widget class="QLabel" name="label_3">
@@ -340,7 +336,7 @@ font-weight: 600;</string>
          <bool>false</bool>
         </attribute>
         <attribute name="verticalHeaderDefaultSectionSize">
-         <number>24</number>
+         <number>30</number>
         </attribute>
         <column>
          <property name="text">

--- a/src/plugins/pcr/src/InSilicoPcrOptionPanelWidget.ui
+++ b/src/plugins/pcr/src/InSilicoPcrOptionPanelWidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>230</width>
+    <width>226</width>
     <height>656</height>
    </rect>
   </property>
@@ -83,6 +83,9 @@
          <property name="bottomMargin">
           <number>0</number>
          </property>
+         <item row="3" column="1">
+          <widget class="QComboBox" name="annsComboBox"/>
+         </item>
          <item row="0" column="0">
           <widget class="QLabel" name="label">
            <property name="text">
@@ -101,33 +104,24 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
+           <property name="minimumSize">
+            <size>
+             <width>125</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="text">
-            <string>Maximum product</string>
+            <string>Maximum product size</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
-          <widget class="QSpinBox" name="productSizeSpinBox">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="suffix">
-            <string> bp</string>
-           </property>
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>2500</number>
-           </property>
-           <property name="value">
-            <number>2500</number>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>Use ambiguous bases</string>
            </property>
           </widget>
          </item>
@@ -164,13 +158,25 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="1">
-          <widget class="QComboBox" name="annsComboBox"/>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="label_3">
-           <property name="text">
-            <string>Use ambiguous bases</string>
+         <item row="1" column="1">
+          <widget class="QSpinBox" name="productSizeSpinBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="suffix">
+            <string> bp</string>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>999999999</number>
+           </property>
+           <property name="value">
+            <number>5000</number>
            </property>
           </widget>
          </item>

--- a/src/plugins/pcr/transl/russian.ts
+++ b/src/plugins/pcr/transl/russian.ts
@@ -116,63 +116,67 @@
         <translation>Форма</translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="105"/>
         <source>Maximum product</source>
-        <translation>Максимальный продукт</translation>
+        <translation type="vanished">Максимальный продукт</translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="121"/>
-        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="160"/>
+        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="154"/>
+        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="170"/>
         <source> bp</source>
         <translation> нк</translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="89"/>
+        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="92"/>
         <source>3&apos; perfect match</source>
         <translation>3&apos; идеальное совпадение</translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="147"/>
+        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="141"/>
         <source>Extract annotations</source>
         <translation>Извлечь аннотации</translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="177"/>
+        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="124"/>
         <source>Use ambiguous bases</source>
         <translation>Использовать расширенный алфавит</translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="191"/>
+        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="114"/>
+        <source>Maximum product size</source>
+        <translation>Максимальный размер продукта</translation>
+    </message>
+    <message>
+        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="193"/>
         <source>&lt;a href=&quot;details&quot;&gt;Show primers details&lt;/a&gt;</source>
         <translation>&lt;a href=&quot;details&quot;&gt;Показать информацию о праймерах&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="252"/>
+        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="254"/>
         <source>Find product(s)</source>
         <translation>Найти продукт(ы)</translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="347"/>
+        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="349"/>
         <source>Region</source>
         <translation>Регион</translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="352"/>
+        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="354"/>
         <source>Length</source>
         <translation>Длина</translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="357"/>
+        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="359"/>
         <source>Ta</source>
         <translation>Ta</translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="386"/>
+        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="388"/>
         <source>Extract product(s)</source>
         <translation>Извлечь продукт(ы)</translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="400"/>
+        <location filename="../src/InSilicoPcrOptionPanelWidget.ui" line="402"/>
         <source>Info: choose a nucleic sequence for running In Silico PCR</source>
         <translation>Информация: выберите нуклеотидную последовательность для запуска In Silico PCR</translation>
     </message>


### PR DESCRIPTION
https://ugene.dev/tracker/browse/UGENE-6176

This issue is a bit obsolete. In [UGENE-7193](https://ugene.dev/tracker/browse/UGENE-7193) the limit of primers to found was added (50 forward and 50 reverse). Which means, that there are 50*50=2500 products maximum we may have. I added the corresponding info to the manual (see [here](https://doc.ugene.net/wiki/display/UM/In+Silico+PCR)) and made a limit 2500 for products. That's a minor fix, not sure that GUI test is required