### PR TITLE
Change default wheel action from Zoom -> Scroll in tree views

### DIFF
--- a/src/corelibs/U2Formats/src/sqlite_dbi/SQLiteAssemblyDbi.cpp
+++ b/src/corelibs/U2Formats/src/sqlite_dbi/SQLiteAssemblyDbi.cpp
@@ -582,7 +582,7 @@ void SQLiteAssemblyUtils::addToCoverage(U2AssemblyCoverageImportInfo& ii, const 
     if (!ii.computeCoverage) {
         return;
     }
-    int csize = ii.coverage.size();
+    int coverageLength = ii.coverage.size();
 
     QVector<U2CigarOp> cigarVector;
     foreach (const U2CigarToken& cigar, read->cigar) {
@@ -592,20 +592,14 @@ void SQLiteAssemblyUtils::addToCoverage(U2AssemblyCoverageImportInfo& ii, const 
     cigarVector.removeAll(U2CigarOp_S);
     cigarVector.removeAll(U2CigarOp_P);
 
-    int startPos = (int)(read->leftmostPos / ii.coverageBasesPerPoint);
-    int endPos = (int)((read->leftmostPos + read->effectiveLen) / ii.coverageBasesPerPoint) - 1;
-    if (endPos > csize - 1) {
-        endPos = csize - 1;
+    int coverageStartPos = (int)(read->leftmostPos / ii.coverageBasesPerPoint);
+    int coverageEndPos = qMax(coverageStartPos, (int)((read->leftmostPos + read->effectiveLen) / ii.coverageBasesPerPoint) - 1);
+    if (coverageEndPos > coverageLength - 1) {
+        coverageEndPos = coverageLength - 1;
     }
     int* coverageData = ii.coverage.data();
-    for (int i = startPos; i <= endPos && i < csize; i++) {
-        switch (cigarVector[(i - startPos) * ii.coverageBasesPerPoint]) {
-            case U2CigarOp_D:  // skip the deletion
-            case U2CigarOp_N:  // skip the skiped
-                continue;
-            default:
-                coverageData[i]++;
-        }
+    for (int i = coverageStartPos; i <= coverageEndPos && i < coverageLength; i++) {
+        coverageData[i]++;
     }
 }
 

--- a/src/corelibs/U2View/src/ov_msa/MaEditorSequenceArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorSequenceArea.cpp
@@ -838,10 +838,12 @@ void MaEditorSequenceArea::paintEvent(QPaintEvent* e) {
 
 void MaEditorSequenceArea::wheelEvent(QWheelEvent* we) {
     bool toMin = we->delta() > 0;
-    if (we->modifiers() == 0) {
-        shBar->triggerAction(toMin ? QAbstractSlider::SliderSingleStepSub : QAbstractSlider::SliderSingleStepAdd);
-    } else if (we->modifiers() & Qt::SHIFT) {
-        svBar->triggerAction(toMin ? QAbstractSlider::SliderSingleStepSub : QAbstractSlider::SliderSingleStepAdd);
+    // Manually shift scrollbars on wheel event.
+    // With no modifiers the default scrollbar is shifted.
+    // Wheel + Alt changes the default wheel action from horizontal <=> vertical (default QT behavior for scroll-areas).
+    auto scrollBar = we->modifiers() == Qt::AltModifier ? svBar : (we->modifiers() == 0 ? shBar : nullptr);
+    if (scrollBar) {
+        scrollBar->triggerAction(toMin ? QAbstractSlider::SliderSingleStepSub : QAbstractSlider::SliderSingleStepAdd);
     }
     QWidget::wheelEvent(we);
 }

--- a/src/corelibs/U2View/src/ov_msa/MaEditorSequenceArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorSequenceArea.cpp
@@ -841,7 +841,7 @@ void MaEditorSequenceArea::wheelEvent(QWheelEvent* we) {
     // Manually shift scrollbars on wheel event.
     // With no modifiers the default scrollbar is shifted.
     // Wheel + Alt changes the default wheel action from horizontal <=> vertical (default QT behavior for scroll-areas).
-    auto scrollBar = we->modifiers() == Qt::AltModifier ? svBar : (we->modifiers() == 0 ? shBar : nullptr);
+    auto scrollBar = we->modifiers() == Qt::AltModifier ? svBar : (we->modifiers() == 0 ? (shBar->isEnabled() ? shBar : svBar) : nullptr);
     if (scrollBar) {
         scrollBar->triggerAction(toMin ? QAbstractSlider::SliderSingleStepSub : QAbstractSlider::SliderSingleStepAdd);
     }

--- a/src/corelibs/U2View/src/ov_phyltree/TreeViewer.cpp
+++ b/src/corelibs/U2View/src/ov_phyltree/TreeViewer.cpp
@@ -981,9 +981,12 @@ void TreeViewerUI::updateLegend() {
 }
 
 void TreeViewerUI::wheelEvent(QWheelEvent* we) {
-    double newZoomLevel = zoomLevel * pow(ZOOM_LEVEL_STEP, we->delta() / 120.0);
-    setZoomLevel(newZoomLevel);
-    we->accept();
+    // Wheel + Shift changes zoom level. Wheel only -> scrolls.
+    if (we->modifiers().testFlag(Qt::ControlModifier)) {
+        double newZoomLevel = zoomLevel * pow(ZOOM_LEVEL_STEP, we->delta() / 120.0);
+        setZoomLevel(newZoomLevel);
+    }
+    QGraphicsView::wheelEvent(we);
 }
 
 void TreeViewerUI::setZoomLevel(double newZoomLevel) {

--- a/src/plugins/GUITestBase/src/GTUtilsPhyTree.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsPhyTree.cpp
@@ -19,6 +19,7 @@
  * MA 02110-1301, USA.
  */
 
+#include <drivers/GTKeyboardDriver.h>
 #include <drivers/GTMouseDriver.h>
 #include <primitives/GTToolbar.h>
 #include <primitives/GTWidget.h>
@@ -409,11 +410,19 @@ int GTUtilsPhyTree::getSceneWidth(HI::GUITestOpStatus& os) {
 #define GT_METHOD_NAME "zoomWithMouseWheel"
 void GTUtilsPhyTree::zoomWithMouseWheel(GUITestOpStatus& os, int steps) {
     TreeViewerUI* treeViewer = getTreeViewerUi(os);
+    zoomWithMouseWheel(os, treeViewer, steps);
+}
+#undef GT_METHOD_NAME
+
+#define GT_METHOD_NAME "zoomWithMouseWheelWithTreeViewer"
+void GTUtilsPhyTree::zoomWithMouseWheel(GUITestOpStatus&, QWidget* treeViewer, int steps) {
     QPoint treeViewCenter = treeViewer->mapToGlobal(treeViewer->rect().center());
     GTMouseDriver::moveTo(treeViewCenter);
+    GTKeyboardDriver::keyPress(Qt::Key_Control);
     for (int i = 0; i < qAbs(steps); i++) {
         GTMouseDriver::scroll(steps > 0 ? 1 : -1);
     }
+    GTKeyboardDriver::keyRelease(Qt::Key_Control);
 }
 #undef GT_METHOD_NAME
 

--- a/src/plugins/GUITestBase/src/GTUtilsPhyTree.h
+++ b/src/plugins/GUITestBase/src/GTUtilsPhyTree.h
@@ -67,6 +67,9 @@ public:
     /** Zooms in (positive steps) or zooms out (negative steps) using mouse wheel. */
     static void zoomWithMouseWheel(HI::GUITestOpStatus& os, int steps);
 
+    /** Zooms in (positive steps) or zooms out (negative steps) using mouse wheel. */
+    static void zoomWithMouseWheel(HI::GUITestOpStatus& os, QWidget* treeViewer, int steps);
+
     /** Clicks zoom-in button once. */
     static void clickZoomInButton(HI::GUITestOpStatus& os);
 

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/GTTestsMsaEditor.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/GTTestsMsaEditor.cpp
@@ -61,6 +61,7 @@
 #include "GTUtilsMsaEditorSequenceArea.h"
 #include "GTUtilsNotifications.h"
 #include "GTUtilsOptionPanelMSA.h"
+#include "GTUtilsPhyTree.h"
 #include "GTUtilsProject.h"
 #include "GTUtilsProjectTreeView.h"
 #include "GTUtilsTaskTreeView.h"
@@ -3901,14 +3902,14 @@ GUI_TEST_CLASS_DEFINITION(test_0078) {
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
     // Zoom in the tree to make horizontal scroll bar visible.
-    auto parent = GTWidget::findWidget(os, "qt_scrollarea_hcontainer", GTWidget::findWidget(os, "treeView"));
+    QWidget* treeViewer = GTWidget::findWidget(os, "treeView");
+    auto parent = GTWidget::findWidget(os, "qt_scrollarea_hcontainer", treeViewer);
     auto horizontalScrollbar = parent->findChild<QScrollBar*>();
     int valueBefore = GTScrollBar::getValue(os, horizontalScrollbar);
 
-    GTWidget::click(os, GTWidget::findWidget(os, "treeView"));
-    for (int i = 0; i < 10; i++) {
-        GTMouseDriver::scroll(1);
-    }
+    GTWidget::click(os, treeViewer);
+    GTUtilsPhyTree::zoomWithMouseWheel(os, treeViewer, 10);
+
     // Check that scroll bar is shifted to the center: the value is increased.
     int valueAfter = GTScrollBar::getValue(os, horizontalScrollbar);
     CHECK_SET_ERR(valueAfter > valueBefore, QString("Unexpected scroll value: %1, original value: %2").arg(valueAfter).arg(valueBefore));


### PR DESCRIPTION
The patch changes default wheel action from Zoom -> Scroll in tree views. 
Zoom is still available with `Ctrl` pressed.

I also changed `Shift` to `Alt` in MsaEditor to make scrolling by wheel aligned with the default QT behavior where Alt is used to switch between scrollbars