### PR TITLE
Cleanup AppResources.h source code

### DIFF
--- a/src/corelibs/U2Core/src/globals/AppResources.cpp
+++ b/src/corelibs/U2Core/src/globals/AppResources.cpp
@@ -257,7 +257,7 @@ AppResourceReadWriteLock::~AppResourceReadWriteLock() {
 }
 
 void AppResourceReadWriteLock::acquire(int type) {
-    SAFE_POINT(type == UseType::Read || type == UseType::Write, "Invalid lock type: " + QString::number(type), );
+    SAFE_POINT(type == UseType::Read || type == UseType::Write, "AppResourceReadWriteLock::acquire. Invalid lock type: " + QString::number(type), );
     if (type == UseType::Write) {
         resource->lockForWrite();
     } else {
@@ -266,12 +266,12 @@ void AppResourceReadWriteLock::acquire(int type) {
 }
 
 bool AppResourceReadWriteLock::tryAcquire(int type) {
-    SAFE_POINT(type == UseType::Read || type == UseType::Write, "Invalid lock type: " + QString::number(type), false);
+    SAFE_POINT(type == UseType::Read || type == UseType::Write, "AppResourceReadWriteLock::tryAcquire. Invalid lock type: " + QString::number(type), false);
     return type == UseType::Write ? resource->tryLockForWrite() : resource->tryLockForRead();
 }
 
 bool AppResourceReadWriteLock::tryAcquire(int type, int timeout) {
-    SAFE_POINT(type == UseType::Read || type == UseType::Write, "Invalid lock type: " + QString::number(type), false);
+    SAFE_POINT(type == UseType::Read || type == UseType::Write, "AppResourceReadWriteLock::tryAcquire(timeout). Invalid lock type: " + QString::number(type), false);
     return type == UseType::Write ? resource->tryLockForWrite(timeout) : resource->tryLockForRead(timeout);
 }
 

--- a/src/corelibs/U2Core/src/globals/AppResources.cpp
+++ b/src/corelibs/U2Core/src/globals/AppResources.cpp
@@ -32,7 +32,6 @@
 #include <U2Test/GTest.h>
 
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-#    include <stdio.h>
 #    include <unistd.h>  //for sysconf(3)
 #endif
 #if defined(Q_OS_LINUX)
@@ -94,8 +93,8 @@ AppResourcePool::AppResourcePool() {
     memResource = new AppResourceSemaphore(RESOURCE_MEMORY, maxMem, tr("Memory"), tr("Mb"));
     registerResource(memResource);
 
-    projectResouce = new AppResourceSemaphore(RESOURCE_PROJECT, 1, tr("Project"));
-    registerResource(projectResouce);
+    projectResource = new AppResourceSemaphore(RESOURCE_PROJECT, 1, tr("Project"));
+    registerResource(projectResource);
 
     listenLogInGTest = new AppResourceReadWriteLock(RESOURCE_LISTEN_LOG_IN_TESTS, "LogInTests");
     registerResource(listenLogInGTest);
@@ -106,9 +105,8 @@ AppResourcePool::~AppResourcePool() {
 }
 
 int AppResourcePool::getTotalPhysicalMemory() {
-    int totalPhysicalMemory = defaultMemoryLimitMb;
-
 #if defined(Q_OS_WIN32)
+    int totalPhysicalMemory = defaultMemoryLimitMb;
     MEMORYSTATUSEX memory_status;
     ZeroMemory(&memory_status, sizeof(MEMORYSTATUSEX));
     memory_status.dwLength = sizeof(memory_status);
@@ -124,11 +122,12 @@ int AppResourcePool::getTotalPhysicalMemory() {
 
     // Assume that page size is always a multiple of 1024, so it can be
     // divided without losing any precision.  On the other hand, number
-    // of pages would hardly overflow `long' when multiplied by a small
+    // of pages would hardly overflow 'long' when multiplied by a small
     // number (number of pages / 1024), so we should be safe here.
-    totalPhysicalMemory = (int)(numpages * (pagesize / 1024) / 1024);
+    int totalPhysicalMemory = (int)(numpages * (pagesize / 1024) / 1024);
 
 #elif defined(Q_OS_DARWIN)
+    int totalPhysicalMemory = defaultMemoryLimitMb;
     QProcess p;
     p.start("sysctl", QStringList() << "-n"
                                     << "hw.memsize");
@@ -148,9 +147,9 @@ int AppResourcePool::getTotalPhysicalMemory() {
 }
 
 void AppResourcePool::setIdealThreadCount(int n) {
-    SAFE_POINT(n > 0 && n <= threadResource->maxUse(), QString("Invalid ideal threads count: %1").arg(n), );
+    SAFE_POINT(n > 0 && n <= threadResource->getMaximumUsage(), QString("Invalid ideal threads count: %1").arg(n), );
 
-    n = qBound(1, n, threadResource->maxUse());
+    n = qBound(1, n, threadResource->getMaximumUsage());
     idealThreadCount = n;
     AppContext::getSettings()->setValue(SETTINGS_ROOT + "idealThreadCount", idealThreadCount);
 }
@@ -158,15 +157,17 @@ void AppResourcePool::setIdealThreadCount(int n) {
 void AppResourcePool::setMaxThreadCount(int n) {
     SAFE_POINT(n >= 1, QString("Invalid max threads count: %1").arg(n), );
 
-    threadResource->setMaxUse(qMax(idealThreadCount, n));
-    AppContext::getSettings()->setValue(SETTINGS_ROOT + "maxThreadCount", threadResource->maxUse());
+    threadResource->setMaximumUsage(qMax(idealThreadCount, n));
+    AppContext::getSettings()->setValue(SETTINGS_ROOT + "maxThreadCount", threadResource->getMaximumUsage());
 }
 
-void AppResourcePool::setMaxMemorySizeInMB(int n) {
-    SAFE_POINT(n >= MIN_MEMORY_SIZE, QString("Invalid max memory size: %1").arg(n), );
+static constexpr int MIN_MAXIMUM_MEMORY_SIZE_MB = 200;
 
-    memResource->setMaxUse(qMax(n, MIN_MEMORY_SIZE));
-    AppContext::getSettings()->setValue(SETTINGS_ROOT + "maxMem", memResource->maxUse());
+void AppResourcePool::setMaxMemorySizeInMB(int n) {
+    int maxMemorySize = qMax(n, MIN_MAXIMUM_MEMORY_SIZE_MB);
+    memResource->setMaximumUsage(maxMemorySize);
+    AppContext::getSettings()->setValue(SETTINGS_ROOT + "maxMem", maxMemorySize);
+    SAFE_POINT(n >= MIN_MAXIMUM_MEMORY_SIZE_MB, "Invalid max memory size: " + QString::number(n), );
 }
 
 size_t AppResourcePool::getCurrentAppMemory() {
@@ -188,10 +189,8 @@ size_t AppResourcePool::getCurrentAppMemory() {
     p.close();
     bool ok = false;
     qlonglong output_mem = ps_vsize.toLongLong(&ok);
-    if (ok) {
-        return output_mem;
-    }
-#elif defined(Q_OS_DARWIN)
+    return ok ? output_mem : 0;
+// #elif defined(Q_OS_DARWIN)
 //    qint64 pid = QCoreApplication::applicationPid();
 
 //    QProcess p;
@@ -205,8 +204,9 @@ size_t AppResourcePool::getCurrentAppMemory() {
 //    if (ok) {
 //        return output_mem * 1024 * 1024;
 //    }
+#else
+    return 0;
 #endif
-    return -1;
 }
 
 void AppResourcePool::registerResource(AppResource* r) {
@@ -229,17 +229,177 @@ AppResourcePool* AppResourcePool::instance() {
     return AppContext::getAppSettings() ? AppContext::getAppSettings()->getAppResourcePool() : nullptr;
 }
 
-MemoryLocker& MemoryLocker::operator=(MemoryLocker& other) {
-    MemoryLocker tmp(other);
-    qSwap(os, tmp.os);
-    qSwap(preLockMB, tmp.preLockMB);
-    qSwap(lockedMB, tmp.lockedMB);
-    qSwap(needBytes, tmp.needBytes);
-    qSwap(memoryLockType, tmp.memoryLockType);
-    qSwap(resource, tmp.resource);
-    qSwap(errorMessage, tmp.errorMessage);
+////////////////////////////////////////////////
+///////////// AppResource
 
-    return *this;
+AppResource::AppResource(int id, int _maxUse, const QString& _name, const QString& _suffix)
+    : name(_name), suffix(_suffix), resourceId(id), maximumUsage(_maxUse) {
+}
+
+int AppResource::getMaximumUsage() const {
+    return maximumUsage;
+}
+
+int AppResource::getResourceId() const {
+    return resourceId;
+}
+
+////////////////////////////////////////////////
+///////////// AppResourceReadWriteLock
+
+AppResourceReadWriteLock::AppResourceReadWriteLock(int id, const QString& _name, const QString& _suffix)
+    : AppResource(id, Write, _name, _suffix) {
+    resource = new QReadWriteLock();
+}
+
+AppResourceReadWriteLock::~AppResourceReadWriteLock() {
+    delete resource;
+}
+
+void AppResourceReadWriteLock::acquire(int type) {
+    SAFE_POINT(type == UseType::Read || type == UseType::Write, "Invalid lock type: " + QString::number(type), );
+    if (type == UseType::Write) {
+        resource->lockForWrite();
+    } else {
+        resource->lockForRead();
+    }
+}
+
+bool AppResourceReadWriteLock::tryAcquire(int type) {
+    SAFE_POINT(type == UseType::Read || type == UseType::Write, "Invalid lock type: " + QString::number(type), false);
+    return type == UseType::Write ? resource->tryLockForWrite() : resource->tryLockForRead();
+}
+
+bool AppResourceReadWriteLock::tryAcquire(int type, int timeout) {
+    SAFE_POINT(type == UseType::Read || type == UseType::Write, "Invalid lock type: " + QString::number(type), false);
+    return type == UseType::Write ? resource->tryLockForWrite(timeout) : resource->tryLockForRead(timeout);
+}
+
+void AppResourceReadWriteLock::release(int) {
+    resource->unlock();
+}
+
+int AppResourceReadWriteLock::available() const {
+    return -1;
+}
+
+////////////////////////////////////////////////
+///////////// AppResourceReadWriteLock
+
+AppResourceSemaphore::AppResourceSemaphore(int id, int _maxUse, const QString& _name, const QString& _suffix)
+    : AppResource(id, _maxUse, _name, _suffix) {
+    resource = new QSemaphore(_maxUse);
+}
+
+AppResourceSemaphore::~AppResourceSemaphore() {
+    delete resource;
+}
+
+void AppResourceSemaphore::acquire(int n) {
+    LOG_TRACE(acquire);
+    resource->acquire(n);
+}
+
+bool AppResourceSemaphore::tryAcquire(int n) {
+    LOG_TRACE(tryAcquire);
+    return resource->tryAcquire(n);
+}
+
+bool AppResourceSemaphore::tryAcquire(int n, int timeout) {
+    LOG_TRACE(tryAcquire_timeout);
+    return resource->tryAcquire(n, timeout);
+}
+
+void AppResourceSemaphore::release(int n) {
+    LOG_TRACE(release);
+    SAFE_POINT(n >= 0, QString("AppResource %1 release %2 < 0 called").arg(name).arg(n), );
+    resource->release(n);
+    // QSemaphore allow to create resources by releasing, we do not want to get such behavior
+    int avail = resource->available();
+    SAFE_POINT(avail <= maximumUsage, "Invalid result available resource value: " + QString::number(avail), );
+}
+
+int AppResourceSemaphore::available() const {
+    return resource->available();
+}
+
+void AppResourceSemaphore::setMaximumUsage(int n) {
+    LOG_TRACE(setMaximumUsage);
+    int diff = n - maximumUsage;
+    if (diff > 0) {
+        // adding resources
+        resource->release(diff);
+        maximumUsage += diff;
+    } else {
+        diff = -diff;
+        // safely remove resources
+        for (int i = diff; i > 0; i--) {
+            bool ok = resource->tryAcquire(i, 0);
+            if (ok) {
+                // successfully acquired i resources
+                maximumUsage -= i;
+                break;
+            }
+        }
+    }
+}
+
+////////////////////////////////////////////////
+///////////// MemoryLocker
+
+MemoryLocker::MemoryLocker(U2OpStatus& os, int preLockMB)
+    : os(&os),
+      preLockMB(preLockMB > 0 ? preLockMB : 0) {
+    resource = AppResourcePool::instance()->getResource(RESOURCE_MEMORY);
+    tryAcquire(0);
+}
+
+MemoryLocker::MemoryLocker(int preLockMB)
+    : preLockMB(preLockMB > 0 ? preLockMB : 0) {
+    resource = AppResourcePool::instance()->getResource(RESOURCE_MEMORY);
+    tryAcquire(0);
+}
+
+MemoryLocker::~MemoryLocker() {
+    release();
+}
+
+bool MemoryLocker::tryAcquire(qint64 bytes) {
+    needBytes += bytes;
+
+    int needMB = needBytes / (1000 * 1000) + preLockMB;
+    if (needMB > lockedMB) {
+        int diff = needMB - lockedMB;
+        CHECK_EXT(resource != nullptr, if (os) os->setError("MemoryLocker - Resource error"), false);
+        bool ok = resource->tryAcquire(diff);
+        if (ok) {
+            lockedMB = needMB;
+        } else {
+            errorMessage = QString("MemoryLocker - Not enough memory error, %1 megabytes are required").arg(needMB);
+            if (nullptr != os) {
+                os->setError(errorMessage);
+            }
+        }
+        return ok;
+    }
+    return true;
+}
+
+void MemoryLocker::release() {
+    CHECK_EXT(resource != nullptr, if (os) os->setError("MemoryLocker - Resource error"), );
+    if (lockedMB > 0) {
+        resource->release(lockedMB);
+    }
+    lockedMB = 0;
+    needBytes = 0;
+}
+
+bool MemoryLocker::hasError() const {
+    return !errorMessage.isEmpty();
+}
+
+const QString& MemoryLocker::getError() const {
+    return errorMessage;
 }
 
 }  // namespace U2

--- a/src/corelibs/U2Core/src/globals/AppResources.h
+++ b/src/corelibs/U2Core/src/globals/AppResources.h
@@ -48,218 +48,98 @@ namespace U2 {
 #define LOG_TRACE(METHOD) \
     coreLog.trace(QString("AppResource %1 ::" #METHOD " %2, available %3").arg(name).arg(n).arg(available()));
 
+/** Abstraction of a unique logical resource with max capacity. */
 class U2CORE_EXPORT AppResource {
 public:
-    // TaskMemory will be released after Task is finished,
-    // SystemMemory will be released only on UGENE shutdown. Example: SQLite buffer memory lock
-    enum MemoryLockType {
-        TaskMemory,
-        SystemMemory
-    };
+    AppResource(int id, int maxUse, const QString& name, const QString& suffix = "");
+    virtual ~AppResource() = default;
 
-    AppResource(int id, int _maxUse, const QString& _name, const QString& _suffix = QString())
-        : name(_name), suffix(_suffix), resourceId(id), _maxUse(_maxUse), systemUse(0) {
-    }
+    AppResource(const AppResource& other) = delete;
+    AppResource& operator=(const AppResource& other) = delete;
 
-    virtual ~AppResource() {
-    }
+    virtual void acquire(int n) = 0;
 
-    virtual void acquire(int n = 1, MemoryLockType lt = TaskMemory) = 0;
-    virtual bool tryAcquire(int n = 1, MemoryLockType lt = TaskMemory) = 0;
+    virtual bool tryAcquire(int n) = 0;
 
-    virtual bool tryAcquire(int n, int timeout, MemoryLockType lt = TaskMemory) = 0;
+    virtual bool tryAcquire(int n, int timeout) = 0;
 
-    virtual void release(int n = 1, MemoryLockType lt = TaskMemory) = 0;
+    virtual void release(int n) = 0;
 
+    /** Returns available amount of the resource. If returns -1 the method is not supported. */
     virtual int available() const = 0;
 
-    // total maximum usage of resource
-    int maxUse() const {
-        return _maxUse;
-    }
+    int getMaximumUsage() const;
 
-    // total maximum usage of resource without system memory
-    int maxTaskUse() const {
-        SAFE_POINT_EXT(systemUse >= 0, , _maxUse);
-        return _maxUse - systemUse;
-    }
-    int getResourceId() const {
-        return resourceId;
-    }
+    int getResourceId() const;
 
-    QString name;
-    QString suffix;
+    /** Visual resource name. */
+    const QString name;
+
+    /** Visual resource suffix (units): Mb, Kb, threads, etc…. */
+    const QString suffix;
 
 protected:
-    int resourceId;
-    int _maxUse;
-    int systemUse;
+    /** Unique resource id. */
+    int resourceId = -1;
 
-private:
-    AppResource(const AppResource& other);
-    AppResource& operator=(const AppResource& other);
+    /** Maximum limit available for acquire for the resource. */
+    int maximumUsage = -1;
 };
 
+/** Resource based on QReadWriteLock. The resource must be acquire with either UseType::Read or UseType::Write. */
 class U2CORE_EXPORT AppResourceReadWriteLock : public AppResource {
 public:
-    AppResourceReadWriteLock(int id, const QString& _name, const QString& _suffix = QString())
-        : AppResource(id, Write, _name, _suffix), resource(nullptr) {
-        resource = new QReadWriteLock;
-    }
+    AppResourceReadWriteLock(int id, const QString& name, const QString& suffix = "");
 
-    virtual ~AppResourceReadWriteLock() {
-        delete resource;
-        resource = nullptr;
-    }
+    ~AppResourceReadWriteLock() override;
 
     enum UseType {
-        Read,
-        Write
+        Read = 1,
+        Write = 2,
     };
 
-    // for TaskScheduler
-    virtual void acquire(int n, MemoryLockType lt = TaskMemory) {
-        Q_UNUSED(lt);
-        switch (n) {
-            case Read:
-                resource->lockForRead();
-                break;
-            case Write:
-                resource->lockForWrite();
-                break;
-            default:
-                break;
-        }
-    }
+    void acquire(int n) override;
 
-    virtual bool tryAcquire(int n, MemoryLockType lt = TaskMemory) {
-        Q_UNUSED(lt);
-        switch (n) {
-            case Read:
-                return resource->tryLockForRead();
-            case Write:
-                return resource->tryLockForWrite();
-            default:
-                return false;
-        }
-    }
-    virtual bool tryAcquire(int n, int timeout, MemoryLockType lt = TaskMemory) {
-        Q_UNUSED(lt);
-        switch (n) {
-            case Read:
-                return resource->tryLockForRead(timeout);
-            case Write:
-                return resource->tryLockForWrite(timeout);
-            default:
-                return false;
-        }
-    }
+    bool tryAcquire(int n) override;
 
-    virtual void release(int n, MemoryLockType lt = TaskMemory) {
-        Q_UNUSED(n);
-        Q_UNUSED(lt);
-        resource->unlock();
-    }
+    bool tryAcquire(int n, int timeout) override;
 
-    virtual int available() const {
-        return -1;
-    }
+    void release(int) override;
+
+    int available() const override;
 
 private:
-    QReadWriteLock* resource;
+    QReadWriteLock* resource = nullptr;
 };
 
+/** Resource based on QSemaphore (counter). The resource may be acquired up to maxUse times. */
 class U2CORE_EXPORT AppResourceSemaphore : public AppResource {
 public:
-    AppResourceSemaphore(int id, int _maxUse, const QString& _name, const QString& _suffix = QString())
-        : AppResource(id, _maxUse, _name, _suffix), resource(nullptr) {
-        resource = new QSemaphore(_maxUse);
-    }
-    virtual ~AppResourceSemaphore() {
-        delete resource;
-        resource = nullptr;
-    }
+    AppResourceSemaphore(int id, int maxUse, const QString& name, const QString& suffix = "");
 
-    void acquire(int n = 1, MemoryLockType lt = TaskMemory) {
-        LOG_TRACE(acquire);
-        resource->acquire(n);
-        if (lt == AppResource::SystemMemory) {
-            systemUse += n;
-        }
-    }
+    ~AppResourceSemaphore() override;
 
-    bool tryAcquire(int n = 1, MemoryLockType lt = TaskMemory) {
-        LOG_TRACE(tryAcquire);
-        bool acquired = resource->tryAcquire(n);
-        if (acquired && (lt == AppResource::SystemMemory)) {
-            systemUse += n;
-        }
-        return acquired;
-    }
+    void acquire(int n) override;
 
-    bool tryAcquire(int n, int timeout, MemoryLockType lt = TaskMemory) {
-        LOG_TRACE(tryAcquire_timeout);
-        bool acquired = resource->tryAcquire(n, timeout);
-        if (acquired && (lt == AppResource::SystemMemory)) {
-            systemUse += n;
-        }
-        return acquired;
-    }
+    bool tryAcquire(int n) override;
 
-    void release(int n = 1, MemoryLockType lt = TaskMemory) {
-        LOG_TRACE(release);
-        SAFE_POINT(n >= 0, QString("AppResource %1 release %2 < 0 called").arg(name).arg(n), );
-        resource->release(n);
-        if (lt == AppResource::SystemMemory) {
-            systemUse -= n;
-            SAFE_POINT_EXT(systemUse >= 0, , );
-        }
+    bool tryAcquire(int n, int timeout) override;
 
-        // QSemaphore allow to create resources by releasing, we do not want to get such behavior
-        int avail = resource->available();
-        SAFE_POINT_EXT(avail <= _maxUse, , );
-    }
+    void release(int n) override;
 
-    int available() const {
-        return resource->available();
-    }
+    int available() const override;
 
-    void setMaxUse(int n) {
-        LOG_TRACE(setMaxUse);
-        int diff = n - _maxUse;
-        if (diff > 0) {
-            // adding resources
-            resource->release(diff);
-            _maxUse += diff;
-        } else {
-            diff = -diff;
-            // safely remove resources
-            for (int i = diff; i > 0; i--) {
-                bool ok = resource->tryAcquire(i, 0);
-                if (ok) {
-                    // successfully acquired i resources
-                    _maxUse -= i;
-                    if (_maxUse < systemUse) {
-                        resource->release(systemUse - _maxUse);
-                        _maxUse = systemUse;
-                    }
-                    break;
-                }
-            }
-        }
-    }
+    void setMaximumUsage(int n);
 
 private:
-    QSemaphore* resource;
+    QSemaphore* resource = nullptr;
 };
-
-#define MIN_MEMORY_SIZE 200
 
 class U2CORE_EXPORT AppResourcePool : public QObject {
     Q_OBJECT
 public:
     AppResourcePool();
-    virtual ~AppResourcePool();
+    ~AppResourcePool() override;
 
     int getIdealThreadCount() const {
         return idealThreadCount;
@@ -267,18 +147,19 @@ public:
     void setIdealThreadCount(int n);
 
     int getMaxThreadCount() const {
-        return threadResource->maxUse();
+        return threadResource->getMaximumUsage();
     }
     void setMaxThreadCount(int n);
 
     int getMaxMemorySizeInMB() const {
-        return memResource->maxUse();
+        return memResource->getMaximumUsage();
     }
     void setMaxMemorySizeInMB(int m);
 
     static size_t getCurrentAppMemory();
 
     void registerResource(AppResource* r);
+
     void unregisterResource(int id);
 
     AppResource* getResource(int id) const;
@@ -288,107 +169,46 @@ public:
     static int getTotalPhysicalMemory();
 
     static const int x64MaxMemoryLimitMb = 2 * 1024 * 1024;  // 2Tb
+
 private:
     static const int defaultMemoryLimitMb = 8 * 1024;
 
     QHash<int, AppResource*> resources;
 
-    int idealThreadCount;
+    int idealThreadCount = 0;
 
-    AppResourceSemaphore* threadResource;
-    AppResourceSemaphore* memResource;
-    AppResourceSemaphore* projectResouce;
-    AppResourceReadWriteLock* listenLogInGTest;
+    AppResourceSemaphore* threadResource = nullptr;
+    AppResourceSemaphore* memResource = nullptr;
+    AppResourceSemaphore* projectResource = nullptr;
+    AppResourceReadWriteLock* listenLogInGTest = nullptr;
 };
 
-class MemoryLocker {
+class U2CORE_EXPORT MemoryLocker {
 public:
-    MemoryLocker(U2OpStatus& os, int preLockMB = 10, AppResource::MemoryLockType memoryLockType = AppResource::TaskMemory)
-        : os(&os),
-          preLockMB(preLockMB > 0 ? preLockMB : 0),
-          lockedMB(0),
-          needBytes(0),
-          resource(nullptr),
-          memoryLockType(memoryLockType) {
-        resource = AppResourcePool::instance()->getResource(RESOURCE_MEMORY);
-        tryAcquire(0);
-    }
+    MemoryLocker(U2OpStatus& os, int preLockMB = 10);
 
-    MemoryLocker(int preLockMB = 10, AppResource::MemoryLockType memoryLockType = AppResource::TaskMemory)
-        : os(nullptr),
-          preLockMB(preLockMB > 0 ? preLockMB : 0),
-          lockedMB(0),
-          needBytes(0),
-          resource(nullptr),
-          memoryLockType(memoryLockType) {
-        resource = AppResourcePool::instance()->getResource(RESOURCE_MEMORY);
-        tryAcquire(0);
-    }
+    MemoryLocker(int preLockMB = 10);
 
-    MemoryLocker(MemoryLocker& other) {
-        resource = other.resource;
-        memoryLockType = other.memoryLockType;
-        os = nullptr;
-        preLockMB = other.preLockMB;
-        lockedMB = other.lockedMB;
-        other.lockedMB = 0;
-        needBytes = other.needBytes;
-        other.needBytes = 0;
-        resource = nullptr;
-        errorMessage = "";
-    }
+    virtual ~MemoryLocker();
 
-    MemoryLocker& operator=(MemoryLocker& other);
+    MemoryLocker(const MemoryLocker& other) = delete;
 
-    virtual ~MemoryLocker() {
-        release();
-    }
+    MemoryLocker& operator=(const MemoryLocker& other) = delete;
 
-    bool tryAcquire(qint64 bytes) {
-        needBytes += bytes;
+    bool tryAcquire(qint64 bytes);
 
-        int needMB = needBytes / (1000 * 1000) + preLockMB;
-        if (needMB > lockedMB) {
-            int diff = needMB - lockedMB;
-            CHECK_EXT(nullptr != resource, if (os) os->setError("MemoryLocker - Resource error"), false);
-            bool ok = resource->tryAcquire(diff, memoryLockType);
-            if (ok) {
-                lockedMB = needMB;
-            } else {
-                errorMessage = QString("MemoryLocker - Not enough memory error, %1 megabytes are required").arg(needMB);
-                if (nullptr != os) {
-                    os->setError(errorMessage);
-                }
-            }
-            return ok;
-        }
-        return true;
-    }
+    void release();
 
-    void release() {
-        CHECK_EXT(nullptr != resource, if (os) os->setError("MemoryLocker - Resource error"), );
-        if (lockedMB > 0) {
-            resource->release(lockedMB, memoryLockType);
-        }
-        lockedMB = 0;
-        needBytes = 0;
-    }
+    bool hasError() const;
 
-    bool hasError() {
-        return !errorMessage.isEmpty();
-    }
-
-    const QString& getError() {
-        return errorMessage;
-    }
+    const QString& getError() const;
 
 private:
-    U2OpStatus* os;
-    int preLockMB;
-    int lockedMB;
-    qint64 needBytes;
-    AppResource* resource;
-    AppResource::MemoryLockType memoryLockType;
+    U2OpStatus* os = nullptr;
+    int preLockMB = 0;
+    int lockedMB = 0;
+    qint64 needBytes = 0;
+    AppResource* resource = nullptr;
     QString errorMessage;
 };
 

--- a/src/corelibs/U2Core/src/globals/AppResources.h
+++ b/src/corelibs/U2Core/src/globals/AppResources.h
@@ -94,8 +94,8 @@ public:
     ~AppResourceReadWriteLock() override;
 
     enum UseType {
-        Read = 1,
-        Write = 2,
+        Read = 0,
+        Write = 1,
     };
 
     void acquire(int n) override;

--- a/src/corelibs/U2Core/src/globals/Task.h
+++ b/src/corelibs/U2Core/src/globals/Task.h
@@ -36,22 +36,14 @@ namespace U2 {
 
 struct U2CORE_EXPORT TaskResourceUsage {
     TaskResourceUsage(int id = 0, int use = 0, bool prepareStage = false)
-        : resourceId(id), resourceUse(use), prepareStageLock(prepareStage), locked(false) {
-    }
-
-    enum UseType {
-        Read,
-        Write
-    };
-
-    TaskResourceUsage(int id, UseType use, bool prepareStage = false)
-        : resourceId(id), resourceUse(use), prepareStageLock(prepareStage), locked(false) {
+        : resourceId(id), resourceUse(use), prepareStageLock(prepareStage) {
     }
 
     int resourceId;
     int resourceUse;
     bool prepareStageLock;
-    bool locked;
+    bool locked = false;
+
     /* Leave it empty for default message */
     QString errorMessage;
 };

--- a/src/corelibs/U2Private/src/TaskSchedulerImpl.cpp
+++ b/src/corelibs/U2Private/src/TaskSchedulerImpl.cpp
@@ -386,7 +386,7 @@ QString TaskSchedulerImpl::tryLockResources(Task* task, bool prepareStage, bool&
             SAFE_POINT(prepareStage ? !taskRes.locked : taskRes.locked, QString("Task %1 lock state is not correct.").arg(task->getTaskName()), L10N::internalError());
             continue;
         }
-        SAFE_POINT(!prepareStage || taskRes.resourceId != RESOURCE_THREAD, QString("Task %1 resouce id belongs to wrong thread.").arg(task->getTaskName()), L10N::internalError());
+        SAFE_POINT(!prepareStage || taskRes.resourceId != RESOURCE_THREAD, QString("Task %1 resource id belongs to wrong thread.").arg(task->getTaskName()), L10N::internalError());
         AppResource* appRes = resourcePool->getResource(taskRes.resourceId);
         if (!appRes) {
             task->setError(tr("No required resources for the task, resource id: '%1'").arg(taskRes.resourceId));

--- a/src/corelibs/U2Private/src/TaskSchedulerImpl.cpp
+++ b/src/corelibs/U2Private/src/TaskSchedulerImpl.cpp
@@ -371,7 +371,7 @@ QString TaskSchedulerImpl::tryLockResources(Task* task, bool prepareStage, bool&
     // to work but there are child tasks with locked threads waiting for instructions from the WD scheduler.
     bool isThreadResourceNeeded = !prepareStage && !task->hasFlags(TaskFlag_RunMessageLoopOnly);
     if (isThreadResourceNeeded) {
-        if (!threadsResource->tryAcquire()) {
+        if (!threadsResource->tryAcquire(1)) {
             return tr("Waiting for resource '%1', count: %2").arg(threadsResource->name).arg(1);
         }
         isThreadResourceAcquired = true;
@@ -396,10 +396,10 @@ QString TaskSchedulerImpl::tryLockResources(Task* task, bool prepareStage, bool&
 
         bool resourceAcquired = appRes->tryAcquire(taskRes.resourceUse);
         if (!resourceAcquired) {
-            if (appRes->maxTaskUse() < taskRes.resourceUse) {
+            if (appRes->getMaximumUsage() < taskRes.resourceUse) {
                 QString error = tr("Not enough resources for the task, resource name: '%1' max: %2%3 requested: %4%5")
                                     .arg(appRes->name)
-                                    .arg(appRes->maxTaskUse())
+                                    .arg(appRes->getMaximumUsage())
                                     .arg(appRes->suffix)
                                     .arg(taskRes.resourceUse)
                                     .arg(appRes->suffix);
@@ -433,7 +433,7 @@ QString TaskSchedulerImpl::tryLockResources(Task* task, bool prepareStage, bool&
         taskRes.locked = false;
     }
     if (isThreadResourceAcquired) {
-        threadsResource->release();
+        threadsResource->release(1);
     }
 
     hasLockedResourcesAfterCall = false;
@@ -447,7 +447,7 @@ void TaskSchedulerImpl::releaseResources(TaskInfo* ti, bool prepareStage) {
     }
     bool isThreadResourceUsed = !prepareStage && !ti->task->hasFlags(TaskFlag_RunMessageLoopOnly);
     if (isThreadResourceUsed) {
-        threadsResource->release();
+        threadsResource->release(1);
     }
     TaskResources& tres = getTaskResources(ti->task);
     for (int i = 0, n = tres.size(); i < n; i++) {

--- a/src/corelibs/U2Private/src/crash_handler/CrashLogCache.cpp
+++ b/src/corelibs/U2Private/src/crash_handler/CrashLogCache.cpp
@@ -43,7 +43,7 @@ QString CrashLogCache::formMemInfo() {
     QString memInfo = QString("AppMemory: %1Mb").arg(memoryBytes / (1000 * 1000));
     AppResource* mem = pool->getResource(RESOURCE_MEMORY);
     if (mem) {
-        memInfo += QString("; Locked memory AppResource: %1/%2").arg(mem->maxUse() - mem->available()).arg(mem->maxUse());
+        memInfo += QString("; Locked memory AppResource: %1/%2").arg(mem->getMaximumUsage() - mem->available()).arg(mem->getMaximumUsage());
     }
 
     int currentMemory = 0, maxMemory = 0;

--- a/src/corelibs/U2Test/src/xmltest/XMLTestUtils.cpp
+++ b/src/corelibs/U2Test/src/xmltest/XMLTestUtils.cpp
@@ -26,6 +26,7 @@
 #include <QFile>
 #include <QFileInfo>
 
+#include <U2Core/AppResources.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/U2SafePoints.h>
 
@@ -49,7 +50,7 @@ void XmlTest::checkAttribute(const QDomElement& element, const QString& attribut
     }
 
     CHECK_EXT(!element.hasAttribute(attribute) || acceptableValues.contains(element.attribute(attribute)),
-              setError(QString("Attribute '%1' has inacceptable value. Acceptable values are: %2")
+              setError(QString("Attribute '%1' has unacceptable value. Acceptable values are: %2")
                            .arg(attribute)
                            .arg(acceptableValues.join(", "))), );
 }
@@ -139,8 +140,8 @@ void XMLTestUtils::replacePrefix(const GTestEnvironment* env, QString& path) {
     int prefixSize = prefix.size();
     QStringList relativePaths = path.mid(prefixSize).split(";");
 
-    for (const QString& releativePath : qAsConst(relativePaths)) {
-        QString fullPath = prefixPath + releativePath;
+    for (const QString& relativePath : qAsConst(relativePaths)) {
+        QString fullPath = prefixPath + relativePath;
         result += fullPath + ";";
     }
 
@@ -149,15 +150,8 @@ void XMLTestUtils::replacePrefix(const GTestEnvironment* env, QString& path) {
 
 bool XMLTestUtils::parentTasksHaveError(Task* t) {
     Task* parentTask = t->getParentTask();
-    CHECK(nullptr != parentTask, false);
-
-    bool result = false;
-    if (parentTask->hasError()) {
-        result = true;
-    } else {
-        result = parentTasksHaveError(parentTask);
-    }
-    return result;
+    CHECK(parentTask != nullptr, false);
+    return parentTask->hasError() || parentTasksHaveError(parentTask);
 }
 
 const QString XMLMultiTest::FAIL_ON_SUBTEST_FAIL = "fail-on-subtest-fail";
@@ -202,13 +196,9 @@ void XMLMultiTest::init(XMLTestFormat* tf, const QDomElement& el) {
         subs.append(subTest);
     }
     if (!hasError()) {
-        if (lockForLogListening) {
-            addTaskResource(TaskResourceUsage(RESOURCE_LISTEN_LOG_IN_TESTS, TaskResourceUsage::Write, true));
-        } else {
-            addTaskResource(TaskResourceUsage(RESOURCE_LISTEN_LOG_IN_TESTS, TaskResourceUsage::Read, true));
-        }
-
-        foreach (Task* t, subs) {
+        auto lockTime = lockForLogListening ? AppResourceReadWriteLock::Write : AppResourceReadWriteLock::Read;
+        addTaskResource(TaskResourceUsage(RESOURCE_LISTEN_LOG_IN_TESTS, lockTime, true));
+        for (Task* t : qAsConst(subs)) {
             addSubTask(t);
         }
     }

--- a/src/ugeneui/src/Main.cpp
+++ b/src/ugeneui/src/Main.cpp
@@ -33,7 +33,6 @@
 #include <QApplication>
 #include <QDesktopWidget>
 #include <QIcon>
-#include <QMessageBox>
 #include <QStyleFactory>
 #include <QTranslator>
 
@@ -861,9 +860,7 @@ int main(int argc, char** argv) {
 
     mw->registerStartupChecks(tasks);
 
-    MemoryLocker l(160, AppResource::SystemMemory);  // 100Mb on UGENE start, ~60Mb SQLite cache
     int rc = GApplication::exec();
-    l.release();
 
     // 4 deallocate resources
     if (!envList.contains(ENV_UGENE_DEV + QString("=1"))) {


### PR DESCRIPTION
In the patch:
1. Move resource all methods from headers to cpps
2. Remove system resource type (we do not use it)
3. Do not allow copying of MemoryLocker (we do not use it)
