### PR TITLE
UGENE-7803. Cut info for melting tempeature on Statistics tab (Russia…

### DIFF
--- a/src/corelibs/U2View/src/ov_sequence/sequence_info/SequenceInfo.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/sequence_info/SequenceInfo.cpp
@@ -272,7 +272,7 @@ void SequenceInfo::updateCommonStatisticsData(const DNAStatistics& commonStatist
     if (alphabet->isNucleic()) {
         statsInfo += formTableRow(tr(CAPTION_SEQ_GC_CONTENT), getValue(QString::number(commonStatistics.gcContent, 'f', 2) + "%", isValid), availableSpace);
         bool isValidMeltingTm = isValid && commonStatistics.meltingTemp != BaseTempCalc::INVALID_TM;
-        QString meltingTmFormattedValue = getValue(QString::number(commonStatistics.meltingTemp, 'f', 2) + " &#176;C", isValidMeltingTm);
+        QString meltingTmFormattedValue = getValue(QString::number(commonStatistics.meltingTemp, 'f', 2) + " °C", isValidMeltingTm);
         statsInfo += formTableRow(tr(CAPTION_SEQ_MELTING_TEMPERATURE), meltingTmFormattedValue, availableSpace, isValidMeltingTm);
 
         const QString ssCaption = alphabet->isRNA() ? CAPTION_SUFFIX_SS_RNA : CAPTION_SUFFIX_SS_DNA;

--- a/src/plugins/GUITestBase/src/GTUtilsOptionPanelSequenceView.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsOptionPanelSequenceView.cpp
@@ -46,7 +46,7 @@
 namespace U2 {
 using namespace HI;
 
-const QString GTUtilsOptionPanelSequenceView::meltingTmReportString = "<tr><td>Melting temperature: </td><td style=\"vertical-align:top;\">%1 &#176;C&nbsp;&nbsp;<a href=\"Melting temperature\"><img src=\":core/images/gear.svg\" width=16 height=16;\"></a></td></tr>";
+const QString GTUtilsOptionPanelSequenceView::meltingTmReportString = "<tr><td>Melting temperature: </td><td style=\"vertical-align:top;\">%1 °C&nbsp;&nbsp;<a href=\"Melting temperature\"><img src=\":core/images/gear.svg\" width=16 height=16;\"></a></td></tr>";
 
 QMap<GTUtilsOptionPanelSequenceView::Tabs, QString> GTUtilsOptionPanelSequenceView::initNames() {
     QMap<Tabs, QString> result;


### PR DESCRIPTION
…n translation)

The info was cut because of non-standard text scaling. There is nothing we can do here.

This patch only fixes the way temperature label is cut: there is no partial Unicode text anymore