### PR TITLE
Cleanup TM algorithm code and support default priorities between TM a…

### DIFF
--- a/src/corelibs/U2Algorithm/src/registry/TempCalcRegistry.cpp
+++ b/src/corelibs/U2Algorithm/src/registry/TempCalcRegistry.cpp
@@ -46,6 +46,10 @@ TempCalcFactory* TempCalcRegistry::getDefaultTempCalcFactory() const {
 }
 
 QSharedPointer<BaseTempCalc> TempCalcRegistry::createTempCalculator(const QVariantMap& settingsMap) const {
+    if (settingsMap.isEmpty()) {
+        auto factory = getDefaultTempCalcFactory();
+        return factory->createCalculator(factory->createDefaultSettings());
+    }
     CHECK(!settingsMap.isEmpty(), nullptr);
     auto factoryId = settingsMap.value(BaseTempCalc::KEY_ID).toString();
     TempCalcFactory* calcFactory = getById(factoryId);

--- a/src/corelibs/U2Algorithm/src/registry/TempCalcRegistry.cpp
+++ b/src/corelibs/U2Algorithm/src/registry/TempCalcRegistry.cpp
@@ -46,7 +46,7 @@ TempCalcFactory* TempCalcRegistry::getDefaultTempCalcFactory() const {
 }
 
 QSharedPointer<BaseTempCalc> TempCalcRegistry::createTempCalculator(const QVariantMap& settingsMap) const {
-    CHECK(settingsMap.isEmpty(), nullptr);
+    CHECK(!settingsMap.isEmpty(), nullptr);
     auto factoryId = settingsMap.value(BaseTempCalc::KEY_ID).toString();
     TempCalcFactory* calcFactory = getById(factoryId);
     CHECK(calcFactory != nullptr, nullptr);

--- a/src/corelibs/U2Algorithm/src/registry/TempCalcRegistry.cpp
+++ b/src/corelibs/U2Algorithm/src/registry/TempCalcRegistry.cpp
@@ -26,7 +26,6 @@
 namespace U2 {
 
 bool TempCalcRegistry::registerEntry(TempCalcFactory* newFactory) {
-    // If Primer3 factory is available: give it a priority and use it by default.
     if (defaultFactory == nullptr || defaultFactory->defaultPriority < newFactory->defaultPriority) {
         defaultFactory = newFactory;
     }

--- a/src/corelibs/U2Algorithm/src/registry/TempCalcRegistry.cpp
+++ b/src/corelibs/U2Algorithm/src/registry/TempCalcRegistry.cpp
@@ -25,37 +25,41 @@
 
 namespace U2 {
 
-bool TempCalcRegistry::registerEntry(TempCalcFactory* t) {
-    if (defaultFactory == nullptr) {
-        defaultFactory = t;
+bool TempCalcRegistry::registerEntry(TempCalcFactory* newFactory) {
+    // If Primer3 factory is available: give it a priority and use it by default.
+    if (defaultFactory == nullptr || defaultFactory->defaultPriority < newFactory->defaultPriority) {
+        defaultFactory = newFactory;
     }
-    return IdRegistry::registerEntry(t);
+    return IdRegistry::registerEntry(newFactory);
 }
 
-QSharedPointer<BaseTempCalc> TempCalcRegistry::createDefaultTempCalculator(const QString& saveId) const {
-    CHECK(!saveId.isEmpty(), defaultFactory->createDefaultTempCalculator());
-
-    auto savedFactory = getById(savedSettings.value(saveId).value(BaseTempCalc::KEY_ID).toString());
-    CHECK(savedFactory != nullptr, defaultFactory->createDefaultTempCalculator());
-
-    return savedFactory->createTempCalculator(savedSettings.value(saveId));
+QSharedPointer<BaseTempCalc> TempCalcRegistry::createTempCalculator(const QString& settingsId) const {
+    auto settings = loadSettings(settingsId);
+    auto factoryId = settings.value(BaseTempCalc::KEY_ID).toString();
+    auto factory = getById(factoryId);
+    CHECK(factory != nullptr, defaultFactory->createCalculator(defaultFactory->createDefaultSettings()));
+    return factory->createCalculator(savedSettings.value(settingsId));
 }
 
-TempCalcSettings TempCalcRegistry::createDefaultTempCalcSettings() const {
-    return defaultFactory->createDefaultTempCalcSettings();
+TempCalcFactory* TempCalcRegistry::getDefaultTempCalcFactory() const {
+    SAFE_POINT(defaultFactory != nullptr, "defaultFactory is null!", nullptr);
+    return defaultFactory;
 }
 
-QSharedPointer<BaseTempCalc> TempCalcRegistry::createTempCalculatorBySettingsMap(const QVariantMap& settingsMap) const {
-    if (settingsMap.isEmpty()) {
-        return createDefaultTempCalculator();
-    }
-    auto settingsId = settingsMap.value(BaseTempCalc::KEY_ID).toString();
-    TempCalcFactory* calcFactory = getById(settingsId);
-    return calcFactory != nullptr ? calcFactory->createTempCalculator(settingsMap) : nullptr;
+QSharedPointer<BaseTempCalc> TempCalcRegistry::createTempCalculator(const QVariantMap& settingsMap) const {
+    CHECK(settingsMap.isEmpty(), nullptr);
+    auto factoryId = settingsMap.value(BaseTempCalc::KEY_ID).toString();
+    TempCalcFactory* calcFactory = getById(factoryId);
+    CHECK(calcFactory != nullptr, nullptr);
+    return calcFactory->createCalculator(settingsMap);
 }
 
-void TempCalcRegistry::saveSettings(const QString& saveId, const TempCalcSettings& settings) {
-    savedSettings.insert(saveId, settings);
+void TempCalcRegistry::saveSettings(const QString& settingsId, const TempCalcSettings& settings) {
+    savedSettings.insert(settingsId, settings);
+}
+
+TempCalcSettings TempCalcRegistry::loadSettings(const QString& settingsId) const {
+    return savedSettings.value(settingsId);
 }
 
 }  // namespace U2

--- a/src/corelibs/U2Algorithm/src/registry/TempCalcRegistry.h
+++ b/src/corelibs/U2Algorithm/src/registry/TempCalcRegistry.h
@@ -48,7 +48,8 @@ public:
 
     /**
      * Creates a temperature calculator instance preconfigured with the given settings.
-     * If settings are not provided or contains invalid algorithm ID returns a null value.
+     * If settings contains invalid algorithm ID returns a null value.
+     * If settings are empty returns the default calculator.
      */
     QSharedPointer<BaseTempCalc> createTempCalculator(const QVariantMap& settingsMap) const;
 

--- a/src/corelibs/U2Algorithm/src/registry/TempCalcRegistry.h
+++ b/src/corelibs/U2Algorithm/src/registry/TempCalcRegistry.h
@@ -20,13 +20,13 @@
  */
 #pragma once
 
-#include <U2Core/IdRegistry.h>
-#include <U2Core/global.h>
+#include <QSharedPointer>
 
 #include <U2Algorithm/BaseTempCalc.h>
 #include <U2Algorithm/TempCalcFactory.h>
 
-#include <QSharedPointer>
+#include <U2Core/IdRegistry.h>
+#include <U2Core/global.h>
 
 namespace U2 {
 
@@ -35,40 +35,35 @@ namespace U2 {
  */
 class U2ALGORITHM_EXPORT TempCalcRegistry : public IdRegistry<TempCalcFactory> {
 public:
-    bool registerEntry(TempCalcFactory* t) override;
+    bool registerEntry(TempCalcFactory* factory) override;
+
+    /** Returns the default temperature calculator factory. The returned factory is never null. */
+    TempCalcFactory* getDefaultTempCalcFactory() const;
+
     /**
-     * Get the default temperature calculator
-     * Get the factory with the corresponding ID @saveId
-     * If @saveId is empty - get the first registred factory
-     * @return pointer to the temperature calculator
+     * Creates a pre-configured 'BaseTempCalc' using saved settings ID.
+     * If ID is not provided or settings are not found creates a default calculator with a default settings.
      */
-    QSharedPointer<BaseTempCalc> createDefaultTempCalculator(const QString& saveId = "") const;
+    QSharedPointer<BaseTempCalc> createTempCalculator(const QString& settingsId = "") const;
+
     /**
-     * Get the default temperature calculator settings
-     * @return pointer to the temperature calculator settings
+     * Creates a temperature calculator instance preconfigured with the given settings.
+     * If settings are not provided or contains invalid algorithm ID returns a null value.
      */
-    TempCalcSettings createDefaultTempCalcSettings() const;
+    QSharedPointer<BaseTempCalc> createTempCalculator(const QVariantMap& settingsMap) const;
+
     /**
-     * Get the temperature calculator settings by temperature settings,
-     * which are stored as a variant map
-     * @settingsMap map settings
-     * @return pointer to the temperature calculator settings
+     * Saves TM algorithms settings by the given 'settingsId' key.
+     * The saved settings can be retrieved later within the same UGENE session using 'createCalculator' method.
      */
-    QSharedPointer<BaseTempCalc> createTempCalculatorBySettingsMap(const QVariantMap& settingsMap) const;
-    /**
-     * Save calculation settings to this static object
-     * This is required if, for example, we need to store settings,
-     * which are stored in some other object, but this object should be destroyed
-     * (for example, if this object is some widget and should be closed).
-     * @saveId ID of the saved settings. If it is settings of some Sequence View you can use its AnnotatedDNAView name
-     * If @saveId is empty - get the first registred factory
-     * @return pointer to the temperature calculator
-     */
-    void saveSettings(const QString& saveId, const TempCalcSettings& settings);
+    void saveSettings(const QString& settingsId, const TempCalcSettings& settings);
+
+    /** Loads previously saved settings. Returns an empty value if the settings was not found. */
+    TempCalcSettings loadSettings(const QString& settingsId) const;
 
 private:
     TempCalcFactory* defaultFactory = nullptr;
     QMap<QString, TempCalcSettings> savedSettings;
 };
 
-}
+}  // namespace U2

--- a/src/corelibs/U2Algorithm/src/temperature/TempCalcFactory.cpp
+++ b/src/corelibs/U2Algorithm/src/temperature/TempCalcFactory.cpp
@@ -23,8 +23,8 @@
 
 namespace U2 {
 
-TempCalcFactory::TempCalcFactory(const QString& _id, const QString& _visualName)
-    : id(_id), visualName(_visualName) {
+TempCalcFactory::TempCalcFactory(const QString& _id, const QString& _visualName, int _defaultPriority)
+    : id(_id), visualName(_visualName), defaultPriority(_defaultPriority) {
 }
 
 const QString& TempCalcFactory::getId() const {

--- a/src/corelibs/U2Algorithm/src/temperature/TempCalcFactory.h
+++ b/src/corelibs/U2Algorithm/src/temperature/TempCalcFactory.h
@@ -36,30 +36,18 @@ class BaseTempCalcWidget;
  */
 class U2ALGORITHM_EXPORT TempCalcFactory {
 public:
-    TempCalcFactory(const QString& id, const QString& visualName);
+    TempCalcFactory(const QString& id, const QString& visualName, int defaultPriority);
+
     virtual ~TempCalcFactory() = default;
 
-    /**
-     * Creates temperature calculator.
-     * @settings settings of the calculator, which should be created.
-     * @return pointer to the temperature calculator.
-     */
-    virtual QSharedPointer<BaseTempCalc> createTempCalculator(const TempCalcSettings& settings) const = 0;
-    /**
-     * Creates temperature calculator with the default settings.
-     * @return pointer to the temperature calculator.
-     */
-    virtual QSharedPointer<BaseTempCalc> createDefaultTempCalculator() const = 0;
-    /**
-     * Creates default settings of the default temperature calculator.
-     * @return temperature calculator settings.
-     */
-    virtual TempCalcSettings createDefaultTempCalcSettings() const = 0;
-    /**
-     * Creates widget to set manually settings and get TempCalcSettings from this widget.
-     * @return pointer to the temperature calculator.
-     */
-    virtual BaseTempCalcWidget* createTempCalcSettingsWidget(QWidget* parent) const = 0;
+    /** Creates temperature calculator pre-configured with the given settings. */
+    virtual QSharedPointer<BaseTempCalc> createCalculator(const TempCalcSettings& settings) const = 0;
+
+    /** Creates default settings of the default temperature calculator. */
+    virtual TempCalcSettings createDefaultSettings() const = 0;
+
+    /** Creates a widget with a settings for the given TempCalc. */
+    virtual BaseTempCalcWidget* createSettingsWidget(QWidget* parent) const = 0;
 
     /** Returns id of the factory. The method is required by IdRegistry. */
     const QString& getId() const;
@@ -67,6 +55,12 @@ public:
     const QString id;
 
     const QString visualName;
+
+    /**
+     * Priority of this algorithm to be selected as the default in UGENE.
+     * The built-in 'Rough' algorithm has 0 priority. Any higher value will be preferable over '0'.
+     */
+    const int defaultPriority;
 };
 
 }  // namespace U2

--- a/src/corelibs/U2Algorithm/src/temperature/methods/RoughTempCalcCmdFactory.cpp
+++ b/src/corelibs/U2Algorithm/src/temperature/methods/RoughTempCalcCmdFactory.cpp
@@ -26,24 +26,20 @@
 namespace U2 {
 
 RoughTempCalcCmdFactory::RoughTempCalcCmdFactory()
-    : TempCalcFactory("rough-tm-algorithm", tr("Rough")) {
+    : TempCalcFactory("rough-tm-algorithm", tr("Rough"), 0) {
 }
 
-QSharedPointer<BaseTempCalc> RoughTempCalcCmdFactory::createTempCalculator(const TempCalcSettings& settings) const {
+QSharedPointer<BaseTempCalc> RoughTempCalcCmdFactory::createCalculator(const TempCalcSettings& settings) const {
     return QSharedPointer<BaseTempCalc>(new RoughTempCalc(settings));
 }
 
-QSharedPointer<BaseTempCalc> RoughTempCalcCmdFactory::createDefaultTempCalculator() const {
-    return createTempCalculator(createDefaultTempCalcSettings());
-}
-
-TempCalcSettings RoughTempCalcCmdFactory::createDefaultTempCalcSettings() const {
+TempCalcSettings RoughTempCalcCmdFactory::createDefaultSettings() const {
     TempCalcSettings settings;
     settings.insert(BaseTempCalc::KEY_ID, id);
     return settings;
 }
 
-BaseTempCalcWidget* RoughTempCalcCmdFactory::createTempCalcSettingsWidget(QWidget*) const {
+BaseTempCalcWidget* RoughTempCalcCmdFactory::createSettingsWidget(QWidget*) const {
     return nullptr;
 }
 

--- a/src/corelibs/U2Algorithm/src/temperature/methods/RoughTempCalcCmdFactory.h
+++ b/src/corelibs/U2Algorithm/src/temperature/methods/RoughTempCalcCmdFactory.h
@@ -39,10 +39,9 @@ class U2ALGORITHM_EXPORT RoughTempCalcCmdFactory : public TempCalcFactory {
 public:
     RoughTempCalcCmdFactory();
 
-    QSharedPointer<BaseTempCalc> createTempCalculator(const TempCalcSettings& settings) const override;
-    QSharedPointer<BaseTempCalc> createDefaultTempCalculator() const override;
-    TempCalcSettings createDefaultTempCalcSettings() const override;
-    BaseTempCalcWidget* createTempCalcSettingsWidget(QWidget* parent) const override;
+    QSharedPointer<BaseTempCalc> createCalculator(const TempCalcSettings& settings) const override;
+    TempCalcSettings createDefaultSettings() const override;
+    BaseTempCalcWidget* createSettingsWidget(QWidget* parent) const override;
 };
 
 }

--- a/src/corelibs/U2Core/src/datatype/primers/PrimerStatistics.cpp
+++ b/src/corelibs/U2Core/src/datatype/primers/PrimerStatistics.cpp
@@ -23,10 +23,7 @@
 
 #include <U2Core/AppContext.h>
 #include <U2Core/DNAAlphabet.h>
-#include <U2Core/DNASequenceUtils.h>
-#include <U2Core/DNATranslation.h>
 #include <U2Core/L10n.h>
-#include <U2Core/Primer.h>
 #include <U2Core/TextUtils.h>
 #include <U2Core/U2SafePoints.h>
 
@@ -101,6 +98,7 @@ PrimerStatisticsCalculator::PrimerStatisticsCalculator(const QByteArray& _sequen
       direction(_direction), 
       energyThreshold(_energyThreshold),
       nA(0), nC(0), nG(0), nT(0), maxRun(0) {
+    SAFE_POINT(temperatureCalculator != nullptr, "PrimerStatisticsCalculator:temperatureCalculator is null" ,)
     CHECK(!sequence.isEmpty(), );
 
     int currentRun = 0;
@@ -294,10 +292,10 @@ QString PrimersPairStatistics::getFirstError() const {
 }
 
 #define CREATE_COLUMN(name, width, center) \
-    result += QString("<th width=\"%1%\"/><p %2><strong>%3</strong></p></th>").arg(width).arg(center ? "align=\"center\"" : "align=\"left\"").arg(name);
+    result += QString("<th width=\"%1%\"/><p %2><strong>%3</strong></p></th>").arg(width).arg((center) ? "align=\"center\"" : "align=\"left\"").arg(name);
 
 #define CREATE_CELL(value, good, center) \
-    result += QString("<td %1 %2>%3</td>").arg(good ? "" : " style=\"color: red;\"").arg(center ? " align=\"center\"" : "").arg(value);
+    result += QString("<td %1 %2>%3</td>").arg((good) ? "" : " style=\"color: red;\"").arg((center) ? " align=\"center\"" : "").arg(value);
 
 #define CREATE_ROW(criteria, range, value1, value2, good1, good2) \
     result += "<tr>"; \

--- a/src/corelibs/U2View/src/ov_sequence/sequence_info/SequenceInfo.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/sequence_info/SequenceInfo.cpp
@@ -82,7 +82,7 @@ SequenceInfo::SequenceInfo(AnnotatedDNAView* _annotatedDnaView)
     : annotatedDnaView(_annotatedDnaView),
       annotatedDnaViewName(annotatedDnaView->getName()),
       savableWidget(this, GObjectViewUtils::findViewByName(annotatedDnaViewName)),
-      temperatureCalculator(AppContext::getTempCalcRegistry()->createDefaultTempCalculator(annotatedDnaViewName)) {
+      temperatureCalculator(AppContext::getTempCalcRegistry()->createTempCalculator(annotatedDnaViewName)) {
     SAFE_POINT(0 != annotatedDnaView, "AnnotatedDNAView is NULL!", );
 
     updateCurrentRegions();

--- a/src/corelibs/U2View/src/temperature/TempCalcDialog.cpp
+++ b/src/corelibs/U2View/src/temperature/TempCalcDialog.cpp
@@ -51,7 +51,7 @@ TempCalcDialog::TempCalcDialog(QWidget* parent, const TempCalcSettings& currentS
 
 QSharedPointer<BaseTempCalc> TempCalcDialog::createTemperatureCalculator() const {
     auto settings = tempCalcWidget->getSettings();
-    return AppContext::getTempCalcRegistry()->getById(settings.value(BaseTempCalc::KEY_ID).toString())->createTempCalculator(settings);
+    return AppContext::getTempCalcRegistry()->getById(settings.value(BaseTempCalc::KEY_ID).toString())->createCalculator(settings);
 }
 
 TempCalcSettings TempCalcDialog::getTemperatureCalculatorSettings() const {

--- a/src/corelibs/U2View/src/temperature/TempCalcWidget.cpp
+++ b/src/corelibs/U2View/src/temperature/TempCalcWidget.cpp
@@ -49,7 +49,7 @@ TempCalcWidget::TempCalcWidget(QWidget* parent)
     layout->addWidget(swSettings);
     auto factories = AppContext::getTempCalcRegistry()->getAllEntries();
     for (auto tempCalcMethodFactory : qAsConst(factories)) {
-        auto settingsWidget = tempCalcMethodFactory->createTempCalcSettingsWidget(this);
+        auto settingsWidget = tempCalcMethodFactory->createSettingsWidget(this);
         cbAlgorithm->addItem(tempCalcMethodFactory->visualName, tempCalcMethodFactory->getId());
         swSettings->addWidget(settingsWidget);
         settingsWidget->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);

--- a/src/corelibs/U2View/src/temperature/methods/RoughTempCalcFactory.cpp
+++ b/src/corelibs/U2View/src/temperature/methods/RoughTempCalcFactory.cpp
@@ -24,7 +24,7 @@
 
 namespace U2 {
 
-BaseTempCalcWidget* RoughTempCalcFactory::createTempCalcSettingsWidget(QWidget* parent) const {
+BaseTempCalcWidget* RoughTempCalcFactory::createSettingsWidget(QWidget* parent) const {
     return new RoughTempCalcWidget(parent, id);
 }
 

--- a/src/corelibs/U2View/src/temperature/methods/RoughTempCalcFactory.h
+++ b/src/corelibs/U2View/src/temperature/methods/RoughTempCalcFactory.h
@@ -30,7 +30,7 @@ namespace U2 {
  */
 class U2VIEW_EXPORT RoughTempCalcFactory : public RoughTempCalcCmdFactory {
 public:
-    BaseTempCalcWidget* createTempCalcSettingsWidget(QWidget* parent) const override;
+    BaseTempCalcWidget* createSettingsWidget(QWidget* parent) const override;
 };
 
 }  // namespace U2

--- a/src/plugins/CoreTests/src/DnaStatisticsTests.cpp
+++ b/src/plugins/CoreTests/src/DnaStatisticsTests.cpp
@@ -104,7 +104,7 @@ void GTest_DnaStatisticsTest::init(XMLTestFormat*, const QDomElement& element) {
         CHECK_EXT(!resultMap.isEmpty(), setError("No temperature settings"), );
         CHECK_EXT(resultMap.keys().contains(BaseTempCalc::KEY_ID), setError("No ID were set"), );
 
-        temperatureCalculator = AppContext::getTempCalcRegistry()->createTempCalculatorBySettingsMap(resultMap);
+        temperatureCalculator = AppContext::getTempCalcRegistry()->createTempCalculator(resultMap);
         CHECK_EXT(temperatureCalculator != nullptr, setError("Can't set temperature settings: " + resultMap.value("id").toString()), );
     }
 

--- a/src/plugins/pcr/src/FindPrimerPairsWorker.cpp
+++ b/src/plugins/pcr/src/FindPrimerPairsWorker.cpp
@@ -89,7 +89,7 @@ Task* FindPrimerPairsWorker::tick() {
     if (!inPort->hasMessage() && inPort->isEnded()) {
         QString reportFileUrl = getValue<QString>(FindPrimerPairsWorkerFactory::OUT_FILE);
         auto tempSettings = getValue<QVariantMap>(FindPrimerPairsWorkerFactory::TEMPERATURE_SETTINGS_ID);
-        auto tempCalc = AppContext::getTempCalcRegistry()->createTempCalculatorBySettingsMap(getValue<QVariantMap>(FindPrimerPairsWorkerFactory::TEMPERATURE_SETTINGS_ID));
+        auto tempCalc = AppContext::getTempCalcRegistry()->createTempCalculator(getValue<QVariantMap>(FindPrimerPairsWorkerFactory::TEMPERATURE_SETTINGS_ID));
         Task* t = new FindPrimersTask(reportFileUrl, data, tempCalc);
         connect(new TaskSignalMapper(t), SIGNAL(si_taskFinished(Task*)), SLOT(sl_onTaskFinished(Task*)));
         return t;

--- a/src/plugins/pcr/src/FindPrimerPairsWorker.cpp
+++ b/src/plugins/pcr/src/FindPrimerPairsWorker.cpp
@@ -177,6 +177,7 @@ FindPrimersTask::FindPrimersTask(const QString& outputFileUrl, const QList<DNASe
       sequences(sequences),
       temperatureCalculator(_temperatureCalculator),
       outputUrl(outputFileUrl) {
+    SAFE_POINT(temperatureCalculator != nullptr, "FindPrimersTask: temperatureCalculator is null" ,)
 }
 
 void FindPrimersTask::run() {

--- a/src/plugins/pcr/src/InSilicoPcrOptionPanelWidget.cpp
+++ b/src/plugins/pcr/src/InSilicoPcrOptionPanelWidget.cpp
@@ -65,7 +65,7 @@ InSilicoPcrOptionPanelWidget::InSilicoPcrOptionPanelWidget(AnnotatedDNAView* _an
       resultTableShown(false),
       savableWidget(this, GObjectViewUtils::findViewByName(annotatedDnaView->getName())),
       tempCalcId(annotatedDnaView->getName() + ID_POSTFIX),
-      temperatureCalculator(AppContext::getTempCalcRegistry()->createDefaultTempCalculator(tempCalcId)) {
+      temperatureCalculator(AppContext::getTempCalcRegistry()->createTempCalculator(tempCalcId)) {
     GCOUNTER(cvar, "PCR options panel");
     setupUi(this);
     forwardPrimerBoxSubgroup->init(FORWARD_SUBGROUP_ID, tr("Forward primer"), forwardPrimerBox, true);
@@ -283,7 +283,7 @@ void InSilicoPcrOptionPanelWidget::sl_showDetails(const QString& link) {
 void U2::InSilicoPcrOptionPanelWidget::sl_temperatureSettingsChanged() {
     auto tempCalcSettings = temperatureWidget->getSettings();
     auto id = tempCalcSettings.value(BaseTempCalc::KEY_ID).toString();
-    temperatureCalculator = AppContext::getTempCalcRegistry()->getById(id)->createTempCalculator(tempCalcSettings);
+    temperatureCalculator = AppContext::getTempCalcRegistry()->getById(id)->createCalculator(tempCalcSettings);
     forwardPrimerBox->setTemperatureCalculator(temperatureCalculator);
     reversePrimerBox->setTemperatureCalculator(temperatureCalculator);
 }

--- a/src/plugins/pcr/src/InSilicoPcrWorker.cpp
+++ b/src/plugins/pcr/src/InSilicoPcrWorker.cpp
@@ -371,9 +371,6 @@ Task* InSilicoPcrWorker::createTask(const Message& message, U2OpStatus& os) {
         pcrSettings->sequenceName = seq->getSequenceName();
         QVariantMap tmAlgorithmSettings = getValue<QVariantMap>(TEMPERATURE_SETTINGS_ID);
         TempCalcRegistry* tmRegistry = AppContext::getTempCalcRegistry();
-        if (tmAlgorithmSettings.isEmpty()) {
-            tmAlgorithmSettings = tmRegistry->getDefaultTempCalcFactory()->createDefaultSettings();
-        }
         pcrSettings->temperatureCalculator = tmRegistry->createTempCalculator(tmAlgorithmSettings);
         CHECK(pcrSettings->temperatureCalculator != nullptr,
               new FailTask(tr("Failed to find TM algorithm with id '%1'.").arg(tmAlgorithmSettings.value(BaseTempCalc::KEY_ID).toString())));

--- a/src/plugins/pcr/src/InSilicoPcrWorker.cpp
+++ b/src/plugins/pcr/src/InSilicoPcrWorker.cpp
@@ -366,7 +366,7 @@ Task* InSilicoPcrWorker::createTask(const Message& message, U2OpStatus& os) {
         pcrSettings->useAmbiguousBases = getValue<bool>(USE_AMBIGUOUS_BASES_ID);
         pcrSettings->perfectMatch = getValue<int>(PERFECT_ATTR_ID);
         pcrSettings->sequenceName = seq->getSequenceName();
-        pcrSettings->temperatureCalculator = AppContext::getTempCalcRegistry()->createTempCalculatorBySettingsMap(getValue<QVariantMap>(TEMPERATURE_SETTINGS_ID));
+        pcrSettings->temperatureCalculator = AppContext::getTempCalcRegistry()->createTempCalculator(getValue<QVariantMap>(TEMPERATURE_SETTINGS_ID));
 
         Task* pcrTask = new InSilicoPcrWorkflowTask(pcrSettings, productSettings);
         pcrTask->setProperty(PAIR_NUMBER_PROP_ID, i);
@@ -390,7 +390,7 @@ InSilicoPcrReportTask::InSilicoPcrReportTask(const QList<TableRow>& table,
       primers(primers), 
       reportUrl(reportUrl), 
       primersUrl(_primersUrl),
-      temperatureCalculator(AppContext::getTempCalcRegistry()->createTempCalculatorBySettingsMap(tempSettings)) {}
+      temperatureCalculator(AppContext::getTempCalcRegistry()->createTempCalculator(tempSettings)) {}
 
 void InSilicoPcrReportTask::run() {
     QScopedPointer<IOAdapter> io(IOAdapterUtils::open(reportUrl, stateInfo, IOAdapterMode_Write));

--- a/src/plugins/pcr/src/InSilicoPcrWorker.cpp
+++ b/src/plugins/pcr/src/InSilicoPcrWorker.cpp
@@ -322,7 +322,11 @@ int InSilicoPcrWorker::createMetadata(int sequenceLength, const U2Region& produc
 Task* InSilicoPcrWorker::onInputEnded() {
     CHECK(!reported, nullptr);
     reported = true;
-    return new InSilicoPcrReportTask(table, primers, getValue<QString>(REPORT_ATTR_ID), getValue<QString>(PRIMERS_ATTR_ID), getValue<QVariantMap>(TEMPERATURE_SETTINGS_ID));
+    QVariantMap tmAlgorithmSettings = getValue<QVariantMap>(TEMPERATURE_SETTINGS_ID);
+    if (tmAlgorithmSettings.isEmpty()) {
+        tmAlgorithmSettings = AppContext::getTempCalcRegistry()->getDefaultTempCalcFactory()->createDefaultSettings();
+    }
+    return new InSilicoPcrReportTask(table, primers, getValue<QString>(REPORT_ATTR_ID), getValue<QString>(PRIMERS_ATTR_ID), tmAlgorithmSettings);
 }
 
 Task* InSilicoPcrWorker::createTask(const Message& message, U2OpStatus& os) {
@@ -350,7 +354,6 @@ Task* InSilicoPcrWorker::createTask(const Message& message, U2OpStatus& os) {
     productSettings.targetDbiRef = context->getDataStorage()->getDbiRef();
     productSettings.annotationsExtraction = ExtractProductSettings::AnnotationsExtraction(getValue<int>(EXTRACT_ANNOTATIONS_ATTR_ID));
 
-
     QList<Task*> tasks;
     for (int i = 0; i < primers.size(); i++) {
         auto pcrSettings = new InSilicoPcrTaskSettings;
@@ -366,7 +369,14 @@ Task* InSilicoPcrWorker::createTask(const Message& message, U2OpStatus& os) {
         pcrSettings->useAmbiguousBases = getValue<bool>(USE_AMBIGUOUS_BASES_ID);
         pcrSettings->perfectMatch = getValue<int>(PERFECT_ATTR_ID);
         pcrSettings->sequenceName = seq->getSequenceName();
-        pcrSettings->temperatureCalculator = AppContext::getTempCalcRegistry()->createTempCalculator(getValue<QVariantMap>(TEMPERATURE_SETTINGS_ID));
+        QVariantMap tmAlgorithmSettings = getValue<QVariantMap>(TEMPERATURE_SETTINGS_ID);
+        TempCalcRegistry* tmRegistry = AppContext::getTempCalcRegistry();
+        if (tmAlgorithmSettings.isEmpty()) {
+            tmAlgorithmSettings = tmRegistry->getDefaultTempCalcFactory()->createDefaultSettings();
+        }
+        pcrSettings->temperatureCalculator = tmRegistry->createTempCalculator(tmAlgorithmSettings);
+        CHECK(pcrSettings->temperatureCalculator != nullptr,
+              new FailTask(tr("Failed to find TM algorithm with id '%1'.").arg(tmAlgorithmSettings.value(BaseTempCalc::KEY_ID).toString())));
 
         Task* pcrTask = new InSilicoPcrWorkflowTask(pcrSettings, productSettings);
         pcrTask->setProperty(PAIR_NUMBER_PROP_ID, i);
@@ -381,18 +391,21 @@ Task* InSilicoPcrWorker::createTask(const Message& message, U2OpStatus& os) {
 /************************************************************************/
 /* InSilicoPcrReportTask */
 /************************************************************************/
-InSilicoPcrReportTask::InSilicoPcrReportTask(const QList<TableRow>& table, 
-                                             const QList<QPair<Primer, Primer>>& primers, 
-                                             const QString& reportUrl, 
-                                             const QString& _primersUrl, 
+InSilicoPcrReportTask::InSilicoPcrReportTask(const QList<TableRow>& table,
+                                             const QList<QPair<Primer, Primer>>& primers,
+                                             const QString& reportUrl,
+                                             const QString& _primersUrl,
                                              const QVariantMap& tempSettings)
-    : Task(tr("Generate In Silico PCR report"), TaskFlag_None), table(table), 
-      primers(primers), 
-      reportUrl(reportUrl), 
+    : Task(tr("Generate In Silico PCR report"), TaskFlag_None), table(table),
+      primers(primers),
+      reportUrl(reportUrl),
       primersUrl(_primersUrl),
-      temperatureCalculator(AppContext::getTempCalcRegistry()->createTempCalculator(tempSettings)) {}
+      temperatureCalculator(AppContext::getTempCalcRegistry()->createTempCalculator(tempSettings)) {
+    SAFE_POINT(temperatureCalculator != nullptr, "temperatureCalculator is nullptr!", )
+}
 
 void InSilicoPcrReportTask::run() {
+    CHECK(temperatureCalculator != nullptr, );
     QScopedPointer<IOAdapter> io(IOAdapterUtils::open(reportUrl, stateInfo, IOAdapterMode_Write));
     CHECK_OP(stateInfo, );
     const QString report = createReport();

--- a/src/plugins/pcr/src/PrimerLibrary.cpp
+++ b/src/plugins/pcr/src/PrimerLibrary.cpp
@@ -354,10 +354,10 @@ void PrimerLibrary::initTemperatureCalculator() {
 
     auto factory = AppContext::getTempCalcRegistry()->getById(calcId);
     if (factory != nullptr) {
-        temperatureCalculator = factory->createTempCalculator(settings);
+        temperatureCalculator = factory->createCalculator(settings);
         initializedFromDb = true;
     } else {
-        temperatureCalculator = AppContext::getTempCalcRegistry()->createDefaultTempCalculator();
+        temperatureCalculator = AppContext::getTempCalcRegistry()->createTempCalculator();
     }
     
 }

--- a/src/plugins/pcr/src/TempCalcDelegate.cpp
+++ b/src/plugins/pcr/src/TempCalcDelegate.cpp
@@ -20,24 +20,25 @@
  */
 
 #include "TempCalcDelegate.h"
-#include "TempCalcPropertyWidget.h"
 
 #include <U2Algorithm/BaseTempCalc.h>
 #include <U2Algorithm/TempCalcRegistry.h>
 
 #include <U2Core/AppContext.h>
 
+#include "TempCalcPropertyWidget.h"
+
 namespace U2 {
 
-TempCalcDelegate::TempCalcDelegate(QObject* parent) 
-    : PropertyDelegate(parent) {}
+TempCalcDelegate::TempCalcDelegate(QObject* parent)
+    : PropertyDelegate(parent) {
+}
 
 QVariant TempCalcDelegate::getDisplayValue(const QVariant& value) const {
     if (!value.isValid()) {
-        TempCalcSettings defaultSettings(AppContext::getTempCalcRegistry()->createDefaultTempCalcSettings());
-        return defaultSettings.value(BaseTempCalc::KEY_ID).toString();
+        auto defaultFactory = AppContext::getTempCalcRegistry()->getDefaultTempCalcFactory();
+        return defaultFactory->getId();
     }
-
     return value.toMap().value(BaseTempCalc::KEY_ID).toString();
 }
 
@@ -73,4 +74,4 @@ void TempCalcDelegate::sl_commit() {
     emit commitData(editor);
 }
 
-}
+}  // namespace U2

--- a/src/plugins/pcr/src/TempCalcPropertyWidget.h
+++ b/src/plugins/pcr/src/TempCalcPropertyWidget.h
@@ -43,6 +43,9 @@ private slots:
     void sl_showDialog();
 
 private:
+    /** Updates state of UI based in the current settings. */
+    void updateUiState();
+
     QLineEdit* lineEdit = nullptr;
     QToolButton* toolButton = nullptr;
     TempCalcSettings tempSettings;

--- a/src/plugins_3rdparty/primer3/src/temperature/Primer3TempCalcFactory.cpp
+++ b/src/plugins_3rdparty/primer3/src/temperature/Primer3TempCalcFactory.cpp
@@ -26,18 +26,14 @@
 namespace U2 {
 
 Primer3TempCalcFactory::Primer3TempCalcFactory()
-    : TempCalcFactory("primer3-tm-algorithm", tr("Primer 3")) {
+    : TempCalcFactory("primer3-tm-algorithm", tr("Primer 3"), -1) {  // TODO: Make Primer3 default once issues are fixed.
 }
 
-QSharedPointer<BaseTempCalc> Primer3TempCalcFactory::createTempCalculator(const TempCalcSettings& settings) const {
+QSharedPointer<BaseTempCalc> Primer3TempCalcFactory::createCalculator(const TempCalcSettings& settings) const {
     return QSharedPointer<BaseTempCalc>(new Primer3TempCalc(settings));
 }
 
-QSharedPointer<BaseTempCalc> Primer3TempCalcFactory::createDefaultTempCalculator() const {
-    return createTempCalculator(createDefaultTempCalcSettings());
-}
-
-TempCalcSettings Primer3TempCalcFactory::createDefaultTempCalcSettings() const {
+TempCalcSettings Primer3TempCalcFactory::createDefaultSettings() const {
     TempCalcSettings settings;
     settings.insert(BaseTempCalc::KEY_ID, id);
     settings.insert(Primer3TempCalc::KEY_DNA_CONC, Primer3TempCalc::DNA_CONC_DEFAULT);
@@ -54,7 +50,7 @@ TempCalcSettings Primer3TempCalcFactory::createDefaultTempCalcSettings() const {
     return settings;
 }
 
-BaseTempCalcWidget* Primer3TempCalcFactory::createTempCalcSettingsWidget(QWidget* parent) const {
+BaseTempCalcWidget* Primer3TempCalcFactory::createSettingsWidget(QWidget* parent) const {
     return new Primer3TempCalcWidget(parent, id);
 }
 

--- a/src/plugins_3rdparty/primer3/src/temperature/Primer3TempCalcFactory.h
+++ b/src/plugins_3rdparty/primer3/src/temperature/Primer3TempCalcFactory.h
@@ -34,10 +34,9 @@ class Primer3TempCalcFactory : public TempCalcFactory {
 public:
     Primer3TempCalcFactory();
 
-    QSharedPointer<BaseTempCalc> createTempCalculator(const TempCalcSettings& settings) const override;
-    QSharedPointer<BaseTempCalc> createDefaultTempCalculator() const override;
-    TempCalcSettings createDefaultTempCalcSettings() const override;
-    BaseTempCalcWidget* createTempCalcSettingsWidget(QWidget* parent) const override;
+    QSharedPointer<BaseTempCalc> createCalculator(const TempCalcSettings& settings) const override;
+    TempCalcSettings createDefaultSettings() const override;
+    BaseTempCalcWidget* createSettingsWidget(QWidget* parent) const override;
 };
 
 }  // namespace U2


### PR DESCRIPTION
…lgorithms.

This patch contains:

1) Fix for copy-pasted, unrelated and boilerplate (no-info) comments for Tm algorithms.
2) Show visual algorithm name instead of WD instead if ID.
3) Support for Tm algorithms priority that allows making Primer3 algorithm default (the initial intention of the patch that caused other changes).
4) Fixes of wrong names for variables: mix of tmKeyId and settingsId.
5) Dropped 'Temp' part for methods that are already inside TempCalcFactory: createTempCalculator->createCalculator 
6) Dropped 'Default' part for methods where 'Default' is unclear: example createDefaultTempCalculator(settingsId)->createTempCalculator(settingsId) - the calculator created here is not default, but the one described by the settingsId.

Primer3 was not made default because it computes wrong TM values for regions that are out of range.
