### PR TITLE
samtools/src/samtools/bgzf.c: Include "ugene_custom_io.h"

### DIFF
--- a/src/libs_3rdparty/samtools/src/samtools/bgzf.c
+++ b/src/libs_3rdparty/samtools/src/samtools/bgzf.c
@@ -34,6 +34,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include "bgzf.h"
+#include "ugene_custom_io.h"
 
 #include "khash.h"
 typedef struct {


### PR DESCRIPTION
This is necessary to obtain a prototype for the ugene_custom_open function.  Otherwise, the build fails with compilers which do not support implicit function declarations (which were removed from C in 1999).

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
