### PR TITLE
Rework AppResource lock ids from numbers to strings

### DIFF
--- a/src/corelibs/U2Algorithm/src/misc/FindAlgorithmTask.cpp
+++ b/src/corelibs/U2Algorithm/src/misc/FindAlgorithmTask.cpp
@@ -48,9 +48,8 @@ FindAlgorithmTask::FindAlgorithmTask(const FindAlgorithmTaskSettings& s)
     tpm = Progress_Manual;
     assert(config.strand == FindAlgorithmStrand_Direct || config.complementTT != nullptr);
 
-    addTaskResource(TaskResourceUsage(RESOURCE_MEMORY,
-                                      FindAlgorithm::estimateRamUsageInMbytes(config.patternSettings, config.proteinTT != nullptr, config.pattern.length(), config.maxErr),
-                                      true));
+    int usageInMb = FindAlgorithm::estimateRamUsageInMbytes(config.patternSettings, config.proteinTT != nullptr, config.pattern.length(), config.maxErr);
+    addTaskResource(TaskResourceUsage(UGENE_RESOURCE_ID_MEMORY, usageInMb, true));
 }
 
 void FindAlgorithmTask::run() {

--- a/src/corelibs/U2Algorithm/src/molecular_geometry/MolecularSurface.cpp
+++ b/src/corelibs/U2Algorithm/src/molecular_geometry/MolecularSurface.cpp
@@ -126,7 +126,7 @@ MolecularSurfaceCalcTask::MolecularSurfaceCalcTask(const QString& surfaceTypeNam
     qint64 memUseMB = (molSurface->estimateMemoryUsage(atoms.size())) / 1024 / 1024;
     algoLog.trace(QString("Estimated memory usage: %1 MB").arg(memUseMB));
 
-    addTaskResource(TaskResourceUsage(RESOURCE_MEMORY, memUseMB, true));
+    addTaskResource(TaskResourceUsage(UGENE_RESOURCE_ID_MEMORY, memUseMB, true));
 
     tpm = Progress_Manual;
 }
@@ -149,9 +149,6 @@ Task::ReportResult MolecularSurfaceCalcTask::report() {
     algoLog.trace(QString("Number of atoms: %1, number of faces: %2").arg(atoms.size()).arg(numFaces));
     algoLog.trace(QString("Used memory: %1 MB").arg(((qint64)numFaces * sizeof(double) * 3 * 6) / 1024 / 1024));
     return ReportResult_Finished;
-}
-
-MolecularSurfaceFactory::~MolecularSurfaceFactory() {
 }
 
 }  // namespace U2

