### PR TITLE
UGENE-7795 Fix gui tests

### DIFF
--- a/src/plugins/GUITestBase/src/GTUtilsOptionPanelSequenceView.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsOptionPanelSequenceView.cpp
@@ -36,6 +36,7 @@
 
 #include <U2Core/U2SafePoints.h>
 
+#include "GTUtilsNotifications.h"
 #include "GTUtilsMdi.h"
 #include "GTUtilsMsaEditorSequenceArea.h"
 #include "GTUtilsOptionPanelSequenceView.h"
@@ -282,6 +283,8 @@ void GTUtilsOptionPanelSequenceView::pressExtractProduct(HI::GUITestOpStatus& os
     auto extractProduct = GTWidget::findPushButton(os, "extractProductButton");
     GT_CHECK(extractProduct->isEnabled(), "Extract Product buttons is unexpectedly disabled");
 
+    // Wait until notification is closed to avoid overlapping the "extractProductButton" button by notification
+    GTUtilsNotifications::waitAllNotificationsClosed(os);
     GTWidget::click(os, extractProduct);
 }
 #undef GT_METHOD_NAME

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/pcr/GTTestsInSilicoPcr.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/pcr/GTTestsInSilicoPcr.cpp
@@ -250,8 +250,7 @@ GUI_TEST_CLASS_DEFINITION(test_0005) {
     //  TODO
 
     // 7. Click the extract button.
-    GTWidget::click(os, GTWidget::findWidget(os, "extractProductButton"));
-
+    GTUtilsOptionPanelSequenceView::pressExtractProduct(os);
     // Expected: two new files are opened "pIB2-SEC13_2-133.gb" and "pIB2-SEC13_2-3775.gb".
     GTUtilsTaskTreeView::waitTaskFinished(os);
     GTUtilsProjectTreeView::findIndex(os, "pIB2-SEC13_2-133.gb");
@@ -444,9 +443,7 @@ GUI_TEST_CLASS_DEFINITION(test_0010) {
     GTComboBox::selectItemByIndex(os, annsComboBox, 1);
 
     // 7. Click "Export product(s)".
-    auto extractPB = GTWidget::findWidget(os, "extractProductButton");
-    GTUtilsNotifications::waitAllNotificationsClosed(os);
-    GTWidget::click(os, extractPB);
+    GTUtilsOptionPanelSequenceView::pressExtractProduct(os);
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
     // Expected: there are 3 annotations in the exported document: 2 primers and center 51..150.
@@ -459,9 +456,7 @@ GUI_TEST_CLASS_DEFINITION(test_0010) {
     GTComboBox::selectItemByIndex(os, annsComboBox, 0);
 
     // 9. Click "Export product(s)".
-    extractPB = GTWidget::findWidget(os, "extractProductButton");
-    GTUtilsNotifications::waitAllNotificationsClosed(os);
-    GTWidget::click(os, extractPB);
+    GTUtilsOptionPanelSequenceView::pressExtractProduct(os);
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
     // Expected: there are 4 annotations in the exported document: 2 primers, center 51..150 and middle 1..200. Middle has the warning qualifier.
@@ -474,9 +469,7 @@ GUI_TEST_CLASS_DEFINITION(test_0010) {
     GTComboBox::selectItemByIndex(os, annsComboBox, 2);
 
     // 11. Click "Export product(s)".
-    extractPB = GTWidget::findWidget(os, "extractProductButton");
-    GTUtilsNotifications::waitAllNotificationsClosed(os);
-    GTWidget::click(os, extractPB);
+    GTUtilsOptionPanelSequenceView::pressExtractProduct(os);
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
     // Expected: there are only 2 primers annotations in the exported document.

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_4001_5000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_4001_5000.cpp
@@ -3284,7 +3284,7 @@ GUI_TEST_CLASS_DEFINITION(test_4557) {
     GTWidget::click(os, GTWidget::findWidget(os, "findProductButton"));
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
-    GTWidget::click(os, GTWidget::findWidget(os, "extractProductButton"));
+    GTUtilsOptionPanelSequenceView::pressExtractProduct(os);
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
     QString product = GTUtilsSequenceView::getSequenceAsString(os);

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_6001_7000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_6001_7000.cpp
@@ -3644,7 +3644,7 @@ GUI_TEST_CLASS_DEFINITION(test_6649) {
 
     auto annsComboBox = GTWidget::findComboBox(os, "annsComboBox");
     GTComboBox::selectItemByIndex(os, annsComboBox, 1);
-    GTWidget::click(os, GTWidget::findWidget(os, "extractProductButton"));
+    GTUtilsOptionPanelSequenceView::pressExtractProduct(os);
     GTUtilsTaskTreeView::waitTaskFinished(os);
 
     int length = GTUtilsSequenceView::getLengthOfSequence(os);


### PR DESCRIPTION
Because of the new parameter's show/hide menu, the "Extract product" button was overlapped by notification:

![image](https://user-images.githubusercontent.com/26257527/218032769-b8c840ea-a0ec-48e1-8915-56473df866ac.png)
