### PR TITLE
UGENE-7768 Too long CIGAR line is out of border

### DIFF
--- a/src/corelibs/U2View/src/ov_assembly/AssemblyReadsAreaHint.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyReadsAreaHint.cpp
@@ -66,19 +66,16 @@ AssemblyReadsAreaHint::AssemblyReadsAreaHint(QWidget* parent)
     setObjectName("AssemblyReadsAreaHint");
 }
 
-static QString getCigarString(const QString& ci, bool trimmed = false) {
+QString getCigarString(const QString& ci) {
     if (ci.isEmpty()) {
         return QObject::tr("no information");
     }
 
     QString cigar;
-    int cigarSize = ci.size();
-    bool sizeBecameLess = false;
-    if (trimmed) {
-        cigarSize = qMin(cigarSize, AssemblyReadsAreaHint::LETTER_MAX_COUNT);
-        if (cigarSize < ci.size()) {
-            sizeBecameLess = true;
-        }
+    int cigarSize = qMin(ci.size(), AssemblyReadsAreaHint::LETTER_MAX_COUNT);
+    bool isTrimmed = false;
+    if (cigarSize < ci.size()) {
+        isTrimmed = true;
     }
     for (int i = 0; i < cigarSize; ++i) {
         QChar ch = ci.at(i);
@@ -88,7 +85,7 @@ static QString getCigarString(const QString& ci, bool trimmed = false) {
             cigar.append(QString("<b>%1 </b>").arg(ch));
         }
     }
-    if (sizeBecameLess) {
+    if (isTrimmed) {
         cigar.append("...");
     }
     return cigar;
@@ -156,7 +153,7 @@ static QString formatReadInfo(U2AssemblyRead r) {
         text += QString("<tr><td>%1</td></tr>").arg(formatReadPosString(r));
         text += QString("<tr><td><b>Length</b>:&nbsp;%1</td></tr>").arg(len);
     }
-    text += QString("<tr><td><b>Cigar</b>:&nbsp;%1</td></tr>").arg(getCigarString(U2AssemblyUtils::cigar2String(r->cigar), true));
+    text += QString("<tr><td><b>Cigar</b>:&nbsp;%1</td></tr>").arg(getCigarString(U2AssemblyUtils::cigar2String(r->cigar)));
     {
         bool onCompl = ReadFlagsUtils::isComplementaryRead(r->flags);
         text += QString("<tr><td><b>Strand</b>:&nbsp;%1</td></tr>").arg(onCompl ? QObject::tr("complement") : QObject::tr("direct"));

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyReadsAreaHint.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyReadsAreaHint.cpp
@@ -32,6 +32,7 @@
 namespace U2 {
 
 const QPoint AssemblyReadsAreaHint::OFFSET_FROM_CURSOR(13, 13);
+const int AssemblyReadsAreaHint::LETTER_MAX_COUNT = 60;
 static const int HINT_MAX_WIDTH = 200;
 
 AssemblyReadsAreaHint::AssemblyReadsAreaHint(QWidget* parent)
@@ -73,10 +74,6 @@ QString getCigarString(const QString& ci) {
 
     QString cigar;
     int cigarSize = qMin(ci.size(), AssemblyReadsAreaHint::LETTER_MAX_COUNT);
-    bool isTrimmed = false;
-    if (cigarSize < ci.size()) {
-        isTrimmed = true;
-    }
     for (int i = 0; i < cigarSize; ++i) {
         QChar ch = ci.at(i);
         if (ch.isNumber()) {
@@ -85,7 +82,7 @@ QString getCigarString(const QString& ci) {
             cigar.append(QString("<b>%1 </b>").arg(ch));
         }
     }
-    if (isTrimmed) {
+    if (cigarSize < ci.size()) {
         cigar.append("...");
     }
     return cigar;

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyReadsAreaHint.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyReadsAreaHint.cpp
@@ -66,19 +66,30 @@ AssemblyReadsAreaHint::AssemblyReadsAreaHint(QWidget* parent)
     setObjectName("AssemblyReadsAreaHint");
 }
 
-static QString getCigarString(const QString& ci) {
+static QString getCigarString(const QString& ci, bool trimmed = false) {
     if (ci.isEmpty()) {
         return QObject::tr("no information");
     }
 
     QString cigar;
-    for (int i = 0; i < ci.size(); ++i) {
+    int cigarSize = ci.size();
+    bool sizeBecameLess = false;
+    if (trimmed) {
+        cigarSize = qMin(cigarSize, AssemblyReadsAreaHint::LETTER_MAX_COUNT);
+        if (cigarSize < ci.size()) {
+            sizeBecameLess = true;
+        }
+    }
+    for (int i = 0; i < cigarSize; ++i) {
         QChar ch = ci.at(i);
         if (ch.isNumber()) {
             cigar.append(ch);
         } else {
             cigar.append(QString("<b>%1 </b>").arg(ch));
         }
+    }
+    if (sizeBecameLess) {
+        cigar.append("...");
     }
     return cigar;
 }
@@ -145,7 +156,7 @@ static QString formatReadInfo(U2AssemblyRead r) {
         text += QString("<tr><td>%1</td></tr>").arg(formatReadPosString(r));
         text += QString("<tr><td><b>Length</b>:&nbsp;%1</td></tr>").arg(len);
     }
-    text += QString("<tr><td><b>Cigar</b>:&nbsp;%1</td></tr>").arg(getCigarString(U2AssemblyUtils::cigar2String(r->cigar)));
+    text += QString("<tr><td><b>Cigar</b>:&nbsp;%1</td></tr>").arg(getCigarString(U2AssemblyUtils::cigar2String(r->cigar), true));
     {
         bool onCompl = ReadFlagsUtils::isComplementaryRead(r->flags);
         text += QString("<tr><td><b>Strand</b>:&nbsp;%1</td></tr>").arg(onCompl ? QObject::tr("complement") : QObject::tr("direct"));

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyReadsAreaHint.h
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyReadsAreaHint.h
@@ -34,7 +34,7 @@ class AssemblyReadsAreaHint : public QFrame {
     Q_OBJECT
 public:
     static const QPoint OFFSET_FROM_CURSOR;
-    static const int LETTER_MAX_COUNT = 60;
+    static const int LETTER_MAX_COUNT;
     static QString getReadDataAsString(const U2AssemblyRead& r);
 
 public:


### PR DESCRIPTION
We do not have any features to read pop-up hints from Assembly Browser (even we can't target some specific read), so I decided not to make a test.