--- a/src/corelibs/U2Algorithm/src/molecular_geometry/MolecularSurface.h
+++ b/src/corelibs/U2Algorithm/src/molecular_geometry/MolecularSurface.h
@@ -87,7 +87,7 @@ public:
 
 class U2ALGORITHM_EXPORT MolecularSurfaceFactory {
 public:
-    virtual ~MolecularSurfaceFactory();
+    virtual ~MolecularSurfaceFactory() = default;
     virtual MolecularSurface* createInstance() const = 0;
     virtual bool hasConstraints(const BioStruct3D&) const {
         return false;

--- a/src/corelibs/U2Core/src/globals/ServiceModel.cpp
+++ b/src/corelibs/U2Core/src/globals/ServiceModel.cpp
@@ -30,22 +30,25 @@
 
 namespace U2 {
 
-Service::Service(ServiceType t, const QString& _name, const QString& _desc, const QList<ServiceType>& _parentServices, ServiceFlags f)
+Service::Service(const ServiceType& t, const QString& _name, const QString& _desc, const QList<ServiceType>& _parentServices, ServiceFlags f)
     : type(t), name(_name), description(_desc), parentServices(_parentServices), state(ServiceState_Disabled_New), flags(f) {
     // Register service resource
     AppSettings* settings = AppContext::getAppSettings();
-    SAFE_POINT(nullptr != settings, "Can not get application settings", );
+    SAFE_POINT(settings != nullptr, "Can not get application settings", );
     AppResourcePool* resourcePool = settings->getAppResourcePool();
-    SAFE_POINT(nullptr != resourcePool, "Can not get resource pool", );
+    SAFE_POINT(resourcePool != nullptr, "Can not get resource pool", );
 
-    AppResource* resource = resourcePool->getResource(t.id);
+    const QString& serviceResourceId = getServiceResourceId(t);
+    AppResource* resource = resourcePool->getResource(serviceResourceId);
 
-    if (nullptr == resource) {
-        AppResourceSemaphore* serviceResource = new AppResourceSemaphore(t.id, 1, _name);
-        resourcePool->registerResource(serviceResource);
-    } else {
-        SAFE_POINT(resource->name == _name, QString("Resources %1 and %2 have the same identifiers").arg(resource->name).arg(_name), );
+    if (resource == nullptr) {
+        resourcePool->registerResource(new AppResourceSemaphore(serviceResourceId));
     }
+}
+
+/** Returns unique resource identifier for the service type. */
+QString Service::getServiceResourceId(const ServiceType& serviceType) {
+    return "Service:" + QString::number(serviceType.id);
 }
 
 void ServiceRegistry::_setServiceState(Service* s, ServiceState state) {

--- a/src/corelibs/U2Core/src/globals/ServiceModel.h
+++ b/src/corelibs/U2Core/src/globals/ServiceModel.h
@@ -52,10 +52,13 @@ typedef QFlags<ServiceFlag> ServiceFlags;
 
 class U2CORE_EXPORT Service : public QObject {
     friend class ServiceRegistry;
-    friend class ServiceLock;
     Q_OBJECT
 public:
-    Service(ServiceType t, const QString& _name, const QString& _desc, const QList<ServiceType>& parentServices = QList<ServiceType>(), ServiceFlags flags = ServiceFlag_None);
+    Service(const ServiceType& t,
+            const QString& _name,
+            const QString& _desc,
+            const QList<ServiceType>& parentServices = QList<ServiceType>(),
+            ServiceFlags flags = ServiceFlag_None);
 
     const QList<ServiceType>& getParentServiceTypes() const {
         return parentServices;
@@ -88,6 +91,9 @@ public:
     ServiceFlags getFlags() const {
         return flags;
     }
+
+    /** Returns unique resource identifier for the service type. */
+    static QString getServiceResourceId(const ServiceType& serviceType);
 
 protected:
     /// returns NULL if no actions are required to enable service

--- a/src/corelibs/U2Core/src/globals/Task.cpp
+++ b/src/corelibs/U2Core/src/globals/Task.cpp
@@ -26,6 +26,10 @@
 
 namespace U2 {
 
+TaskResourceUsage::TaskResourceUsage(const QString& _resourceId, int _usage, bool prepareStage)
+    : resourceId(_resourceId), resourceUse(_usage), prepareStageLock(prepareStage) {
+}
+
 void TaskStateInfo::addWarning(const QString& warning) {
     QWriteLocker w(&lock);
     warnings << warning;

--- a/src/corelibs/U2Core/src/tasks/LoadDocumentTask.cpp
+++ b/src/corelibs/U2Core/src/tasks/LoadDocumentTask.cpp
@@ -316,7 +316,7 @@ void LoadDocumentTask::prepare() {
 
     int memUseMB = calculateMemory();
     if (memUseMB > 0) {
-        addTaskResource(TaskResourceUsage(RESOURCE_MEMORY, memUseMB, false));
+        addTaskResource(TaskResourceUsage(UGENE_RESOURCE_ID_MEMORY, memUseMB, false));
     }
 }
 

--- a/src/corelibs/U2Private/src/ServiceRegistryImpl.cpp
+++ b/src/corelibs/U2Private/src/ServiceRegistryImpl.cpp
@@ -135,13 +135,14 @@ Service* ServiceRegistryImpl::findServiceReadyToEnable() const {
 
 /// RegisterServiceTask
 
-AbstractServiceTask::AbstractServiceTask(QString taskName, TaskFlags flag, ServiceRegistryImpl* _sr, Service* _s, bool lockServiceResource)
+AbstractServiceTask::AbstractServiceTask(const QString& taskName, TaskFlags flag, ServiceRegistryImpl* _sr, Service* _s, bool lockServiceResource)
     : Task(taskName, flag), sr(_sr), s(_s) {
     SAFE_POINT_EXT(sr, stateInfo.setError("Pointer to ServiceRegistryImpl is null"), );
     SAFE_POINT_EXT(s, stateInfo.setError("Pointer to Service is null"), );
 
     if (lockServiceResource) {
-        addTaskResource(TaskResourceUsage(s->getType().id, 1, true));
+        QString serviceResourceId = Service::getServiceResourceId(s->getType());
+        addTaskResource(TaskResourceUsage(serviceResourceId, 1, true));
     }
 }
 

--- a/src/corelibs/U2Private/src/ServiceRegistryImpl.h
+++ b/src/corelibs/U2Private/src/ServiceRegistryImpl.h
@@ -93,7 +93,7 @@ private:
 class AbstractServiceTask : public Task {
     Q_OBJECT
 protected:
-    AbstractServiceTask(QString taskName, TaskFlags flag, ServiceRegistryImpl* _sr, Service* _s, bool lockServiceResource);
+    AbstractServiceTask(const QString& taskName, TaskFlags flag, ServiceRegistryImpl* _sr, Service* _s, bool lockServiceResource);
 
     ServiceRegistryImpl* sr;
     Service* s;

--- a/src/corelibs/U2Private/src/crash_handler/CrashLogCache.cpp
+++ b/src/corelibs/U2Private/src/crash_handler/CrashLogCache.cpp
@@ -39,11 +39,11 @@ QString CrashLogCache::formMemInfo() {
     AppResourcePool* pool = AppResourcePool::instance();
     CHECK(pool, QString());
 
-    size_t memoryBytes = pool->getCurrentAppMemory();
+    size_t memoryBytes = AppResourcePool::getCurrentAppMemory();
     QString memInfo = QString("AppMemory: %1Mb").arg(memoryBytes / (1000 * 1000));
-    AppResource* mem = pool->getResource(RESOURCE_MEMORY);
+    AppResource* mem = pool->getResource(UGENE_RESOURCE_ID_MEMORY);
     if (mem) {
-        memInfo += QString("; Locked memory AppResource: %1/%2").arg(mem->getMaximumUsage() - mem->available()).arg(mem->getMaximumUsage());
+        memInfo += QString("; Locked memory AppResource: %1/%2").arg(mem->getCapacity() - mem->available()).arg(mem->getCapacity());
     }
 
     int currentMemory = 0, maxMemory = 0;

--- a/src/corelibs/U2Test/src/GTest.h
+++ b/src/corelibs/U2Test/src/GTest.h
@@ -33,7 +33,7 @@
 namespace U2 {
 
 /** Tests that need to verify log uses this resource */
-#define RESOURCE_LISTEN_LOG_IN_TESTS 1000001
+#define UGENE_RESOURCE_ID_TEST_LOG_LISTENER "Test logs listener"
 
 class U2TEST_EXPORT GTestEnvironment {
 public:

--- a/src/corelibs/U2Test/src/xmltest/XMLTestUtils.cpp
+++ b/src/corelibs/U2Test/src/xmltest/XMLTestUtils.cpp
@@ -197,7 +197,7 @@ void XMLMultiTest::init(XMLTestFormat* tf, const QDomElement& el) {
     }
     if (!hasError()) {
         auto lockTime = lockForLogListening ? AppResourceReadWriteLock::Write : AppResourceReadWriteLock::Read;
-        addTaskResource(TaskResourceUsage(RESOURCE_LISTEN_LOG_IN_TESTS, lockTime, true));
+        addTaskResource(TaskResourceUsage(UGENE_RESOURCE_ID_TEST_LOG_LISTENER, lockTime, true));
         for (Task* t : qAsConst(subs)) {
             addSubTask(t);
         }

--- a/src/plugins/dna_export/src/DNASequenceGenerator.cpp
+++ b/src/plugins/dna_export/src/DNASequenceGenerator.cpp
@@ -408,7 +408,7 @@ GenerateDNASequenceTask::GenerateDNASequenceTask(const QMap<char, qreal>& baseCo
 void GenerateDNASequenceTask::prepare() {
     int memUseMB = window / MBYTE_TO_BYTE;
     coreLog.trace(QString("Generate DNA sequence task: Memory resource %1").arg(memUseMB));
-    addTaskResource(TaskResourceUsage(RESOURCE_MEMORY, memUseMB));
+    addTaskResource(TaskResourceUsage(UGENE_RESOURCE_ID_MEMORY, memUseMB));
 }
 
 void GenerateDNASequenceTask::run() {

--- a/src/plugins/external_tool_support/src/blast/BlastCommonTask.cpp
+++ b/src/plugins/external_tool_support/src/blast/BlastCommonTask.cpp
@@ -63,7 +63,7 @@ BlastCommonTask::BlastCommonTask(const BlastTaskSettings& _settings)
     for (const QByteArray& querySequence : qAsConst(settings.querySequences)) {
         querySequences << (settings.isSequenceCircular ? U2PseudoCircularization::createSequenceWithCircularOverlaps(querySequence) : querySequence);
     }
-    addTaskResource(TaskResourceUsage(RESOURCE_THREAD, settings.numberOfProcessors));
+    addTaskResource(TaskResourceUsage(UGENE_RESOURCE_ID_THREAD, settings.numberOfProcessors));
     if (settings.querySequenceObject != nullptr) {
         TaskWatchdog::trackResourceExistence(settings.querySequenceObject, this, tr("A problem occurred during doing BLAST. The sequence is no more available."));
     }

--- a/src/plugins/external_tool_support/src/bowtie/BowtieTask.cpp
+++ b/src/plugins/external_tool_support/src/bowtie/BowtieTask.cpp
@@ -49,7 +49,7 @@ void BowtieBuildTask::prepare() {
         }
         qint64 memUseMB = file.size() * 3 / 1024 / 1024 + 100;
         coreLog.trace(QString("bowtie-build:Memory resource %1").arg(memUseMB));
-        addTaskResource(TaskResourceUsage(RESOURCE_MEMORY, memUseMB));
+        addTaskResource(TaskResourceUsage(UGENE_RESOURCE_ID_MEMORY, memUseMB));
     }
 
     QStringList arguments;
@@ -161,7 +161,7 @@ void BowtieAlignTask::prepare() {
         static const int SHORT_READ_AVG_LENGTH = 1000;
         QFileInfo file(settings.indexFileName + indexSuffixes[0]);
         qint64 memUseMB = (file.size() * 4 + SHORT_READ_AVG_LENGTH * 10) / 1024 / 1024 + 100;
-        addTaskResource(TaskResourceUsage(RESOURCE_MEMORY, memUseMB, false));
+        addTaskResource(TaskResourceUsage(UGENE_RESOURCE_ID_MEMORY, memUseMB, false));
     }
 
     QStringList arguments;

--- a/src/plugins/genome_aligner/src/GenomeAlignerTask.cpp
+++ b/src/plugins/genome_aligner/src/GenomeAlignerTask.cpp
@@ -126,7 +126,7 @@ GenomeAlignerTask::GenomeAlignerTask(const DnaAssemblyToRefTaskSettings& _settin
     if (!justBuildIndex) {
         memUseMB += readMemSize;
     }
-    addTaskResource(TaskResourceUsage(RESOURCE_MEMORY, memUseMB, true));
+    addTaskResource(TaskResourceUsage(UGENE_RESOURCE_ID_MEMORY, memUseMB, true));
 }
 
 GenomeAlignerTask::~GenomeAlignerTask() {

--- a/src/plugins/repeat_finder/src/RF_SArray_TandemFinder.cpp
+++ b/src/plugins/repeat_finder/src/RF_SArray_TandemFinder.cpp
@@ -226,7 +226,7 @@ ConcreteTandemFinder::ConcreteTandemFinder(QString taskName, const char* _sequen
         suffArrMemory = seqSize * sizeof(quint32) * 2;
     }
     suffArrMemory = qMax(suffArrMemory / (1024 * 1024), 1);  // in Mb
-    addTaskResource(TaskResourceUsage(RESOURCE_MEMORY, suffArrMemory, true));
+    addTaskResource(TaskResourceUsage(UGENE_RESOURCE_ID_MEMORY, suffArrMemory, true));
 }
 
 void ConcreteTandemFinder::prepare() {

--- a/src/plugins/smith_waterman/src/SWAlgorithmTask.cpp
+++ b/src/plugins/smith_waterman/src/SWAlgorithmTask.cpp
@@ -161,7 +161,7 @@ void SWAlgorithmTask::setupTask(int maxScore) {
     if (neededRam > SmithWatermanAlgorithm::MEMORY_SIZE_LIMIT_MB) {
         stateInfo.setError(tr("Needed amount of memory for this task is %1 MB, but it limited to %2 MB.").arg(QString::number(neededRam)).arg(QString::number(SmithWatermanAlgorithm::MEMORY_SIZE_LIMIT_MB)));
     } else {
-        addTaskResource(TaskResourceUsage(RESOURCE_MEMORY, neededRam, true));
+        addTaskResource(TaskResourceUsage(UGENE_RESOURCE_ID_MEMORY, neededRam, true));
         t = new SequenceWalkerTask(c, this, tr("Smith Waterman2 SequenceWalker"));
         addSubTask(t);
     }
@@ -597,7 +597,7 @@ void PairwiseAlignmentSmithWatermanTask::setupTask() {
     if (neededRam > SmithWatermanAlgorithm::MEMORY_SIZE_LIMIT_MB) {
         stateInfo.setError(tr("Needed amount of memory for this task is %1 MB, but it limited to %2 MB.").arg(QString::number(neededRam)).arg(QString::number(SmithWatermanAlgorithm::MEMORY_SIZE_LIMIT_MB)));
     } else {
-        addTaskResource(TaskResourceUsage(RESOURCE_MEMORY, neededRam, true));
+        addTaskResource(TaskResourceUsage(UGENE_RESOURCE_ID_MEMORY, neededRam, true));
         t = new SequenceWalkerTask(c, this, tr("Smith Waterman2 SequenceWalker"));
         addSubTask(t);
     }

--- a/src/plugins/workflow_designer/src/library/GenericReadWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/GenericReadWorker.cpp
@@ -211,7 +211,7 @@ void LoadMSATask::prepare() {
     coreLog.trace(QString("load document:Memory resource %1").arg(memUseMB));
 
     if (memUseMB > 0) {
-        addTaskResource(TaskResourceUsage(RESOURCE_MEMORY, memUseMB, false));
+        addTaskResource(TaskResourceUsage(UGENE_RESOURCE_ID_MEMORY, memUseMB, false));
     }
 }
 

--- a/src/plugins/workflow_designer/src/library/ReadAnnotationsWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/ReadAnnotationsWorker.cpp
@@ -250,7 +250,7 @@ void ReadAnnotationsTask::prepare() {
     coreLog.trace(QString("Load annotations: Memory resource %1").arg(memUseMB));
 
     if (memUseMB > 0) {
-        addTaskResource(TaskResourceUsage(RESOURCE_MEMORY, memUseMB, false));
+        addTaskResource(TaskResourceUsage(UGENE_RESOURCE_ID_MEMORY, memUseMB, false));
     }
 }
 

--- a/src/plugins/workflow_designer/src/library/ReadVariationWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/ReadVariationWorker.cpp
@@ -120,7 +120,7 @@ void ReadVariationTask::prepare() {
     coreLog.trace(QString("load document:Memory resource %1").arg(memUseMB));
 
     if (memUseMB > 0) {
-        addTaskResource(TaskResourceUsage(RESOURCE_MEMORY, memUseMB, false));
+        addTaskResource(TaskResourceUsage(UGENE_RESOURCE_ID_MEMORY, memUseMB, false));
     }
 }
 

--- a/src/plugins_3rdparty/kalign/src/KalignTask.cpp
+++ b/src/plugins_3rdparty/kalign/src/KalignTask.cpp
@@ -77,7 +77,7 @@ KalignTask::KalignTask(const MultipleSequenceAlignment& ma, const KalignTaskSett
     tpm = Task::Progress_Manual;
     quint64 mem = inputMA->getRowCount() * sizeof(float);
     quint64 profileMem = (ma->getLength() + 2) * 22 * sizeof(float);  // the size of profile that is built during kalign
-    addTaskResource(TaskResourceUsage(RESOURCE_MEMORY, (profileMem + (mem * mem + 3 * mem)) / (1024 * 1024)));
+    addTaskResource(TaskResourceUsage(UGENE_RESOURCE_ID_MEMORY, (profileMem + (mem * mem + 3 * mem)) / (1024 * 1024)));
 }
 
 void KalignTask::_run() {

--- a/src/plugins_3rdparty/primer3/src/Primer3Plugin.cpp
+++ b/src/plugins_3rdparty/primer3/src/Primer3Plugin.cpp
@@ -63,7 +63,7 @@ Primer3Plugin::Primer3Plugin()
         viewCtx->init();
     }
 
-    auto p3Lock = new AppResourceSemaphore(PRIMER3_STATIC_LOCK_RESOURCE, 1, tr("Primer3 lock"));
+    auto p3Lock = new AppResourceSemaphore(UGENE_PRIMER3_SINGLE_THREAD_RESOURCE_ID, 1, tr("Primer3 lock"));
     AppContext::getAppSettings()->getAppResourcePool()->registerResource(p3Lock);
 
     QDActorPrototypeRegistry* qdpr = AppContext::getQDActorProtoRegistry();

--- a/src/plugins_3rdparty/primer3/src/Primer3Plugin.h
+++ b/src/plugins_3rdparty/primer3/src/Primer3Plugin.h
@@ -36,7 +36,7 @@ namespace U2 {
  * Primer3Task should lock this resource before run and unlock after finish
  * It's required because the original "primer3" tool doesn't support parallel calculations
  */
-#define PRIMER3_STATIC_LOCK_RESOURCE 15162342
+#define UGENE_PRIMER3_SINGLE_THREAD_RESOURCE_ID "Primer 3 single thread"
 
 class Primer3ADVContext;
 class XMLTestFactory;
@@ -45,7 +45,7 @@ class Primer3Plugin : public Plugin {
     Q_OBJECT
 public:
     Primer3Plugin();
-    ~Primer3Plugin();
+    ~Primer3Plugin() override;
 
 private:
     Primer3ADVContext* viewCtx = nullptr;

--- a/src/plugins_3rdparty/primer3/src/Primer3Task.cpp
+++ b/src/plugins_3rdparty/primer3/src/Primer3Task.cpp
@@ -397,7 +397,7 @@ Primer3Task::Primer3Task(Primer3TaskSettings* _settings)
     settings->setSequence(settings->getSequence().mid(sequenceRange.startPos, sequenceRange.length));
     settings->setSequenceQuality(settings->getSequenceQuality().mid(sequenceRange.startPos, sequenceRange.length));
 
-    addTaskResource(TaskResourceUsage(PRIMER3_STATIC_LOCK_RESOURCE, 1));
+    addTaskResource(TaskResourceUsage(UGENE_PRIMER3_SINGLE_THREAD_RESOURCE_ID, 1));
 }
 
 void Primer3Task::run() {

--- a/src/plugins_3rdparty/umuscle/src/MuscleParallel.cpp
+++ b/src/plugins_3rdparty/umuscle/src/MuscleParallel.cpp
@@ -52,7 +52,7 @@ MuscleParallelTask::MuscleParallelTask(const MultipleSequenceAlignment& ma, Mult
     addSubTask(prepareTask);
 
     int memoryEstimationInMb = estimateMemoryUsageInMb(ma);
-    TaskResourceUsage resourseUsage(RESOURCE_MEMORY, memoryEstimationInMb, true);
+    TaskResourceUsage resourseUsage(UGENE_RESOURCE_ID_MEMORY, memoryEstimationInMb, true);
     resourseUsage.errorMessage = tr("There is not enough memory to align these sequences with MUSCLE. Required memory size: %1 Mb").arg(memoryEstimationInMb);
     addTaskResource(resourseUsage);
 }

--- a/src/plugins_3rdparty/umuscle/src/MuscleTask.cpp
+++ b/src/plugins_3rdparty/umuscle/src/MuscleTask.cpp
@@ -90,7 +90,7 @@ MuscleTask::MuscleTask(const MultipleSequenceAlignment& ma, const MuscleTaskSett
     int aliLen = ma->getLength();
     int nSeq = ma->getRowCount();
     int memUseMB = qint64(aliLen) * qint64(nSeq) * 200 / (1024 * 1024);  // 200x per char in alignment
-    TaskResourceUsage tru(RESOURCE_MEMORY, memUseMB);
+    TaskResourceUsage tru(UGENE_RESOURCE_ID_MEMORY, memUseMB);
 
     QString inputAlName = inputMA->getName();
     resultMA->setName(inputAlName);

--- a/src/ugeneui/src/project_support/ProjectImpl.cpp
+++ b/src/ugeneui/src/project_support/ProjectImpl.cpp
@@ -23,11 +23,9 @@
 
 #include <U2Core/AppContext.h>
 #include <U2Core/AppSettings.h>
-#include <U2Core/DocumentModel.h>
 #include <U2Core/GHints.h>
 #include <U2Core/GObjectUtils.h>
 #include <U2Core/Log.h>
-#include <U2Core/ServiceTypes.h>
 
 #include <U2Gui/MainWindow.h>
 #include <U2Gui/ObjectViewModel.h>
@@ -46,7 +44,7 @@ ProjectImpl::ProjectImpl(const QString& _name, const QString& _url, const QList<
     }
     setModified(false);
 
-    resourceTracker = AppContext::getAppSettings()->getAppResourcePool()->getResource(RESOURCE_MEMORY);
+    resourceTracker = AppContext::getAppSettings()->getAppResourcePool()->getResource(UGENE_RESOURCE_ID_MEMORY);
 
     MWMDIManager* mdi = AppContext::getMainWindow()->getMDIManager();
     if (mdi != nullptr) {
@@ -150,7 +148,11 @@ bool ProjectImpl::lockResources(int sizeMB, const QString& url, QString& error) 
         resourceUsage[doc->getName()] = sizeMB;
         return true;
     } else {
-        error = tr("Not enough resources for load document, resource name: '%1' available: %2%3 requested: %4%3").arg(resourceTracker->name).arg(resourceTracker->available()).arg(resourceTracker->suffix).arg(sizeMB);
+        error = tr("Not enough resources for load document, resource: '%1' available: %2%3 requested: %4%3")
+                    .arg(resourceTracker->id)
+                    .arg(resourceTracker->available())
+                    .arg(resourceTracker->units)
+                    .arg(sizeMB);
         return false;
     }
 }

--- a/src/ugeneui/src/project_support/ProjectTasksGui.cpp
+++ b/src/ugeneui/src/project_support/ProjectTasksGui.cpp
@@ -392,7 +392,7 @@ Task::ReportResult ExportProjectTask::report() {
 // tests
 
 void GTest_LoadProject::init(XMLTestFormat*, const QDomElement& el) {
-    addTaskResource(TaskResourceUsage(RESOURCE_PROJECT, 1, true));
+    addTaskResource(TaskResourceUsage(UGENE_RESOURCE_ID_PROJECT, 1, true));
     projContextName = el.attribute("index");
     if (!el.attribute("load_from_temp").isEmpty()) {
         url = env->getVar("TEMP_DATA_DIR") + "/" + el.attribute("url");


### PR DESCRIPTION
Having 'string' instead of 'number' for resource ids allows us to create more flexible runtime resource locks. 

For example we can make a resource lock per output file name or a folder and synchronize work of different parallel tasks based on such dynamic resources.