### PR TITLE
Add nullptr checks after dynamic casts. Part 1

### DIFF
--- a/src/corelibs/U2Algorithm/src/msa_alignment/SimpleAddingToAlignment.cpp
+++ b/src/corelibs/U2Algorithm/src/msa_alignment/SimpleAddingToAlignment.cpp
@@ -208,7 +208,7 @@ const QString& BestPositionFindTask::getSequenceId() const {
 }
 
 AbstractAlignmentTask* SimpleAddToAlignmentTaskFactory::getTaskInstance(AbstractAlignmentTaskSettings* _settings) const {
-    AlignSequencesToAlignmentTaskSettings* addSettings = dynamic_cast<AlignSequencesToAlignmentTaskSettings*>(_settings);
+    auto addSettings = dynamic_cast<AlignSequencesToAlignmentTaskSettings*>(_settings);
     SAFE_POINT(addSettings != nullptr,
                "Add sequences to alignment: incorrect settings",
                nullptr);

--- a/src/corelibs/U2Algorithm/src/smith_waterman/SWMulAlignResultNamesTagsRegistry.h
+++ b/src/corelibs/U2Algorithm/src/smith_waterman/SWMulAlignResultNamesTagsRegistry.h
@@ -124,8 +124,7 @@ inline QBitArray* SWMulAlignResultNamesTagsRegistry::getBitmapOfTagsApplicabilit
 
 inline void SWMulAlignResultNamesTagsRegistry::resetCounters() {
     foreach (SWMulAlignResultNamesTag* tag, tags.values()) {
-        SWMulAlignExternalPropTag* externalPropertyTag = dynamic_cast<SWMulAlignExternalPropTag*>(tag);
-        if (nullptr != externalPropertyTag) {
+        if (auto externalPropertyTag = dynamic_cast<SWMulAlignExternalPropTag*>(tag)) {
             if (SWMulAlignExternalPropTag::COUNTER == externalPropertyTag->getType()) {
                 externalPropertyTag->resetCounter();
             }

--- a/src/corelibs/U2Algorithm/src/util_orf/ORFFinder.cpp
+++ b/src/corelibs/U2Algorithm/src/util_orf/ORFFinder.cpp
@@ -62,7 +62,7 @@ void ORFFindAlgorithm::find(
     int seqPointer = 0;
     QByteArray sequence("");
 
-    DNATranslation3to1Impl* aTT = dynamic_cast<DNATranslation3to1Impl*>(cfg.proteinTT);
+    auto aTT = dynamic_cast<DNATranslation3to1Impl*>(cfg.proteinTT);
     SAFE_POINT(aTT != nullptr, "Cannot convert DNATranslation to DNATranslation3to1Impl!", );
     bool mustFit = cfg.mustFit;
     bool mustInit = cfg.mustInit;
@@ -349,7 +349,7 @@ void ORFFindAlgorithm::checkStopCodonOnJunction(const U2SequenceObject& dnaSeq, 
 
     qint64 seqLen = dnaSeq.getSequenceLength();
     int regLen = cfg.searchRegion.length;
-    DNATranslation3to1Impl* aTT = dynamic_cast<DNATranslation3to1Impl*>(cfg.proteinTT);
+    auto aTT = dynamic_cast<DNATranslation3to1Impl*>(cfg.proteinTT);
     CHECK_EXT(aTT != nullptr, os.setError("Cannot convert DNATranslation to DNATranslation3to1Impl!"), );
     if (strand == ORFAlgorithmStrand_Direct) {
         int end = cfg.searchRegion.endPos();

--- a/src/corelibs/U2Core/src/globals/DBXRefRegistry.cpp
+++ b/src/corelibs/U2Core/src/globals/DBXRefRegistry.cpp
@@ -77,8 +77,8 @@ QScriptValue DBXRefInfo::toScriptValue(QScriptEngine* engine, DBXRefInfo const& 
 }
 
 void DBXRefInfo::fromScriptValue(const QScriptValue& object, DBXRefInfo& out) {
-    DBXRefInfo* info = dynamic_cast<DBXRefInfo*>(object.toQObject());
-    out = nullptr != info ? *info : DBXRefInfo();
+    auto info = dynamic_cast<DBXRefInfo*>(object.toQObject());
+    out = info != nullptr ? *info : DBXRefInfo();
 }
 
 void DBXRefInfo::setupToEngine(QScriptEngine* engine) {

--- a/src/corelibs/U2Core/src/models/MimeDataIterator.cpp
+++ b/src/corelibs/U2Core/src/models/MimeDataIterator.cpp
@@ -32,23 +32,23 @@ namespace U2 {
 /************************************************************************/
 MimeDataIterator::MimeDataIterator(const QMimeData* md)
     : docIdx(0), objectIdx(0), folderIdx(0) {
-    const DocumentMimeData* dmd = dynamic_cast<const DocumentMimeData*>(md);
-    if (nullptr != dmd) {
+    auto dmd = dynamic_cast<const DocumentMimeData*>(md);
+    if (dmd != nullptr) {
         docs << dmd->objPtr;
     }
 
-    const GObjectMimeData* gomd = dynamic_cast<const GObjectMimeData*>(md);
-    if (nullptr != gomd) {
+    auto gomd = dynamic_cast<const GObjectMimeData*>(md);
+    if (gomd != nullptr) {
         objects << gomd->objPtr;
     }
 
-    const FolderMimeData* fmd = dynamic_cast<const FolderMimeData*>(md);
-    if (nullptr != fmd) {
+    auto fmd = dynamic_cast<const FolderMimeData*>(md);
+    if (fmd != nullptr) {
         folders << fmd->folder;
     }
 
-    const BunchMimeData* bmd = dynamic_cast<const BunchMimeData*>(md);
-    if (nullptr != bmd) {
+    auto bmd = dynamic_cast<const BunchMimeData*>(md);
+    if (bmd != nullptr) {
         docs << bmd->docs;
         objects << bmd->objects;
         folders << bmd->folders;

--- a/src/corelibs/U2Core/src/tasks/BackgroundTaskRunner.h
+++ b/src/corelibs/U2Core/src/tasks/BackgroundTaskRunner.h
@@ -26,6 +26,7 @@
 
 #include <U2Core/AppContext.h>
 #include <U2Core/Task.h>
+#include <U2Core/U2SafePoints.h>
 
 namespace U2 {
 
@@ -120,8 +121,8 @@ public:
 
 private:
     virtual void sl_finished() {
-        BackgroundTask<Result>* senderr = dynamic_cast<BackgroundTask<Result>*>(sender());
-        assert(senderr);
+        auto senderr = dynamic_cast<BackgroundTask<Result>*>(sender());
+        SAFE_POINT(senderr != nullptr, "sender is not BackgroundTask", );
         if (task != senderr) {
             return;
         }

--- a/src/corelibs/U2Core/src/util/U1AnnotationUtils.cpp
+++ b/src/corelibs/U2Core/src/util/U1AnnotationUtils.cpp
@@ -299,6 +299,7 @@ QList<U2Region> U1AnnotationUtils::getRelatedLowerCaseRegions(const U2SequenceOb
     QList<U2Region> upperCaseRegs;
     for (GObject* o : qAsConst(aos)) {
         auto ato = dynamic_cast<AnnotationTableObject*>(o);
+        SAFE_POINT(ato != nullptr, "U1AnnotationUtils::getRelatedLowerCaseRegions: ato is nullptr", {});
         foreach (Annotation* a, ato->getAnnotations()) {
             if (a->getName() == lowerCaseAnnotationName) {
                 lowerCaseRegs << a->getRegions().toList();
@@ -561,8 +562,7 @@ U2Location U1AnnotationUtils::shiftLocation(const U2Location& location, qint64 s
     return newLocation;
 }
 
-QMap<Annotation*, QList<QPair<QString, QString>>> FixAnnotationsUtils::fixAnnotations(U2OpStatus* os, U2SequenceObject* seqObj, const U2Region& regionToReplace, const DNASequence& sequence2Insert, 
-                                                                                      QList<Document*> docs, bool recalculateQualifiers, U1AnnotationUtils::AnnotationStrategyForResize str) {
+QMap<Annotation*, QList<QPair<QString, QString>>> FixAnnotationsUtils::fixAnnotations(U2OpStatus* os, U2SequenceObject* seqObj, const U2Region& regionToReplace, const DNASequence& sequence2Insert, QList<Document*> docs, bool recalculateQualifiers, U1AnnotationUtils::AnnotationStrategyForResize str) {
     FixAnnotationsUtils fixer(os, seqObj, regionToReplace, sequence2Insert, recalculateQualifiers, str, docs);
     fixer.fixAnnotations();
     return fixer.annotationForReport;

--- a/src/corelibs/U2Designer/src/DatasetsListWidget.cpp
+++ b/src/corelibs/U2Designer/src/DatasetsListWidget.cpp
@@ -117,8 +117,8 @@ void DatasetsListWidget::sl_newDataset() {
 
 void DatasetsListWidget::sl_renameDataset() {
     GCOUNTER(cvar, "WD::Dataset::Rename Dataset");
-    QAction* a = dynamic_cast<QAction*>(sender());
-    CHECK(nullptr != a, );
+    auto a = dynamic_cast<QAction*>(sender());
+    CHECK(a != nullptr, );
 
     int idx = a->property("idx").toInt();
     CHECK(idx < tabs->count(), );

--- a/src/corelibs/U2Designer/src/DelegateEditors.cpp
+++ b/src/corelibs/U2Designer/src/DelegateEditors.cpp
@@ -537,12 +537,14 @@ void URLDelegate::sl_commit() {
 void URLDelegate::setEditorData(QWidget* editor,
                                 const QModelIndex& index) const {
     QVariant val = index.model()->data(index, ConfigurationEditor::ItemValueRole);
-    URLWidget* lineEdit = dynamic_cast<URLWidget*>(editor);
+    auto lineEdit = dynamic_cast<URLWidget*>(editor);
+    SAFE_POINT(lineEdit != nullptr, "URLDelegate::setEditorData: lineEdit is null!", );
     lineEdit->setValue(val);
 }
 
 void URLDelegate::setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const {
-    URLWidget* lineEdit = dynamic_cast<URLWidget*>(editor);
+    auto lineEdit = dynamic_cast<URLWidget*>(editor);
+    SAFE_POINT(lineEdit != nullptr, "URLDelegate::setModelData: lineEdit is null!", );
     QString val = lineEdit->value().toString().replace('\\', '/').trimmed();
     QStringList urls = val.split(";", QString::SkipEmptyParts);
     val = urls.join(";");
@@ -795,12 +797,14 @@ void StringListDelegate::sl_commit() {
 
 void StringListDelegate::setEditorData(QWidget* editor, const QModelIndex& index) const {
     QVariant val = index.model()->data(index, ConfigurationEditor::ItemValueRole);
-    StingListWidget* lineEdit = dynamic_cast<StingListWidget*>(editor);
+    auto lineEdit = dynamic_cast<StingListWidget*>(editor);
+    SAFE_POINT(lineEdit != nullptr, "StringListDelegate::setEditorData: lineEdit is null!", );
     lineEdit->setValue(val);
 }
 
 void StringListDelegate::setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const {
-    StingListWidget* lineEdit = dynamic_cast<StingListWidget*>(editor);
+    auto lineEdit = dynamic_cast<StingListWidget*>(editor);
+    SAFE_POINT(lineEdit != nullptr, "StringListDelegate::setModelData: lineEdit is null!", );
 
     QString val = lineEdit->value().toString();
     model->setData(index, val, ConfigurationEditor::ItemValueRole);
@@ -891,12 +895,14 @@ QWidget* CharacterDelegate::createEditor(QWidget* parent,
 void CharacterDelegate::setEditorData(QWidget* editor,
                                       const QModelIndex& index) const {
     QVariant val = index.model()->data(index, ConfigurationEditor::ItemValueRole);
-    IgnoreUpDownPropertyWidget* lineEdit = dynamic_cast<IgnoreUpDownPropertyWidget*>(editor);
+    auto lineEdit = dynamic_cast<IgnoreUpDownPropertyWidget*>(editor);
+    SAFE_POINT(lineEdit != nullptr, "CharacterDelegate::setEditorData: lineEdit is null", );
     lineEdit->setValue(val);
 }
 
 void CharacterDelegate::setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const {
-    IgnoreUpDownPropertyWidget* lineEdit = dynamic_cast<IgnoreUpDownPropertyWidget*>(editor);
+    auto lineEdit = dynamic_cast<IgnoreUpDownPropertyWidget*>(editor);
+    SAFE_POINT(lineEdit != nullptr, "CharacterDelegate::setModelData: lineEdit is null", );
     model->setData(index, lineEdit->value().toString(), ConfigurationEditor::ItemValueRole);
 }
 

--- a/src/corelibs/U2Designer/src/EditMarkerGroupDialog.cpp
+++ b/src/corelibs/U2Designer/src/EditMarkerGroupDialog.cpp
@@ -280,7 +280,8 @@ bool EditMarkerGroupDialog::checkAddMarkerResult(const QString& newName, const Q
 void EditMarkerGroupDialog::accept() {
     marker->setName(markerGroupNameEdit->text());
     {  // check edit/add marker result
-        MarkerEditorWidget* parent = dynamic_cast<MarkerEditorWidget*>(this->parent());
+        auto parent = dynamic_cast<MarkerEditorWidget*>(this->parent());
+        SAFE_POINT(parent != nullptr, "EditMarkerGroupDialog: parent is null", );
         QString message;
 
         ParameterState state = marker->hasAdditionalParameter();
@@ -433,7 +434,8 @@ EditMarkerDialog::EditMarkerDialog(bool isNew, const QString& type, const QStrin
 
 void EditMarkerDialog::accept() {
     {  // check edit/add marker result
-        EditMarkerGroupDialog* parent = dynamic_cast<EditMarkerGroupDialog*>(this->parent());
+        auto parent = dynamic_cast<EditMarkerGroupDialog*>(this->parent());
+        SAFE_POINT(parent != nullptr, "EditMarkerDialog: parent is null", );
         QString message;
         QString valueString;
         QVariantList newVals;

--- a/src/corelibs/U2Designer/src/GrouperEditorWidget.cpp
+++ b/src/corelibs/U2Designer/src/GrouperEditorWidget.cpp
@@ -44,8 +44,8 @@ static QMap<Descriptor, DataTypePtr> getBusMap(Port* inPort) {
     {
         Port* src = links.keys().first();
         assert(src->isOutput());
-        IntegralBusPort* bus = dynamic_cast<IntegralBusPort*>(src);
-        assert(nullptr != bus);
+        auto bus = dynamic_cast<IntegralBusPort*>(src);
+        SAFE_POINT(bus != nullptr, "getBusMap: bus is null", {});
         DataTypePtr type = bus->getType();
         busMap = type->getDatatypesMap();
     }
@@ -207,8 +207,8 @@ void GrouperEditorWidget::sl_onAddButtonClicked() {
             GrouperOutSlot newSlot(outSlotName, inSlotId);
             newSlot.setAction(action);
 
-            GrouperSlotsCfgModel* model = dynamic_cast<GrouperSlotsCfgModel*>(grouperModel);
-            assert(nullptr != model);
+            auto model = dynamic_cast<GrouperSlotsCfgModel*>(grouperModel);
+            SAFE_POINT(model != nullptr, "sl_onAddButtonClicked: model is null", );
             model->addGrouperSlot(newSlot);
         }
     }
@@ -225,7 +225,7 @@ void GrouperEditorWidget::sl_onEditButtonClicked() {
     QModelIndex leftIdx = selected.first();
     QModelIndex rightIdx = leftIdx.child(leftIdx.row(), 1);
 
-    GrouperSlotsCfgModel* model = dynamic_cast<GrouperSlotsCfgModel*>(grouperModel);
+    auto model = dynamic_cast<GrouperSlotsCfgModel*>(grouperModel);
     SAFE_POINT(model != nullptr, "GrouperSlotsCfgModel is null", );
     QString outSlotName = model->data(leftIdx).toString();
     QString inSlotId = GrouperOutSlot::readable2busMap(model->data(rightIdx).toString());

--- a/src/corelibs/U2Designer/src/MarkerEditor.cpp
+++ b/src/corelibs/U2Designer/src/MarkerEditor.cpp
@@ -76,7 +76,7 @@ void MarkerEditor::setConfiguration(Actor* actor) {
         }
     }
 
-    if (nullptr == mAttr) {
+    if (mAttr == nullptr) {
         return;
     }
 

--- a/src/corelibs/U2Designer/src/MarkerEditorWidget.cpp
+++ b/src/corelibs/U2Designer/src/MarkerEditorWidget.cpp
@@ -56,7 +56,8 @@ MarkerEditorWidget::MarkerEditorWidget(QAbstractTableModel* markerModel, QWidget
 }
 
 void MarkerEditorWidget::sl_onAddButtonClicked() {
-    Workflow::MarkerGroupListCfgModel* model = dynamic_cast<Workflow::MarkerGroupListCfgModel*>(markerTable->model());
+    auto model = dynamic_cast<Workflow::MarkerGroupListCfgModel*>(markerTable->model());
+    SAFE_POINT(model != nullptr, "MarkerEditorWidget: model is null", );
     QObjectScopedPointer<EditMarkerGroupDialog> dlg = new EditMarkerGroupDialog(true, nullptr, model, this);
     const int dialogResult = dlg->exec();
     CHECK(!dlg.isNull(), );
@@ -74,7 +75,8 @@ void MarkerEditorWidget::sl_onEditButtonClicked() {
         return;
     }
 
-    Workflow::MarkerGroupListCfgModel* model = dynamic_cast<Workflow::MarkerGroupListCfgModel*>(markerTable->model());
+    auto model = dynamic_cast<Workflow::MarkerGroupListCfgModel*>(markerTable->model());
+    SAFE_POINT(model != nullptr, "sl_onEditButtonClicked: model is null", );
     QObjectScopedPointer<EditMarkerGroupDialog> dlg = new EditMarkerGroupDialog(false, model->getMarker(selected.first().row()), model, this);
     const int dialogResult = dlg->exec();
     CHECK(!dlg.isNull(), );
@@ -114,7 +116,9 @@ void MarkerEditorWidget::sl_onItemSelected(const QModelIndex&) {
 }
 
 bool MarkerEditorWidget::checkEditMarkerGroupResult(const QString& oldName, Marker* newMarker, QString& message) {
-    Workflow::MarkerGroupListCfgModel* model = dynamic_cast<Workflow::MarkerGroupListCfgModel*>(markerTable->model());
+    auto model = dynamic_cast<Workflow::MarkerGroupListCfgModel*>(markerTable->model());
+    SAFE_POINT(model != nullptr, "checkEditMarkerGroupResult: model is null", false);
+
     QList<Marker*>& markers = model->getMarkers();
 
     if (oldName != newMarker->getName()) {
@@ -130,7 +134,8 @@ bool MarkerEditorWidget::checkEditMarkerGroupResult(const QString& oldName, Mark
 }
 
 bool MarkerEditorWidget::checkAddMarkerGroupResult(Marker* newMarker, QString& message) {
-    Workflow::MarkerGroupListCfgModel* model = dynamic_cast<Workflow::MarkerGroupListCfgModel*>(markerTable->model());
+    auto model = dynamic_cast<Workflow::MarkerGroupListCfgModel*>(markerTable->model());
+    SAFE_POINT(model != nullptr, "checkAddMarkerGroupResult: model is null", false);
     QList<Marker*>& markers = model->getMarkers();
 
     foreach (Marker* m, markers) {

--- a/src/corelibs/U2Designer/src/NewGrouperSlotDialog.cpp
+++ b/src/corelibs/U2Designer/src/NewGrouperSlotDialog.cpp
@@ -91,8 +91,8 @@ ActionDialog* ActionDialog::getActionDialog(QWidget* parent, GrouperSlotAction* 
         return new StringActionDialog(parent, action);
     } else if (BaseTypes::ANNOTATION_TABLE_LIST_TYPE() == type ||
                BaseTypes::ANNOTATION_TABLE_TYPE() == type) {
-        GrouperSlotsCfgModel* m = dynamic_cast<GrouperSlotsCfgModel*>(grouperModel);
-        assert(nullptr != m);
+        auto m = dynamic_cast<GrouperSlotsCfgModel*>(grouperModel);
+        SAFE_POINT(m != nullptr, "getActionDialog: m is null", nullptr);
         QStringList mergeSeqSlots = m->getMergeSeqSlotsNames();
         return new AnnsActionDialog(parent, action, mergeSeqSlots);
     }

--- a/src/corelibs/U2Designer/src/wizard/PropertyWizardController.cpp
+++ b/src/corelibs/U2Designer/src/wizard/PropertyWizardController.cpp
@@ -86,8 +86,8 @@ QWidget* InUrlDatasetsController::createGUI(U2OpStatus& /*os*/) {
         sets.clear();
         sets << Dataset();
     }
-    URLAttribute* attr = dynamic_cast<URLAttribute*>(attribute());
-    SAFE_POINT(nullptr != attr, "Unexpected attribute value", nullptr);
+    auto attr = dynamic_cast<URLAttribute*>(attribute());
+    SAFE_POINT(attr != nullptr, "Unexpected attribute value", nullptr);
     const QSet<GObjectType> compatibleObjTypes = nullptr != attr ? attr->getCompatibleObjectTypes() : QSet<GObjectType>();
     dsc = new AttributeDatasetsController(sets, compatibleObjTypes);
     connect(dsc, SIGNAL(si_attributeChanged()), SLOT(sl_datasetsChanged()));

--- a/src/corelibs/U2Designer/src/wizard/TophatSamplesWidgetController.cpp
+++ b/src/corelibs/U2Designer/src/wizard/TophatSamplesWidgetController.cpp
@@ -363,10 +363,10 @@ bool TophatSamples::rename(QLineEdit* nameEdit) {
 }
 
 void TophatSamples::sl_remove() {
-    QToolButton* toolButton = dynamic_cast<QToolButton*>(sender());
-    SAFE_POINT(nullptr != toolButton, "NULL button", );
+    auto toolButton = dynamic_cast<QToolButton*>(sender());
+    SAFE_POINT(toolButton != nullptr, "NULL button", );
     QWidget* sampleWidget = toolButton->parentWidget();
-    CHECK(nullptr != sampleWidget, );
+    CHECK(sampleWidget != nullptr, );
     CHECK(order.contains(sampleWidget), );
 
     // remove
@@ -399,8 +399,8 @@ void TophatSamples::sl_add() {
 }
 
 void TophatSamples::sl_selectionChanged() {
-    QListWidget* selectedList = dynamic_cast<QListWidget*>(sender());
-    CHECK(nullptr != selectedList, );
+    auto selectedList = dynamic_cast<QListWidget*>(sender());
+    CHECK(selectedList != nullptr, );
     CHECK(selectedList->selectedItems().size() > 0, );
 
     QWidget* sampleWidget = selectedList->parentWidget();

--- a/src/corelibs/U2Designer/src/wizard/WizardController.cpp
+++ b/src/corelibs/U2Designer/src/wizard/WizardController.cpp
@@ -250,20 +250,20 @@ void WizardController::sl_customButtonClicked(int which) {
     if (QWizard::CustomButton1 == which) {
         run();
     } else if (QWizard::CustomButton2 == which) {
-        QWizard* w = dynamic_cast<QWizard*>(sender());
-        CHECK(nullptr != w, );
+        auto w = dynamic_cast<QWizard*>(sender());
+        CHECK(w != nullptr, );
         defaults(w->currentPage());
     }
 }
 
 void WizardController::sl_pageChanged(int num) {
-    CHECK(-1 != num, );
+    CHECK(num != -1, );
 
-    QWizard* wizard = dynamic_cast<QWizard*>(sender());
-    CHECK(nullptr != wizard, );
+    auto wizard = dynamic_cast<QWizard*>(sender());
+    CHECK(wizard != nullptr, );
 
     QWizardPage* page = wizard->currentPage();
-    CHECK(nullptr != page, );
+    CHECK(page != nullptr, );
 
     page->cleanupPage();
     page->initializePage();
@@ -275,8 +275,8 @@ bool WizardController::eventFilter(QObject* watched, QEvent* event) {
     if (event->type() == QEvent::Close) {  // if close button is pressed
         rejected = true;
     } else if (event->type() == QEvent::KeyPress) {  // if ESC is pressed
-        QKeyEvent* keyEvent = dynamic_cast<QKeyEvent*>(event);
-        CHECK(nullptr != keyEvent, QObject::eventFilter(watched, event));
+        auto keyEvent = dynamic_cast<QKeyEvent*>(event);
+        CHECK(keyEvent != nullptr, QObject::eventFilter(watched, event));
 
         if ((keyEvent->key() == Qt::Key_Escape) && (keyEvent->modifiers() == Qt::NoModifier)) {
             rejected = true;


### PR DESCRIPTION
This is the first patch in the series where I want to add an explicit nullptr checks after any dynamic/qobject cast in UGENE code

In the series of patches I will  update the whole UGENE code project-by-project and also fix related `auto` usage code style issues: add `auto` in case if type is used twice in the same line: as a part of the variable declaration & the cast