### PR TITLE
Switch build to c++17 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ add_definitions(
         -DQT_DISABLE_DEPRECATED_BEFORE=0x050700
 )
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 # Set a default build type for single-configuration
 # CMake generators if no build type is set.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@ Download UGENE: [https://ugeneunipro.github.io/ugene/](https://ugeneunipro.githu
 
 ### Prerequisites
 
-Qt (>= 5.12.0 and <= 5.15.x) with the following components installed with Qt installer:
-* Desktop
-* QtScript
+* Qt (5.15.x) with the following components installed with Qt installer:
+  * Desktop
+  * QtScript
+
+
+* C++ compiler with c++17 standard support.
 
 ### For Windows users:
 

--- a/src/libs_3rdparty/QSpec/src/system/GTFile.cpp
+++ b/src/libs_3rdparty/QSpec/src/system/GTFile.cpp
@@ -27,10 +27,9 @@
 #include "system/GTFile.h"
 
 #ifdef Q_OS_LINUX
-// We using c++14, while <filesystem> is in c++17, so using experimental version.
 // TODO: check on Windows & Mac.
-#    include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
+#    include <filesystem>
+namespace fs = std::filesystem;
 #endif
 
 #ifdef Q_OS_WIN

--- a/src/ugene_globals.pri
+++ b/src/ugene_globals.pri
@@ -15,7 +15,7 @@ win32:DEFINES+=UGENE_VER_MINOR=$${UGENE_VER_MINOR}
 # and do not use any deprecated API.
 DEFINES+=QT_DISABLE_DEPRECATED_BEFORE=0x050700
 
-CONFIG += c++14
+CONFIG += c++17
 
 # Do not use library suffix names for files and ELF-dependency sections on Linux.
 # Reason: we do not support multiple versions of UGENE in the same folder and


### PR DESCRIPTION
This change will allow us using more advanced language features and newer std libraries.

The negative side effect is that we have to bump a minimal supported gcc version from 5.4 to 7.0 (we are building with 7.5 for a couple of years)

Alternatively we can stay longer with C++14 but pick the features from the <experimental> libraries.