### PR TITLE
Cleanup ObjectViewModel: widget creation, layout, naming

### DIFF
--- a/src/corelibs/U2Gui/src/ObjectViewModel.cpp
+++ b/src/corelibs/U2Gui/src/ObjectViewModel.cpp
@@ -387,7 +387,7 @@ void GObjectViewController::buildActionMenu(QMenu* menu, const QList<QString>& m
 /// GObjectViewWindow
 
 GObjectViewWindow::GObjectViewWindow(GObjectViewController* viewController, const QString& _viewName, bool _persistent)
-    : MWMDIWindow(_viewName), view(viewController), persistent(_persistent) {
+    : MWMDIWindow(_viewName), viewController(viewController), persistent(_persistent) {
     viewController->setParent(this);
     viewController->setClosingInterface(this);
 
@@ -457,22 +457,22 @@ void GObjectViewWindow::closeView() {
 }
 
 bool GObjectViewWindow::onCloseEvent() {
-    view->saveWidgetState();
-    return view->onCloseEvent();
+    viewController->saveWidgetState();
+    return viewController->onCloseEvent();
 }
 
 GObjectViewFactory* GObjectViewWindow::getViewFactory() const {
-    GObjectViewFactory* viewFactory = AppContext::getObjectViewFactoryRegistry()->getFactoryById(view->getFactoryId());
+    GObjectViewFactory* viewFactory = AppContext::getObjectViewFactoryRegistry()->getFactoryById(viewController->getFactoryId());
     SAFE_POINT(viewFactory != nullptr, "viewFactory is null!", nullptr)
     return viewFactory;
 }
 
 void GObjectViewWindow::setupMDIToolbar(QToolBar* tb) {
-    view->buildStaticToolbar(tb);
+    viewController->buildStaticToolbar(tb);
 }
 
 void GObjectViewWindow::setupViewMenu(QMenu* m) {
-    view->buildMenu(m, GObjectViewMenuType::STATIC);
+    viewController->buildMenu(m, GObjectViewMenuType::STATIC);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -778,11 +778,11 @@ void GObjectViewWindowContext::onObjectRemoved(GObjectViewController* v, GObject
 // GObjectViewAction
 
 GObjectViewAction::GObjectViewAction(QObject* p, GObjectViewController* v, const QString& text, int order)
-    : QAction(text, p), view(v), actionOrder(order) {
+    : QAction(text, p), viewController(v), actionOrder(order) {
 }
 
 GObjectViewController* GObjectViewAction::getObjectView() const {
-    return view;
+    return viewController;
 }
 
 int GObjectViewAction::getActionOrder() const {

--- a/src/corelibs/U2Gui/src/ObjectViewModel.cpp
+++ b/src/corelibs/U2Gui/src/ObjectViewModel.cpp
@@ -409,22 +409,19 @@ GObjectViewWindow::GObjectViewWindow(GObjectViewController* viewController, cons
     contentWidget->setLayout(contentWidgetLayout);
     rootScrollArea->setWidget(contentWidget);
 
-    QWidget* viewWidget = nullptr;
+    QWidget* viewWidget = viewController->createWidget(nullptr);
+    SAFE_POINT(viewWidget != nullptr, "Internal error: Object View widget is not initialized", );
 
     OptionsPanel* optionsPanel = viewController->getOptionsPanel();
     if (optionsPanel == nullptr) {
         // Set the layout of the whole window
-        viewWidget = viewController->createWidget(contentWidget);
-        SAFE_POINT(viewWidget != nullptr, "Internal error: Object View widget is not initialized", );
         contentWidgetLayout->addWidget(viewWidget);
     } else {
         OptionsPanelWidget* optionsPanelWidget = optionsPanel->getMainWidget();
-        QSplitter* splitter = new QSplitter(contentWidget);
+        auto splitter = new QSplitter(contentWidget);
         splitter->setObjectName("OPTIONS_PANEL_SPLITTER");
         splitter->setOrientation(Qt::Horizontal);
         splitter->setChildrenCollapsible(false);
-        viewWidget = viewController->createWidget(splitter);
-        SAFE_POINT(viewWidget != nullptr, "Internal error: Object View widget is not initialized", );
         splitter->addWidget(viewWidget);
         splitter->addWidget(optionsPanelWidget->getOptionsWidget());
         splitter->setStretchFactor(0, 1);

--- a/src/corelibs/U2Gui/src/ObjectViewModel.h
+++ b/src/corelibs/U2Gui/src/ObjectViewModel.h
@@ -34,7 +34,7 @@ namespace U2 {
 
 class Document;
 class GObject;
-class GObjectView;
+class GObjectViewController;
 class GObjectViewAction;
 class GObjectViewActionsProvider;
 class GObjectViewFactory;
@@ -52,7 +52,7 @@ public:
 
     void unregisterGObjectViewFactory(GObjectViewFactory* f);
 
-    GObjectViewFactory* getFactoryById(GObjectViewFactoryId id) const;
+    GObjectViewFactory* getFactoryById(const GObjectViewFactoryId& id) const;
 
     QList<GObjectViewFactory*> getAllFactories() const {
         return mapping.values();
@@ -66,8 +66,8 @@ class GObjectReference;
 class U2GUI_EXPORT GObjectViewState : public QObject {
     Q_OBJECT
 public:
-    GObjectViewState(GObjectViewFactoryId factoryId, const QString& viewName, const QString& stateName, const QVariantMap& stateData, QObject* parent = nullptr)
-        : QObject(parent), factoryId(factoryId), viewName(viewName), stateName(stateName), stateData(stateData) {
+    GObjectViewState(const GObjectViewFactoryId& _factoryId, const QString& viewName, const QString& stateName, const QVariantMap& stateData, QObject* parent = nullptr)
+        : QObject(parent), factoryId(_factoryId), viewName(viewName), stateName(stateName), stateData(stateData) {
     }
 
     GObjectViewFactoryId getViewFactoryId() const {
@@ -108,23 +108,15 @@ class U2GUI_EXPORT GObjectViewFactory : public QObject {
 public:
     static const GObjectViewFactoryId SIMPLE_TEXT_FACTORY;
 
-    GObjectViewFactory(GObjectViewFactoryId id, const QString& name, QObject* parent = nullptr)
-        : QObject(parent), id(id), name(name) {
-    }
+    GObjectViewFactory(const GObjectViewFactoryId& id, const QString& name, QObject* parent = nullptr);
 
-    GObjectViewFactoryId getId() const {
-        return id;
-    }
+    const GObjectViewFactoryId& getId() const;
 
-    QString getName() const {
-        return name;
-    }
+    const QString& getName() const;
 
     virtual bool canCreateView(const MultiGSelection& multiSelection) = 0;
 
-    virtual bool supportsSavedStates() const {
-        return false;
-    }
+    virtual bool supportsSavedStates() const;
 
     virtual bool isStateInSelection(const MultiGSelection& multiSelection, const QVariantMap& stateData);
 
@@ -141,30 +133,24 @@ class GObjectViewCloseInterface;
 class OptionsPanel;
 class GObjectViewWindow;
 
-class U2GUI_EXPORT GObjectView : public QObject {
+class U2GUI_EXPORT GObjectViewController : public QObject {
     friend class GObjectViewWindow;
     Q_OBJECT
 public:
-    GObjectView(GObjectViewFactoryId factoryId, const QString& viewName, QObject* p = nullptr);
+    GObjectViewController(const GObjectViewFactoryId& factoryId, const QString& viewName, QObject* p = nullptr);
 
-    GObjectViewFactoryId getFactoryId() const {
-        return factoryId;
-    }
+    const GObjectViewFactoryId& getFactoryId() const;
 
-    const QString& getName() const {
-        return viewName;
-    }
+    const QString& getName() const;
 
     void setName(const QString& name);
 
-    QWidget* getWidget();
+    QWidget* getWidget() const;
 
     /** Returns the options panel object, or 0 if it is not defined */
     virtual OptionsPanel* getOptionsPanel();
 
-    const QList<GObject*>& getObjects() const {
-        return objects;
-    }
+    const QList<GObject*>& getObjects() const;
 
     // Returns true if view  contains this object
     bool containsObject(GObject* obj) const;
@@ -172,9 +158,7 @@ public:
     // Returns true if view  contains any objects from the document
     bool containsDocumentObjects(Document* doc) const;
 
-    virtual QVariantMap saveState() {
-        return QVariantMap();
-    }
+    virtual QVariantMap saveState();
 
     virtual Task* updateViewTask(const QString& stateName, const QVariantMap& stateData) = 0;
 
@@ -191,20 +175,13 @@ public:
 
     virtual void removeObject(GObject* o);
 
-    virtual void saveWidgetState() {
-    }
+    virtual void saveWidgetState();
 
-    virtual void addObjectHandler(GObjectViewObjectHandler* oh) {
-        objectHandlers.append(oh);
-    }
+    virtual void addObjectHandler(GObjectViewObjectHandler* oh);
 
-    virtual void removeObjectHandler(GObjectViewObjectHandler* oh) {
-        objectHandlers.removeOne(oh);
-    }
+    virtual void removeObjectHandler(GObjectViewObjectHandler* oh);
 
-    virtual bool onCloseEvent() {
-        return true;
-    }
+    virtual bool onCloseEvent();
 
     /** Registers a new actions provider to the view. */
     void registerActionProvider(GObjectViewActionsProvider* actionsProvider);
@@ -223,7 +200,7 @@ protected:
 
 protected:
     virtual void _removeObject(GObject* o);
-    virtual QWidget* createWidget() = 0;
+    virtual QWidget* createViewWidget(QWidget* parent) = 0;
 
     /**
      * Adds all actions with the given menu types into the menu.
@@ -241,16 +218,19 @@ protected:
      */
     virtual void onAfterViewWindowInit();
 
+private:
+    QWidget* createWidget(QWidget* parent);
+
 signals:
     /**
      * Emitted when menu of the given type is about to be shown.
      * A client should add related menu items to the menu.
      */
-    void si_buildMenu(GObjectView* v, QMenu* m, const QString& type);
+    void si_buildMenu(GObjectViewController* v, QMenu* m, const QString& type);
 
-    void si_buildStaticToolbar(GObjectView* v, QToolBar* tb);
-    void si_objectAdded(GObjectView* v, GObject* obj);
-    void si_objectRemoved(GObjectView* v, GObject* obj);
+    void si_buildStaticToolbar(GObjectViewController* v, QToolBar* tb);
+    void si_objectAdded(GObjectViewController* v, GObject* obj);
+    void si_objectRemoved(GObjectViewController* v, GObject* obj);
     void si_nameChanged(const QString& oldName);
 
 protected slots:
@@ -264,7 +244,7 @@ protected slots:
 protected:
     GObjectViewFactoryId factoryId;
     QString viewName;
-    QWidget* widget;
+    QWidget* viewWidget;
     QList<GObject*> objects;
     QList<GObject*> requiredObjects;
     GObjectViewCloseInterface* closeInterface;
@@ -277,7 +257,7 @@ protected:
 class U2GUI_EXPORT GObjectViewActionsProvider {
 public:
     /** Returns list of actions available to the view. */
-    virtual QList<GObjectViewAction*> getViewActions(GObjectView* view) const = 0;
+    virtual QList<GObjectViewAction*> getViewActions(GObjectViewController* view) const = 0;
 };
 
 /** Constants for known GObject view menu types. */
@@ -301,7 +281,7 @@ class U2GUI_EXPORT GObjectViewWindow : public MWMDIWindow, public GObjectViewClo
     Q_OBJECT
 
 public:
-    GObjectViewWindow(GObjectView* view, const QString& _viewName, bool _persistent = false);
+    GObjectViewWindow(GObjectViewController* viewController, const QString& _viewName, bool _persistent = false);
 
     const QList<GObject*>& getObjects() const {
         return view->getObjects();
@@ -321,7 +301,7 @@ public:
         return view->getName();
     }
 
-    GObjectView* getObjectView() const {
+    GObjectViewController* getObjectView() const {
         return view;
     }
 
@@ -341,7 +321,7 @@ signals:
     void si_windowClosed(GObjectViewWindow* viewWindow);
 
 protected:
-    GObjectView* view;
+    GObjectViewController* view;
     bool persistent;
 };
 
@@ -358,7 +338,7 @@ public:
 
     static QList<GObjectViewWindow*> getAllActiveViews();
 
-    static QList<GObjectViewWindow*> findViewsByFactoryId(GObjectViewFactoryId id);
+    static QList<GObjectViewWindow*> findViewsByFactoryId(const GObjectViewFactoryId& id);
 
     static QList<GObjectViewWindow*> findViewsWithObject(GObject* obj);
 
@@ -385,9 +365,9 @@ public:
 class U2GUI_EXPORT GObjectViewAction : public QAction {
     Q_OBJECT
 public:
-    GObjectViewAction(QObject* p, GObjectView* v, const QString& text, int order = GObjectViewAction_DefaultOrder);
+    GObjectViewAction(QObject* p, GObjectViewController* v, const QString& text, int order = GObjectViewAction_DefaultOrder);
 
-    GObjectView* getObjectView() const;
+    GObjectViewController* getObjectView() const;
 
     int getActionOrder() const;
 
@@ -400,7 +380,7 @@ public:
     void setMenuTypes(const QList<QString>& menuTypes);
 
 private:
-    GObjectView* view;
+    GObjectViewController* view;
 
     // Action order can be used to set-up relative action position in GUI elements
     int actionOrder;
@@ -421,13 +401,13 @@ public:
      * Checks if the handler can 'handle' the object.
      * If there is at least one handler that returns 'yes', the object can be added to the view.
      */
-    virtual bool canHandle(GObjectView* view, GObject* obj);
+    virtual bool canHandle(GObjectViewController* view, GObject* obj);
 
     /** Called when an object is added to the view. */
-    virtual void onObjectAdded(GObjectView* view, GObject* obj);
+    virtual void onObjectAdded(GObjectViewController* view, GObject* obj);
 
     /** Called when an object is removed from the view. */
-    virtual void onObjectRemoved(GObjectView* view, GObject* obj);
+    virtual void onObjectRemoved(GObjectViewController* view, GObject* obj);
 };
 
 class U2GUI_EXPORT GObjectViewWindowContext : public QObject, public GObjectViewObjectHandler, public GObjectViewActionsProvider {
@@ -438,35 +418,35 @@ public:
     virtual ~GObjectViewWindowContext();
     virtual void init();
 
-    QList<GObjectViewAction*> getViewActions(GObjectView* view) const override;
+    QList<GObjectViewAction*> getViewActions(GObjectViewController* view) const override;
 
-    void onObjectRemoved(GObjectView* v, GObject* obj) override;
+    void onObjectRemoved(GObjectViewController* v, GObject* obj) override;
 
 protected:
     /// init context associated with 'view'
-    virtual void initViewContext(GObjectView* view) = 0;
-    void addViewResource(GObjectView* view, QObject* r);
+    virtual void initViewContext(GObjectViewController* view) = 0;
+    void addViewResource(GObjectViewController* view, QObject* r);
     void addViewAction(GObjectViewAction* a);
-    GObjectViewAction* findViewAction(GObjectView* v, const QString& actionName) const;
+    GObjectViewAction* findViewAction(GObjectViewController* v, const QString& actionName) const;
 
 protected slots:
     virtual void sl_windowAdded(MWMDIWindow*);
     virtual void sl_windowClosing(MWMDIWindow*);
 
-    virtual void sl_buildMenu(GObjectView* view, QMenu* menu, const QString& type);
+    virtual void sl_buildMenu(GObjectViewController* view, QMenu* menu, const QString& type);
 
 protected:
     /**
      * Populates static global application menu with actions added by the class instance.
      * This method is called when the view builds GObjectViewMenuType::Static menu.
      */
-    virtual void buildStaticMenu(GObjectView* view, QMenu* menu);
+    virtual void buildStaticMenu(GObjectViewController* view, QMenu* menu);
 
     /**
      * Populates context popup menu with actions added by the class instance.
      * This method is called when the view builds GObjectViewMenuType::Context menu.
      */
-    virtual void buildContextMenu(GObjectView* view, QMenu* menu);
+    virtual void buildContextMenu(GObjectViewController* view, QMenu* menu);
 
     /**
      * Populates menu with type specific actions.
@@ -474,7 +454,7 @@ protected:
      * The method is never called for the generic 'GObjectViewMenuType::Context' or 'GObjectViewMenuType::Static' menu types:
      *  use 'buildContextMenu' or 'buildStaticMenu' for that types.
      */
-    virtual void buildActionMenu(GObjectView* view, QMenu* menu, const QString& menuType);
+    virtual void buildActionMenu(GObjectViewController* view, QMenu* menu, const QString& menuType);
 
     /**
      * Builds both 'GObjectViewMenuType::Static' and 'GObjectViewMenuType::Context' menus.
@@ -484,11 +464,11 @@ protected:
      *
      * This method is never called for menu types other than 'GObjectViewMenuType::Static' and 'GObjectViewMenuType::Context'.
      */
-    virtual void buildStaticOrContextMenu(GObjectView* view, QMenu* menu);
+    virtual void buildStaticOrContextMenu(GObjectViewController* view, QMenu* menu);
 
-    virtual void disconnectView(GObjectView* v);
+    virtual void disconnectView(GObjectViewController* v);
 
-    QMap<GObjectView*, QList<QObject*>> viewResources;
+    QMap<GObjectViewController*, QList<QObject*>> viewResources;
     GObjectViewFactoryId id;
 };
 

--- a/src/corelibs/U2Gui/src/ObjectViewModel.h
+++ b/src/corelibs/U2Gui/src/ObjectViewModel.h
@@ -284,11 +284,11 @@ public:
     GObjectViewWindow(GObjectViewController* viewController, const QString& _viewName, bool _persistent = false);
 
     const QList<GObject*>& getObjects() const {
-        return view->getObjects();
+        return viewController->getObjects();
     }
 
     GObjectViewFactoryId getViewFactoryId() const {
-        return view->getFactoryId();
+        return viewController->getFactoryId();
     }
 
     bool isPersistent() const {
@@ -298,11 +298,11 @@ public:
     void setPersistent(bool v);
 
     QString getViewName() const {
-        return view->getName();
+        return viewController->getName();
     }
 
     GObjectViewController* getObjectView() const {
-        return view;
+        return viewController;
     }
 
     virtual void closeView();
@@ -321,7 +321,7 @@ signals:
     void si_windowClosed(GObjectViewWindow* viewWindow);
 
 protected:
-    GObjectViewController* view;
+    GObjectViewController* viewController;
     bool persistent;
 };
 
@@ -380,7 +380,7 @@ public:
     void setMenuTypes(const QList<QString>& menuTypes);
 
 private:
-    GObjectViewController* view;
+    GObjectViewController* viewController;
 
     // Action order can be used to set-up relative action position in GUI elements
     int actionOrder;

--- a/src/corelibs/U2Gui/src/ObjectViewTasks.cpp
+++ b/src/corelibs/U2Gui/src/ObjectViewTasks.cpp
@@ -45,7 +45,7 @@ namespace U2 {
 
 /* TRANSLATOR U2::ObjectViewTask */
 
-ObjectViewTask::ObjectViewTask(GObjectView* _view, const QString& stateName, const QVariantMap& s)
+ObjectViewTask::ObjectViewTask(GObjectViewController* _view, const QString& stateName, const QVariantMap& s)
     : Task("", TaskFlag_NoRun), taskType(Type_Update), stateData(s), view(_view), stateIsIllegal(false) {
     assert(view != nullptr);
     const QString& vName = view->getName();
@@ -125,7 +125,7 @@ Document* ObjectViewTask::createDocumentAndAddToProject(const QString& docUrl, P
 //////////////////////////////////////////////////////////////////////////
 // AddToViewTask
 
-AddToViewTask::AddToViewTask(GObjectView* v, GObject* obj)
+AddToViewTask::AddToViewTask(GObjectViewController* v, GObject* obj)
     : Task(tr("Add object to view %1").arg(obj->getGObjectName()), TaskFlags_NR_FOSCOE),
       objView(v), viewName(v->getName()), objRef(obj), objDoc(obj->getDocument()) {
     assert(objDoc != nullptr);

--- a/src/corelibs/U2Gui/src/ObjectViewTasks.h
+++ b/src/corelibs/U2Gui/src/ObjectViewTasks.h
@@ -43,7 +43,7 @@ public:
         Type_Update
     };
 
-    ObjectViewTask(GObjectView* view, const QString& stateName, const QVariantMap& s = QVariantMap());
+    ObjectViewTask(GObjectViewController* view, const QString& stateName, const QVariantMap& s = QVariantMap());
 
     ObjectViewTask(GObjectViewFactoryId fid, const QString& viewName = QString(), const QVariantMap& s = QVariantMap());
 
@@ -62,7 +62,7 @@ public:
 protected:
     Type taskType;
     QVariantMap stateData;
-    QPointer<GObjectView> view;
+    QPointer<GObjectViewController> view;
     QString viewName;
     bool stateIsIllegal;
     QStringList objectsNotFound;
@@ -77,10 +77,10 @@ protected:
 class U2GUI_EXPORT AddToViewTask : public Task {
     Q_OBJECT
 public:
-    AddToViewTask(GObjectView* v, GObject* obj);
+    AddToViewTask(GObjectViewController* v, GObject* obj);
     ReportResult report();
 
-    QPointer<GObjectView> objView;
+    QPointer<GObjectViewController> objView;
     QString viewName;
     GObjectReference objRef;
     QPointer<Document> objDoc;

--- a/src/corelibs/U2Gui/src/options_panel/OPWidgetFactory.h
+++ b/src/corelibs/U2Gui/src/options_panel/OPWidgetFactory.h
@@ -106,7 +106,7 @@ public:
     OPWidgetFactory();
     virtual ~OPWidgetFactory();
 
-    virtual QWidget* createWidget(GObjectView* objView, const QVariantMap& options) = 0;
+    virtual QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) = 0;
 
     virtual OPGroupParameters getOPGroupParameters() = 0;
 
@@ -121,7 +121,7 @@ protected:
     }
 
 protected:
-    GObjectView* objView;
+    GObjectViewController* objView;
     ObjectViewType objectViewOfWidget;
 };
 
@@ -131,7 +131,7 @@ public:
     OPCommonWidgetFactory(QList<QString> groupIds);
     virtual ~OPCommonWidgetFactory();
 
-    virtual QWidget* createWidget(GObjectView* objView, const QVariantMap& options) = 0;
+    virtual QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) = 0;
 
     bool isInGroup(QString groupId) {
         return groupIds.contains(groupId);

--- a/src/corelibs/U2Gui/src/options_panel/OptionsPanel.cpp
+++ b/src/corelibs/U2Gui/src/options_panel/OptionsPanel.cpp
@@ -34,7 +34,7 @@
 
 namespace U2 {
 
-OptionsPanel::OptionsPanel(GObjectView* _objView)
+OptionsPanel::OptionsPanel(GObjectViewController* _objView)
     : objView(_objView) {
     widget = new OptionsPanelWidget();
 }

--- a/src/corelibs/U2Gui/src/options_panel/OptionsPanel.h
+++ b/src/corelibs/U2Gui/src/options_panel/OptionsPanel.h
@@ -27,7 +27,7 @@
 
 namespace U2 {
 
-class GObjectView;
+class GObjectViewController;
 class OptionsPanelWidget;
 class OPWidgetFactory;
 
@@ -40,7 +40,7 @@ class U2GUI_EXPORT OptionsPanel : public QObject {
     Q_OBJECT
 public:
     /** Creates a new OptionsPanelWidget */
-    OptionsPanel(GObjectView*);
+    OptionsPanel(GObjectViewController*);
 
     /**
      * Normally, the OptionsPanelWidget is added to another widget and should be deleted
@@ -69,7 +69,7 @@ public slots:
     void sl_groupHeaderPressed(QString groupId);
 
 private:
-    GObjectView* objView;
+    GObjectViewController* objView;
 
     /** Shows the options widget */
     void openOptionsGroup(const QString& groupId, const QVariantMap& options = QVariantMap());

--- a/src/corelibs/U2Gui/src/util/project/ProjectTreeController.cpp
+++ b/src/corelibs/U2Gui/src/util/project/ProjectTreeController.cpp
@@ -629,13 +629,13 @@ void ProjectTreeController::sl_windowDeactivated(MWMDIWindow* w) {
     }
 }
 
-void ProjectTreeController::sl_objectAddedToActiveView(GObjectView*, GObject* obj) {
+void ProjectTreeController::sl_objectAddedToActiveView(GObjectViewController*, GObject* obj) {
     SAFE_POINT(obj != nullptr, tr("No object to add to view"), );
     uiLog.trace(QString("Processing object add to active view in project tree: %1").arg(obj->getGObjectName()));
     updateObjectActiveStateVisual(obj);
 }
 
-void ProjectTreeController::sl_objectRemovedFromActiveView(GObjectView*, GObject* obj) {
+void ProjectTreeController::sl_objectRemovedFromActiveView(GObjectViewController*, GObject* obj) {
     SAFE_POINT(obj != nullptr, tr("No object to remove from view"), );
     uiLog.trace(QString("Processing object remove from active view in project tree: %1").arg(obj->getGObjectName()));
     updateObjectActiveStateVisual(obj);

--- a/src/corelibs/U2Gui/src/util/project/ProjectTreeController.cpp
+++ b/src/corelibs/U2Gui/src/util/project/ProjectTreeController.cpp
@@ -614,8 +614,8 @@ void ProjectTreeController::sl_windowActivated(MWMDIWindow* w) {
     CHECK(ow != nullptr, );
     uiLog.trace(QString("Project view now listens object events in '%1' view").arg(ow->windowTitle()));
     markActiveView = ow->getObjectView();
-    connect(markActiveView, SIGNAL(si_objectAdded(GObjectView*, GObject*)), SLOT(sl_objectAddedToActiveView(GObjectView*, GObject*)));
-    connect(markActiveView, SIGNAL(si_objectRemoved(GObjectView*, GObject*)), SLOT(sl_objectRemovedFromActiveView(GObjectView*, GObject*)));
+    connect(markActiveView, &GObjectViewController::si_objectAdded, this, &ProjectTreeController::sl_objectAddedToActiveView);
+    connect(markActiveView, &GObjectViewController::si_objectRemoved, this, &ProjectTreeController::sl_objectRemovedFromActiveView);
     foreach (GObject* obj, ow->getObjects()) {
         updateObjectActiveStateVisual(obj);
     }

--- a/src/corelibs/U2Gui/src/util/project/ProjectTreeController.h
+++ b/src/corelibs/U2Gui/src/util/project/ProjectTreeController.h
@@ -35,7 +35,7 @@ class QTreeView;
 namespace U2 {
 
 class EditableTreeView;
-class GObjectView;
+class GObjectViewController;
 class MWMDIWindow;
 class ProjectFilterProxyModel;
 class ProjectViewFilterModel;
@@ -78,8 +78,8 @@ private slots:
     void sl_onImportToDatabase();
     void sl_windowActivated(MWMDIWindow* w);
     void sl_windowDeactivated(MWMDIWindow* w);
-    void sl_objectAddedToActiveView(GObjectView* w, GObject* obj);
-    void sl_objectRemovedFromActiveView(GObjectView* w, GObject* obj);
+    void sl_objectAddedToActiveView(GObjectViewController* w, GObject* obj);
+    void sl_objectRemovedFromActiveView(GObjectViewController* w, GObject* obj);
     void sl_onResourceUserRegistered(const QString& res, Task* t);
     void sl_onResourceUserUnregistered(const QString& res, Task* t);
     void sl_onLoadingDocumentProgressChanged();
@@ -163,7 +163,7 @@ private:
     DocumentSelection documentSelection;
     FolderSelection folderSelection;
     GObjectSelection objectSelection;
-    QPointer<GObjectView> markActiveView;
+    QPointer<GObjectViewController> markActiveView;
     GObject* objectIsBeingRecycled;
 
     QHash<Task*, QHash<Document*, QSet<U2DataId>>> task2ObjectsBeingDeleted;

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyBrowser.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyBrowser.cpp
@@ -94,7 +94,7 @@ const double AssemblyBrowser::ZOOM_MULT = 1.25;
 const double AssemblyBrowser::INITIAL_ZOOM_FACTOR = 1.;
 
 AssemblyBrowser::AssemblyBrowser(QString viewName, AssemblyObject* o)
-    : GObjectView(AssemblyBrowserFactory::ID, viewName), ui(nullptr),
+    : GObjectViewController(AssemblyBrowserFactory::ID, viewName), ui(nullptr),
       gobject(o), model(nullptr), zoomFactor(INITIAL_ZOOM_FACTOR), xOffsetInAssembly(0), yOffsetInAssembly(0), coverageReady(false),
       cellRendererRegistry(new AssemblyCellRendererFactoryRegistry(this)),
       zoomInAction(nullptr), zoomOutAction(nullptr), posSelectorAction(nullptr), posSelector(nullptr), showCoordsOnRulerAction(nullptr), saveScreenShotAction(nullptr),
@@ -155,9 +155,9 @@ bool AssemblyBrowser::checkValid(U2OpStatus& os) {
     return true;
 }
 
-QWidget* AssemblyBrowser::createWidget() {
+QWidget* AssemblyBrowser::createViewWidget(QWidget* parent) {
     optionsPanel = new OptionsPanel(this);
-    ui = new AssemblyBrowserUi(this);
+    ui = new AssemblyBrowserUi(this, parent);
 
     const QString objectName = "assembly_browser_" + getName();
     ui->setObjectName(objectName);
@@ -322,7 +322,7 @@ void AssemblyBrowser::buildStaticToolbar(QToolBar* staticToolBar) {
         staticToolBar->addAction(extractAssemblyRegionAction);
         staticToolBar->addAction(saveScreenShotAction);
     }
-    GObjectView::buildStaticToolbar(staticToolBar);
+    GObjectViewController::buildStaticToolbar(staticToolBar);
 }
 
 void AssemblyBrowser::sl_onPosChangeRequest(int pos) {
@@ -331,7 +331,7 @@ void AssemblyBrowser::sl_onPosChangeRequest(int pos) {
 }
 void AssemblyBrowser::buildMenu(QMenu* menu, const QString& type) {
     if (type != GObjectViewMenuType::STATIC) {
-        GObjectView::buildMenu(menu, type);
+        GObjectViewController::buildMenu(menu, type);
         return;
     }
     U2OpStatusImpl os;
@@ -343,7 +343,7 @@ void AssemblyBrowser::buildMenu(QMenu* menu, const QString& type) {
         menu->addAction(extractAssemblyRegionAction);
         menu->addAction(setReferenceAction);
     }
-    GObjectView::buildMenu(menu, type);
+    GObjectViewController::buildMenu(menu, type);
     GUIUtils::disableEmptySubmenus(menu);
 }
 
@@ -1106,8 +1106,8 @@ void AssemblyBrowser::sl_onReferenceLoaded() {
 // AssemblyBrowserUi
 //==============================================================================
 
-AssemblyBrowserUi::AssemblyBrowserUi(AssemblyBrowser* browser_)
-    : browser(browser_), zoomableOverview(0),
+AssemblyBrowserUi::AssemblyBrowserUi(AssemblyBrowser* browser_, QWidget* parent)
+    : QWidget(parent), browser(browser_), zoomableOverview(0),
       referenceArea(0), coverageGraph(0), ruler(0), readsArea(0), annotationsArea(0), nothingToVisualize(true) {
     U2OpStatusImpl os;
     if (browser->getModel()->hasReads(os)) {  // has mapped reads -> show rich visualization

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyBrowser.h
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyBrowser.h
@@ -45,7 +45,7 @@ class PositionSelector;
 class AssemblyCellRendererFactoryRegistry;
 class OptionsPanel;
 
-class AssemblyBrowser : public GObjectView {
+class AssemblyBrowser : public GObjectViewController {
     Q_OBJECT
 public:
     AssemblyBrowser(QString viewName, AssemblyObject* o);
@@ -178,9 +178,9 @@ signals:
     void si_coverageReady();
 
 protected:
-    virtual QWidget* createWidget();
-    virtual bool eventFilter(QObject*, QEvent*);
-    virtual void onObjectRenamed(GObject* obj, const QString& oldName);
+    QWidget* createViewWidget(QWidget* parent) override;
+    bool eventFilter(QObject*, QEvent*) override;
+    void onObjectRenamed(GObject* obj, const QString& oldName) override;
 
 private slots:
     void sl_onPosChangeRequest(int);
@@ -277,7 +277,7 @@ class AssemblyAnnotationsArea;
 class U2VIEW_EXPORT AssemblyBrowserUi : public QWidget {
     Q_OBJECT
 public:
-    AssemblyBrowserUi(AssemblyBrowser* browser);
+    AssemblyBrowserUi(AssemblyBrowser* browser, QWidget* parent);
 
     inline QSharedPointer<AssemblyModel> getModel() const {
         return browser->getModel();

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyBrowserTasks.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyBrowserTasks.cpp
@@ -113,7 +113,7 @@ void OpenAssemblyBrowserTask::updateTitle(AssemblyBrowser* ab) {
     }
 }
 
-AssemblyBrowser* OpenAssemblyBrowserTask::openBrowserForObject(AssemblyObject* obj, QString viewName, bool persistent) {
+AssemblyBrowser* OpenAssemblyBrowserTask::openBrowserForObject(AssemblyObject* obj, const QString& viewName, bool persistent) {
     AssemblyBrowser* v = new AssemblyBrowser(viewName, obj);
     U2OpStatus2Notification os;
     if (!v->checkValid(os)) {

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyBrowserTasks.h
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyBrowserTasks.h
@@ -40,7 +40,7 @@ public:
     OpenAssemblyBrowserTask(Document* doc);
     virtual void open();
     static void updateTitle(AssemblyBrowser* ab);
-    static AssemblyBrowser* openBrowserForObject(AssemblyObject* obj, QString viewName, bool persistent);
+    static AssemblyBrowser* openBrowserForObject(AssemblyObject* obj, const QString& viewName, bool persistent);
 
 private:
     GObjectReference unloadedObjRef;
@@ -56,7 +56,7 @@ public:
 class UpdateAssemblyBrowserTask : public ObjectViewTask {
     Q_OBJECT
 public:
-    UpdateAssemblyBrowserTask(GObjectView* v, const QString& stateName, const QVariantMap& stateData)
+    UpdateAssemblyBrowserTask(GObjectViewController* v, const QString& stateName, const QVariantMap& stateData)
         : ObjectViewTask(v, stateName, stateData) {
     }
 

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyInfoWidget.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyInfoWidget.cpp
@@ -126,7 +126,7 @@ AssemblyInfoWidgetFactory::AssemblyInfoWidgetFactory() {
     objectViewOfWidget = ObjViewType_AssemblyBrowser;
 }
 
-QWidget* AssemblyInfoWidgetFactory::createWidget(GObjectView* objView, const QVariantMap& /*options*/) {
+QWidget* AssemblyInfoWidgetFactory::createWidget(GObjectViewController* objView, const QVariantMap& /*options*/) {
     SAFE_POINT(objView != nullptr,
                QString("Internal error: unable to create widget for group '%1', object view is NULL.").arg(GROUP_ID),
                nullptr);

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyInfoWidget.h
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyInfoWidget.h
@@ -42,7 +42,7 @@ class U2VIEW_EXPORT AssemblyInfoWidgetFactory : public OPWidgetFactory {
 public:
     AssemblyInfoWidgetFactory();
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyNavigationWidget.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyNavigationWidget.cpp
@@ -135,7 +135,7 @@ AssemblyNavigationWidgetFactory::AssemblyNavigationWidgetFactory() {
     objectViewOfWidget = ObjViewType_AssemblyBrowser;
 }
 
-QWidget* AssemblyNavigationWidgetFactory::createWidget(GObjectView* objView, const QVariantMap& /*options*/) {
+QWidget* AssemblyNavigationWidgetFactory::createWidget(GObjectViewController* objView, const QVariantMap& /*options*/) {
     SAFE_POINT(objView != nullptr,
                QString("Internal error: unable to create widget for group '%1', object view is NULL.").arg(GROUP_ID),
                nullptr);

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyNavigationWidget.h
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyNavigationWidget.h
@@ -66,7 +66,7 @@ class U2VIEW_EXPORT AssemblyNavigationWidgetFactory : public OPWidgetFactory {
 public:
     AssemblyNavigationWidgetFactory();
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 

--- a/src/corelibs/U2View/src/ov_assembly/AssemblySettingsWidget.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblySettingsWidget.cpp
@@ -235,7 +235,7 @@ AssemblySettingsWidgetFactory::AssemblySettingsWidgetFactory() {
     objectViewOfWidget = ObjViewType_AssemblyBrowser;
 }
 
-QWidget* AssemblySettingsWidgetFactory::createWidget(GObjectView* objView, const QVariantMap& /*options*/) {
+QWidget* AssemblySettingsWidgetFactory::createWidget(GObjectViewController* objView, const QVariantMap& /*options*/) {
     SAFE_POINT(objView != nullptr,
                QString("Internal error: unable to create widget for group '%1', object view is NULL.").arg(GROUP_ID),
                nullptr);

--- a/src/corelibs/U2View/src/ov_assembly/AssemblySettingsWidget.h
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblySettingsWidget.h
@@ -68,7 +68,7 @@ public:
     virtual ~AssemblySettingsWidgetFactory() {
     }
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 

--- a/src/corelibs/U2View/src/ov_mca/McaEditor.cpp
+++ b/src/corelibs/U2View/src/ov_mca/McaEditor.cpp
@@ -85,12 +85,12 @@ void McaEditor::buildStaticToolbar(QToolBar* tb) {
     tb->addAction(resetZoomAction);
     tb->addSeparator();
 
-    GObjectView::buildStaticToolbar(tb);
+    GObjectViewController::buildStaticToolbar(tb);
 }
 
 void McaEditor::buildMenu(QMenu* menu, const QString& type) {
     if (type != MsaEditorMenuType::STATIC) {
-        GObjectView::buildMenu(menu, type);
+        GObjectViewController::buildMenu(menu, type);
         return;
     }
     addAlignmentMenu(menu);
@@ -101,7 +101,7 @@ void McaEditor::buildMenu(QMenu* menu, const QString& type) {
     menu->addAction(showConsensusTabAction);
     menu->addSeparator();
 
-    GObjectView::buildMenu(menu, type);
+    GObjectViewController::buildMenu(menu, type);
     GUIUtils::disableEmptySubmenus(menu);
 }
 
@@ -160,9 +160,9 @@ void McaEditor::sl_showConsensusTab() {
     optionsPanel->openGroupById(McaExportConsensusTabFactory::getGroupId());
 }
 
-QWidget* McaEditor::createWidget() {
-    Q_ASSERT(ui == nullptr);
-    ui = new McaEditorWgt(this);
+QWidget* McaEditor::createViewWidget(QWidget* parent) {
+    SAFE_POINT(ui == nullptr, "UI is already initialized", ui);
+    ui = new McaEditorWgt(this, parent);
 
     collapseModel->reset(getMaRowIds());
 

--- a/src/corelibs/U2View/src/ov_mca/McaEditor.h
+++ b/src/corelibs/U2View/src/ov_mca/McaEditor.h
@@ -100,7 +100,7 @@ private slots:
     void sl_saveChromatogramState();
 
 protected:
-    QWidget* createWidget() override;
+    QWidget* createViewWidget(QWidget* parent) override;
     void initActions() override;
 
     QAction* showChromatogramsAction;

--- a/src/corelibs/U2View/src/ov_mca/McaEditorSequenceArea.cpp
+++ b/src/corelibs/U2View/src/ov_mca/McaEditorSequenceArea.cpp
@@ -269,7 +269,7 @@ void McaEditorSequenceArea::sl_setRenderAreaHeight(int k) {
     sl_completeUpdate();
 }
 
-void McaEditorSequenceArea::sl_buildStaticToolbar(GObjectView* /*v*/, QToolBar* t) {
+void McaEditorSequenceArea::sl_buildStaticToolbar(GObjectViewController* /*v*/, QToolBar* t) {
     if (scaleAction != nullptr) {
         t->addAction(scaleAction);
     } else {

--- a/src/corelibs/U2View/src/ov_mca/McaEditorSequenceArea.cpp
+++ b/src/corelibs/U2View/src/ov_mca/McaEditorSequenceArea.cpp
@@ -65,7 +65,7 @@ McaEditorSequenceArea::McaEditorSequenceArea(McaEditorWgt* ui, GScrollBar* hb, G
 
     showAllTraces = new QAction(tr("Show all"), this);
     connect(showAllTraces, SIGNAL(triggered()), SLOT(sl_showAllTraces()));
-    connect(editor, SIGNAL(si_buildStaticToolbar(GObjectView*, QToolBar*)), SLOT(sl_buildStaticToolbar(GObjectView*, QToolBar*)));
+    connect(editor, &MaEditor::si_buildStaticToolbar, this, &McaEditorSequenceArea::sl_buildStaticToolbar);
 
     traceActionsMenu = new QMenu(tr("Show/hide trace"), this);
     traceActionsMenu->setObjectName("traceActionsMenu");

--- a/src/corelibs/U2View/src/ov_mca/McaEditorSequenceArea.h
+++ b/src/corelibs/U2View/src/ov_mca/McaEditorSequenceArea.h
@@ -85,7 +85,7 @@ private slots:
     void sl_showAllTraces();
     void sl_setRenderAreaHeight(int k);
 
-    void sl_buildStaticToolbar(GObjectView* v, QToolBar* t);
+    void sl_buildStaticToolbar(GObjectViewController* v, QToolBar* t);
 
     void sl_addInsertion();
     void sl_removeGapBeforeSelection();

--- a/src/corelibs/U2View/src/ov_mca/McaEditorWgt.cpp
+++ b/src/corelibs/U2View/src/ov_mca/McaEditorWgt.cpp
@@ -47,8 +47,8 @@ namespace U2 {
 
 #define TOP_INDENT 10
 
-McaEditorWgt::McaEditorWgt(McaEditor* editor)
-    : MaEditorWgt(editor) {
+McaEditorWgt::McaEditorWgt(McaEditor* editor, QWidget* parent)
+    : MaEditorWgt(editor, parent) {
     rowHeightController = new McaRowHeightController(this);
     refCharController = new McaReferenceCharController(this, editor);
 

--- a/src/corelibs/U2View/src/ov_mca/McaEditorWgt.h
+++ b/src/corelibs/U2View/src/ov_mca/McaEditorWgt.h
@@ -36,7 +36,7 @@ class McaReferenceCharController;
 class U2VIEW_EXPORT McaEditorWgt : public MaEditorWgt {
     Q_OBJECT
 public:
-    McaEditorWgt(McaEditor* editor);
+    McaEditorWgt(McaEditor* editor, QWidget* parent);
 
     McaEditor* getEditor() const;
     McaEditorConsensusArea* getConsensusArea() const;

--- a/src/corelibs/U2View/src/ov_mca/general_tab/McaGeneralTabFactory.cpp
+++ b/src/corelibs/U2View/src/ov_mca/general_tab/McaGeneralTabFactory.cpp
@@ -36,7 +36,7 @@ McaGeneralTabFactory::McaGeneralTabFactory() {
     objectViewOfWidget = ObjViewType_ChromAlignmentEditor;
 }
 
-QWidget* McaGeneralTabFactory::createWidget(GObjectView* objView, const QVariantMap& /*options*/) {
+QWidget* McaGeneralTabFactory::createWidget(GObjectViewController* objView, const QVariantMap& /*options*/) {
     SAFE_POINT(objView != nullptr,
                QString("Internal error: unable to create widget for group '%1', object view is NULL.").arg(GROUP_ID),
                nullptr);

--- a/src/corelibs/U2View/src/ov_mca/general_tab/McaGeneralTabFactory.h
+++ b/src/corelibs/U2View/src/ov_mca/general_tab/McaGeneralTabFactory.h
@@ -30,7 +30,7 @@ class U2VIEW_EXPORT McaGeneralTabFactory : public OPWidgetFactory {
 public:
     McaGeneralTabFactory();
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 

--- a/src/corelibs/U2View/src/ov_mca/reads_tab/McaReadsTabFactory.cpp
+++ b/src/corelibs/U2View/src/ov_mca/reads_tab/McaReadsTabFactory.cpp
@@ -41,7 +41,7 @@ McaReadsTabFactory::McaReadsTabFactory() {
     objectViewOfWidget = ObjViewType_ChromAlignmentEditor;
 }
 
-QWidget* McaReadsTabFactory::createWidget(GObjectView* objView, const QVariantMap&) {
+QWidget* McaReadsTabFactory::createWidget(GObjectViewController* objView, const QVariantMap&) {
     SAFE_POINT(objView != nullptr,
                QString("Internal error: unable to create widget for group '%1', object view is NULL.").arg(GROUP_ID),
                nullptr);

--- a/src/corelibs/U2View/src/ov_mca/reads_tab/McaReadsTabFactory.h
+++ b/src/corelibs/U2View/src/ov_mca/reads_tab/McaReadsTabFactory.h
@@ -31,7 +31,7 @@ class U2VIEW_EXPORT McaReadsTabFactory : public OPWidgetFactory {
 public:
     McaReadsTabFactory();
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 

--- a/src/corelibs/U2View/src/ov_msa/MSAEditor.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditor.cpp
@@ -205,7 +205,7 @@ void MSAEditor::sl_buildTree() {
 }
 
 bool MSAEditor::onObjectRemoved(GObject* obj) {
-    bool result = GObjectView::onObjectRemoved(obj);
+    bool result = GObjectViewController::onObjectRemoved(obj);
 
     for (int i = 0; i < getUI()->getChildrenCount(); i++) {
         obj->disconnect(getMaEditorWgt(i)->getSequenceArea());
@@ -267,7 +267,7 @@ void MSAEditor::buildStaticToolbar(QToolBar* tb) {
     tb->addAction(multilineViewAction);
     tb->addSeparator();
 
-    GObjectView::buildStaticToolbar(tb);
+    GObjectViewController::buildStaticToolbar(tb);
 }
 
 void MSAEditor::buildMenu(QMenu* m, const QString& type) {
@@ -306,7 +306,7 @@ void MSAEditor::buildMenu(QMenu* m, const QString& type) {
 }
 
 void MSAEditor::fillMenu(QMenu* m, const QString& type) {
-    GObjectView::buildMenu(m, type);
+    GObjectViewController::buildMenu(m, type);
 }
 
 void MSAEditor::addCopyPasteMenu(QMenu* m, int uiIndex) {
@@ -410,7 +410,7 @@ void MSAEditor::addAppearanceMenu(QMenu* m, int uiIndex) {
     appearanceMenu->addAction(multilineViewAction);
 }
 
-void MSAEditor::addColorsMenu(QMenu* m, int index) {
+void MSAEditor::addColorsMenu(QMenu* m, int index) const {
     QMenu* colorsSchemeMenu = m->addMenu(tr("Colors"));
     colorsSchemeMenu->menuAction()->setObjectName("Colors");
     colorsSchemeMenu->setIcon(QIcon(":core/images/color_wheel.png"));
@@ -437,7 +437,7 @@ void MSAEditor::addColorsMenu(QMenu* m, int index) {
     m->insertMenu(GUIUtils::findAction(m->actions(), MSAE_MENU_EDIT), colorsSchemeMenu);
 }
 
-void MSAEditor::addHighlightingMenu(QMenu* m) {
+void MSAEditor::addHighlightingMenu(QMenu* m) const {
     QMenu* highlightSchemeMenu = new QMenu(tr("Highlighting"), nullptr);
 
     highlightSchemeMenu->menuAction()->setObjectName("Highlighting");
@@ -484,18 +484,18 @@ void MSAEditor::addStatisticsMenu(QMenu* m) {
     em->menuAction()->setObjectName(MSAE_MENU_STATISTICS);
 }
 
-QWidget* MSAEditor::createWidget() {
-    Q_ASSERT(ui == nullptr);
+QWidget* MSAEditor::createViewWidget(QWidget* parent) {
+    SAFE_POINT(ui == nullptr, "UI is already created", ui);
 
     Settings* s = AppContext::getSettings();
-    bool sMultilineMode = s->getValue(getSettingsRoot() + MSAE_MULTILINE_MODE, false).toBool();
 
     // Use false for multilineMode while creating widget
     multilineMode = false;
-    ui = new MsaEditorMultilineWgt(this, multilineMode);
+    ui = new MsaEditorMultilineWgt(this, parent, multilineMode);
     new MoveToObjectMaController(this, ui);
 
     // Now restore multiline mode from settings
+    bool sMultilineMode = s->getValue(getSettingsRoot() + MSAE_MULTILINE_MODE, false).toBool();
     setMultilineMode(sMultilineMode);
     multilineViewAction->setChecked(sMultilineMode);
 

--- a/src/corelibs/U2View/src/ov_msa/MSAEditor.h
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditor.h
@@ -205,7 +205,7 @@ protected slots:
     }
 
 protected:
-    QWidget* createWidget() override;
+    QWidget* createViewWidget(QWidget* parent) override;
     void onAfterViewWindowInit() override;
 
     void initActions() override;
@@ -219,8 +219,8 @@ protected:
     void addAlignMenu(QMenu* m);
     void addExportMenu(QMenu* m) override;
     void addAppearanceMenu(QMenu* m, int uiIndex);
-    void addColorsMenu(QMenu* m, int index);
-    void addHighlightingMenu(QMenu* m);
+    void addColorsMenu(QMenu* m, int index) const;
+    void addHighlightingMenu(QMenu* m) const;
     void addNavigationMenu(QMenu* m);
     void addTreeMenu(QMenu* m);
     void addAdvancedMenu(QMenu* m);

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusArea.cpp
@@ -48,7 +48,7 @@ QString MSAEditorConsensusArea::getConsensusPercentTip(int pos, int minReportPer
     return MSAConsensusUtils::getConsensusPercentTip(editor->getMaObject()->getMultipleAlignment(), pos, minReportPercent, maxReportChars);
 }
 
-void MSAEditorConsensusArea::sl_buildMenu(GObjectView* /*view*/, QMenu* menu, const QString& menuType) {
+void MSAEditorConsensusArea::sl_buildMenu(GObjectViewController* /*view*/, QMenu* menu, const QString& menuType) {
     if (menuType == MsaEditorMenuType::CONTEXT || menuType == MsaEditorMenuType::STATIC) {
         buildMenu(menu);
     }

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusArea.cpp
@@ -41,7 +41,7 @@ MSAEditorConsensusArea::MSAEditorConsensusArea(MsaEditorWgt* ui)
     initRenderer();
     setupFontAndHeight();
 
-    connect(editor, SIGNAL(si_buildMenu(GObjectView*, QMenu*, const QString&)), SLOT(sl_buildMenu(GObjectView*, QMenu*, const QString&)));
+    connect(editor, &GObjectViewController::si_buildMenu, this, &MSAEditorConsensusArea::sl_buildMenu);
 }
 
 QString MSAEditorConsensusArea::getConsensusPercentTip(int pos, int minReportPercent, int maxReportChars) const {

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusArea.h
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusArea.h
@@ -50,7 +50,7 @@ private:
     void buildMenu(QMenu* menu);
 
 private slots:
-    void sl_buildMenu(GObjectView* view, QMenu* menu, const QString& type);
+    void sl_buildMenu(GObjectViewController* view, QMenu* menu, const QString& type);
 };
 
 }  // namespace U2

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.cpp
@@ -83,8 +83,8 @@ MSAEditorSequenceArea::MSAEditorSequenceArea(MaEditorWgt* _ui, GScrollBar* hb, G
 
     initRenderer();
 
-    connect(editor, SIGNAL(si_buildMenu(GObjectView*, QMenu*, const QString&)), SLOT(sl_buildMenu(GObjectView*, QMenu*, const QString&)));
-    connect(editor, SIGNAL(si_buildStaticToolbar(GObjectView*, QToolBar*)), SLOT(sl_buildStaticToolbar(GObjectView*, QToolBar*)));
+    connect(editor, &GObjectViewController::si_buildMenu, this, &MSAEditorSequenceArea::sl_buildMenu);
+    connect(editor, &GObjectViewController::si_buildStaticToolbar, this, &MSAEditorSequenceArea::sl_buildStaticToolbar);
 
     selectionColor = Qt::black;
     editingEnabled = true;

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.cpp
@@ -214,7 +214,7 @@ void MSAEditorSequenceArea::updateCollapseModel(const MaModificationInfo& modInf
     getEditor()->updateCollapseModel();
 }
 
-void MSAEditorSequenceArea::sl_buildStaticToolbar(GObjectView* v, QToolBar* t) {
+void MSAEditorSequenceArea::sl_buildStaticToolbar(GObjectViewController* v, QToolBar* t) {
     Q_UNUSED(v);
 
     MaEditorWgt* child0 = editor->getMaEditorMultilineWgt()->getUI(0);
@@ -231,7 +231,7 @@ void MSAEditorSequenceArea::sl_buildStaticToolbar(GObjectView* v, QToolBar* t) {
     t->addSeparator();
 }
 
-void MSAEditorSequenceArea::sl_buildMenu(GObjectView*, QMenu* m, const QString& menuType) {
+void MSAEditorSequenceArea::sl_buildMenu(GObjectViewController*, QMenu* m, const QString& menuType) {
     if (editor->getMaEditorMultilineWgt()->getActiveChild() != ui) {
         return;
     }

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.h
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorSequenceArea.h
@@ -37,7 +37,7 @@
 
 namespace U2 {
 
-class GObjectView;
+class GObjectViewController;
 class MsaColorScheme;
 class MsaColorSchemeFactory;
 class MsaColorSchemeRegistry;
@@ -160,8 +160,8 @@ protected:
     QSize minimumSizeHint() const override;
 
 private slots:
-    void sl_buildMenu(GObjectView* v, QMenu* m, const QString& menuType);
-    void sl_buildStaticToolbar(GObjectView* v, QToolBar* t);
+    void sl_buildMenu(GObjectViewController* v, QMenu* m, const QString& menuType);
+    void sl_buildStaticToolbar(GObjectViewController* v, QToolBar* t);
     void sl_lockedStateChanged();
     void sl_addSeqFromFile();
     void sl_addSeqFromProject();

--- a/src/corelibs/U2View/src/ov_msa/MaEditor.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditor.cpp
@@ -65,7 +65,7 @@ const float MaEditor::zoomMult = 1.25;
 const double MaEditor::FONT_BOX_TO_CELL_BOX_MULTIPLIER = 1.25;
 
 MaEditor::MaEditor(GObjectViewFactoryId factoryId, const QString& viewName, MultipleAlignmentObject* obj)
-    : GObjectView(factoryId, viewName),
+    : GObjectViewController(factoryId, viewName),
       ui(nullptr),
       resizeMode(ResizeMode_FontAndContent),
       minimumFontPointSize(6),
@@ -406,7 +406,7 @@ void MaEditor::sl_changeFont() {
     bool ok = false;
     GCounter::increment("Change of the characters font", getFactoryId());
     // QFontDialog::DontUseNativeDialog - no color selector, affects only Mac OS
-    QFont f = QFontDialog::getFont(&ok, font, widget, tr("Characters Font"), QFontDialog::DontUseNativeDialog);
+    QFont f = QFontDialog::getFont(&ok, font, viewWidget, tr("Characters Font"), QFontDialog::DontUseNativeDialog);
     if (!ok) {
         return;
     }
@@ -518,7 +518,7 @@ void MaEditor::setFont(const QFont& f) {
     s->setValue(getSettingsRoot() + MOBJECT_SETTINGS_FONT_SIZE, f.pointSize());
     s->setValue(getSettingsRoot() + MOBJECT_SETTINGS_FONT_ITALIC, f.italic());
     s->setValue(getSettingsRoot() + MOBJECT_SETTINGS_FONT_BOLD, f.bold());
-    widget->update();
+    viewWidget->update();
 }
 
 void MaEditor::updateFontMetrics() {

--- a/src/corelibs/U2View/src/ov_msa/MaEditor.h
+++ b/src/corelibs/U2View/src/ov_msa/MaEditor.h
@@ -104,7 +104,7 @@ enum class MaEditorRowOrderMode {
     Free
 };
 
-class U2VIEW_EXPORT MaEditor : public GObjectView {
+class U2VIEW_EXPORT MaEditor : public GObjectViewController {
     Q_OBJECT
     friend class OpenSavedMaEditorTask;
     friend class MaEditorState;
@@ -277,10 +277,9 @@ private slots:
     void resetColumnWidthCache();
 
 protected:
-    virtual QWidget* createWidget() = 0;
     virtual void initActions();
-    virtual void initZoom();
-    virtual void initFont();
+    void initZoom();
+    void initFont();
     void updateResizeMode();
 
     virtual void addCopyPasteMenu(QMenu* m, int uiIndex);

--- a/src/corelibs/U2View/src/ov_msa/MaEditorConsensusArea.h
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorConsensusArea.h
@@ -36,7 +36,7 @@ class QToolBar;
 
 namespace U2 {
 
-class GObjectView;
+class GObjectViewController;
 class MSAConsensusAlgorithm;
 class MSAConsensusAlgorithmFactory;
 

--- a/src/corelibs/U2View/src/ov_msa/MaEditorMultilineWgt.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorMultilineWgt.cpp
@@ -48,8 +48,8 @@ namespace U2 {
 /************************************************************************/
 /* MaEditorMultilineWgt */
 /************************************************************************/
-MaEditorMultilineWgt::MaEditorMultilineWgt(MaEditor* _editor)
-    : editor(_editor),
+MaEditorMultilineWgt::MaEditorMultilineWgt(MaEditor* _editor, QWidget* parent)
+    : QWidget(parent), editor(_editor),
       scrollController(new MultilineScrollController(editor, this)) {
     SAFE_POINT(editor != nullptr, "MaEditor is null!", );
     setFocusPolicy(Qt::ClickFocus);

--- a/src/corelibs/U2View/src/ov_msa/MaEditorMultilineWgt.h
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorMultilineWgt.h
@@ -60,7 +60,7 @@ class MSAEditorMultiTreeViewer;
 class U2VIEW_EXPORT MaEditorMultilineWgt : public QWidget {
     Q_OBJECT
 public:
-    explicit MaEditorMultilineWgt(MaEditor* editor);
+    explicit MaEditorMultilineWgt(MaEditor* editor, QWidget* parent);
 
     /** Returns MA editor instance. The instance is always defined and is never null. */
     MaEditor* getEditor() const;

--- a/src/corelibs/U2View/src/ov_msa/MaEditorNameList.h
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorNameList.h
@@ -33,7 +33,7 @@
 
 namespace U2 {
 
-class GObjectView;
+class GObjectViewController;
 class MaEditor;
 class MaEditorSelection;
 class MaEditorWgt;

--- a/src/corelibs/U2View/src/ov_msa/MaEditorTasks.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorTasks.cpp
@@ -236,7 +236,7 @@ void OpenSavedMaEditorTask::updateRanges(const QVariantMap& stateData, MaEditor*
 
 //////////////////////////////////////////////////////////////////////////
 // update
-UpdateMaEditorTask::UpdateMaEditorTask(GObjectView* v, const QString& stateName, const QVariantMap& stateData)
+UpdateMaEditorTask::UpdateMaEditorTask(GObjectViewController* v, const QString& stateName, const QVariantMap& stateData)
     : ObjectViewTask(v, stateName, stateData) {
 }
 

--- a/src/corelibs/U2View/src/ov_msa/MaEditorTasks.h
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorTasks.h
@@ -97,7 +97,7 @@ private:
 
 class UpdateMaEditorTask : public ObjectViewTask {
 public:
-    UpdateMaEditorTask(GObjectView* v, const QString& stateName, const QVariantMap& stateData);
+    UpdateMaEditorTask(GObjectViewController* v, const QString& stateName, const QVariantMap& stateData);
 
     virtual void update();
 };

--- a/src/corelibs/U2View/src/ov_msa/MaEditorWgt.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorWgt.cpp
@@ -61,8 +61,8 @@ bool MaEditorWgtEventFilter::eventFilter(QObject* obj, QEvent* event) {
 /************************************************************************/
 /* MaEditorWgt */
 /************************************************************************/
-MaEditorWgt::MaEditorWgt(MaEditor* _editor)
-    : editor(_editor),
+MaEditorWgt::MaEditorWgt(MaEditor* _editor, QWidget* parent)
+    : QWidget(parent), editor(_editor),
       sequenceArea(nullptr),
       nameList(nullptr),
       consensusArea(nullptr),

--- a/src/corelibs/U2View/src/ov_msa/MaEditorWgt.h
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorWgt.h
@@ -66,7 +66,7 @@ private:
 class U2VIEW_EXPORT MaEditorWgt : public QWidget {
     Q_OBJECT
 public:
-    MaEditorWgt(MaEditor* editor);
+    MaEditorWgt(MaEditor* editor, QWidget* parent);
 
     QWidget* createHeaderLabelWidget(const QString& text = QString(),
                                      Qt::Alignment ali = Qt::AlignCenter,

--- a/src/corelibs/U2View/src/ov_msa/MsaEditorMultilineWgt.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MsaEditorMultilineWgt.cpp
@@ -47,8 +47,8 @@ void MsaSizeUtil::updateMinHeightIfPossible(MaEditorSequenceArea* heightFrom, QW
     }
 }
 
-MsaEditorMultilineWgt::MsaEditorMultilineWgt(MSAEditor* editor, bool multiline)
-    : MaEditorMultilineWgt(editor),
+MsaEditorMultilineWgt::MsaEditorMultilineWgt(MSAEditor* editor, QWidget* parent, bool multiline)
+    : MaEditorMultilineWgt(editor, parent),
       multiTreeViewer(nullptr),
       treeViewer(nullptr) {
     initActions();
@@ -75,7 +75,9 @@ MsaEditorMultilineWgt::MsaEditorMultilineWgt(MSAEditor* editor, bool multiline)
 MaEditorWgt* MsaEditorMultilineWgt::createChild(MaEditor* editor,
                                                 MaEditorOverviewArea* overviewArea,
                                                 MaEditorStatusBar* statusBar) {
-    return new MsaEditorWgt(qobject_cast<MSAEditor*>(editor), overviewArea, statusBar);
+    auto msaEditor = qobject_cast<MSAEditor*>(editor);
+    SAFE_POINT(msaEditor != nullptr, "Not MSAEditor!", nullptr);
+    return new MsaEditorWgt(msaEditor, this, overviewArea, statusBar);
 }
 
 void MsaEditorMultilineWgt::deleteChild(int index) {

--- a/src/corelibs/U2View/src/ov_msa/MsaEditorMultilineWgt.h
+++ b/src/corelibs/U2View/src/ov_msa/MsaEditorMultilineWgt.h
@@ -47,7 +47,7 @@ class U2VIEW_EXPORT MsaEditorMultilineWgt : public MaEditorMultilineWgt {
     Q_OBJECT
 
 public:
-    MsaEditorMultilineWgt(MSAEditor* editor, bool multiline);
+    MsaEditorMultilineWgt(MSAEditor* editor, QWidget* parent, bool multiline);
 
     MSAEditor* getEditor() const;
     MaEditorOverviewArea* getOverview();

--- a/src/corelibs/U2View/src/ov_msa/MsaEditorNameList.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MsaEditorNameList.cpp
@@ -34,7 +34,7 @@ MsaEditorNameList::MsaEditorNameList(MaEditorWgt* ui, QScrollBar* nhBar)
     connect(editor, SIGNAL(si_buildMenu(GObjectView*, QMenu*, const QString&)), SLOT(sl_buildMenu(GObjectView*, QMenu*, const QString&)));
 }
 
-void MsaEditorNameList::sl_buildMenu(GObjectView*, QMenu* menu, const QString& menuType) {
+void MsaEditorNameList::sl_buildMenu(GObjectViewController*, QMenu* menu, const QString& menuType) {
     if (menuType == MsaEditorMenuType::CONTEXT || menuType == MsaEditorMenuType::STATIC) {
         buildMenu(menu);
     }

--- a/src/corelibs/U2View/src/ov_msa/MsaEditorNameList.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MsaEditorNameList.cpp
@@ -31,7 +31,7 @@ namespace U2 {
 
 MsaEditorNameList::MsaEditorNameList(MaEditorWgt* ui, QScrollBar* nhBar)
     : MaEditorNameList(ui, nhBar) {
-    connect(editor, SIGNAL(si_buildMenu(GObjectView*, QMenu*, const QString&)), SLOT(sl_buildMenu(GObjectView*, QMenu*, const QString&)));
+    connect(editor, &GObjectViewController::si_buildMenu, this, &MsaEditorNameList::sl_buildMenu);
 }
 
 void MsaEditorNameList::sl_buildMenu(GObjectViewController*, QMenu* menu, const QString& menuType) {

--- a/src/corelibs/U2View/src/ov_msa/MsaEditorNameList.h
+++ b/src/corelibs/U2View/src/ov_msa/MsaEditorNameList.h
@@ -33,7 +33,7 @@ public:
     MsaEditorNameList(MaEditorWgt* ui, QScrollBar* nhBar);
 
 private slots:
-    void sl_buildMenu(GObjectView* view, QMenu* menu, const QString& type);
+    void sl_buildMenu(GObjectViewController* view, QMenu* menu, const QString& type);
 
 private:
     void buildMenu(QMenu* menu);

--- a/src/corelibs/U2View/src/ov_msa/MsaEditorWgt.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MsaEditorWgt.cpp
@@ -39,9 +39,10 @@
 namespace U2 {
 
 MsaEditorWgt::MsaEditorWgt(MSAEditor* editor,
+                           QWidget* parent,
                            MaEditorOverviewArea* overview,
                            MaEditorStatusBar* statusbar)
-    : MaEditorWgt(editor),
+    : MaEditorWgt(editor, parent),
       similarityStatistics(nullptr) {
     overviewArea = overview;
     statusBar = statusbar;

--- a/src/corelibs/U2View/src/ov_msa/MsaEditorWgt.h
+++ b/src/corelibs/U2View/src/ov_msa/MsaEditorWgt.h
@@ -43,6 +43,7 @@ class U2VIEW_EXPORT MsaEditorWgt : public MaEditorWgt {
 
 public:
     MsaEditorWgt(MSAEditor* editor,
+                 QWidget* parent,
                  MaEditorOverviewArea* overview = nullptr,
                  MaEditorStatusBar* statusbar = nullptr);
 

--- a/src/corelibs/U2View/src/ov_msa/align_to_alignment/AlignSequencesToAlignmentSupport.cpp
+++ b/src/corelibs/U2View/src/ov_msa/align_to_alignment/AlignSequencesToAlignmentSupport.cpp
@@ -47,7 +47,7 @@ AlignSequencesToAlignmentSupport::AlignSequencesToAlignmentSupport(QObject* pare
     : GObjectViewWindowContext(parent, MsaEditorFactory::ID) {
 }
 
-void AlignSequencesToAlignmentSupport::initViewContext(GObjectView* view) {
+void AlignSequencesToAlignmentSupport::initViewContext(GObjectViewController* view) {
     auto msaEditor = qobject_cast<MSAEditor*>(view);
     SAFE_POINT(msaEditor != nullptr, "View is not MSAEditor!", );
     CHECK(msaEditor->getMaObject() != nullptr, );

--- a/src/corelibs/U2View/src/ov_msa/align_to_alignment/AlignSequencesToAlignmentSupport.h
+++ b/src/corelibs/U2View/src/ov_msa/align_to_alignment/AlignSequencesToAlignmentSupport.h
@@ -34,7 +34,7 @@ public:
     AlignSequencesToAlignmentSupport(QObject* parent);
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 };
 
 /** Base action for all 'align-to-alignment' actions. */

--- a/src/corelibs/U2View/src/ov_msa/exclude_list/MsaExcludeList.cpp
+++ b/src/corelibs/U2View/src/ov_msa/exclude_list/MsaExcludeList.cpp
@@ -67,7 +67,7 @@ MsaExcludeListContext::MsaExcludeListContext(QObject* parent)
 static const char* TOGGLE_EXCLUDE_LIST_ACTION_NAME = "exclude_list_toggle_action";
 static const char* MOVE_MSA_SELECTION_TO_EXCLUDE_LIST_ACTION_NAME = "exclude_list_move_from_msa_action";
 
-void MsaExcludeListContext::initViewContext(GObjectView* view) {
+void MsaExcludeListContext::initViewContext(GObjectViewController* view) {
     auto msaEditor = qobject_cast<MSAEditor*>(view);
     SAFE_POINT(msaEditor != nullptr, "View is not MSAEditor!", );
     msaEditor->registerActionProvider(this);
@@ -79,7 +79,7 @@ void MsaExcludeListContext::initViewContext(GObjectView* view) {
     toggleExcludeListAction->setObjectName(TOGGLE_EXCLUDE_LIST_ACTION_NAME);
     toggleExcludeListAction->setToolTip(tr("Show/Hide Exclude List view visibility"));
     connect(toggleExcludeListAction, &QAction::triggered, this, [this, msaEditor] { toggleExcludeListView(msaEditor); });
-    connect(view, &GObjectView::si_buildStaticToolbar, this, [toggleExcludeListAction](GObjectView*, QToolBar* toolBar) { toolBar->addAction(toggleExcludeListAction); });
+    connect(view, &GObjectViewController::si_buildStaticToolbar, this, [toggleExcludeListAction](GObjectViewController*, QToolBar* toolBar) { toolBar->addAction(toggleExcludeListAction); });
     addViewAction(toggleExcludeListAction);
 
     auto moveFromMsaAction = new GObjectViewAction(this, view, tr("Move to Exclude List"));
@@ -109,7 +109,7 @@ void MsaExcludeListContext::initViewContext(GObjectView* view) {
         CHECK(!msaObjectPtr.isNull(), );
         msaObjectPtr->disconnect(this);
     });
-    connect(view, &GObjectView::si_buildMenu, this, [msaEditor, moveFromMsaAction](GObjectView*, QMenu* menu) {
+    connect(view, &GObjectViewController::si_buildMenu, this, [msaEditor, moveFromMsaAction](GObjectViewController*, QMenu* menu) {
         QMenu* copyMenu = GUIUtils::findSubMenu(menu, MSAE_MENU_COPY);
         GUIUtils::insertActionAfter(copyMenu, msaEditor->getUI()->getUI(0)->cutSelectionAction, moveFromMsaAction);
     });

--- a/src/corelibs/U2View/src/ov_msa/exclude_list/MsaExcludeList.h
+++ b/src/corelibs/U2View/src/ov_msa/exclude_list/MsaExcludeList.h
@@ -54,7 +54,7 @@ public:
     QAction* getMoveMsaSelectionToExcludeListAction(MSAEditor* msaEditor);
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 
 private:
     void toggleExcludeListView(MSAEditor* msaEditor);

--- a/src/corelibs/U2View/src/ov_msa/export_consensus/MaExportConsensusTabFactory.cpp
+++ b/src/corelibs/U2View/src/ov_msa/export_consensus/MaExportConsensusTabFactory.cpp
@@ -44,7 +44,7 @@ MsaExportConsensusTabFactory::MsaExportConsensusTabFactory() {
     objectViewOfWidget = ObjViewType_AlignmentEditor;
 }
 
-QWidget* MsaExportConsensusTabFactory::createWidget(GObjectView* objView, const QVariantMap& /*options*/) {
+QWidget* MsaExportConsensusTabFactory::createWidget(GObjectViewController* objView, const QVariantMap& /*options*/) {
     SAFE_POINT(objView != nullptr,
                QString("Internal error: unable to create widget for group '%1', object view is NULL.").arg(GROUP_ID),
                nullptr);
@@ -65,7 +65,7 @@ McaExportConsensusTabFactory::McaExportConsensusTabFactory() {
     objectViewOfWidget = ObjViewType_ChromAlignmentEditor;
 }
 
-QWidget* McaExportConsensusTabFactory::createWidget(GObjectView* objView, const QVariantMap& /*options*/) {
+QWidget* McaExportConsensusTabFactory::createWidget(GObjectViewController* objView, const QVariantMap& /*options*/) {
     SAFE_POINT(objView != nullptr,
                QString("Internal error: unable to create widget for group '%1', object view is NULL.").arg(GROUP_ID),
                nullptr);

--- a/src/corelibs/U2View/src/ov_msa/export_consensus/MaExportConsensusTabFactory.h
+++ b/src/corelibs/U2View/src/ov_msa/export_consensus/MaExportConsensusTabFactory.h
@@ -29,7 +29,7 @@ class U2VIEW_EXPORT MsaExportConsensusTabFactory : public OPWidgetFactory {
 public:
     MsaExportConsensusTabFactory();
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 
@@ -42,7 +42,7 @@ class U2VIEW_EXPORT McaExportConsensusTabFactory : public OPWidgetFactory {
 public:
     McaExportConsensusTabFactory();
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 

--- a/src/corelibs/U2View/src/ov_msa/find_pattern/FindPatternMsaWidgetFactory.cpp
+++ b/src/corelibs/U2View/src/ov_msa/find_pattern/FindPatternMsaWidgetFactory.cpp
@@ -41,7 +41,7 @@ FindPatternMsaWidgetFactory::FindPatternMsaWidgetFactory() {
 
 #define SEARCH_MODE_OPTION_KEY "FindPatternMsaWidgetFactory_searchMode"
 
-QWidget* FindPatternMsaWidgetFactory::createWidget(GObjectView* objView, const QVariantMap& options) {
+QWidget* FindPatternMsaWidgetFactory::createWidget(GObjectViewController* objView, const QVariantMap& options) {
     SAFE_POINT(objView != nullptr,
                QString("Internal error: unable to create widget for group '%1', object view is NULL.").arg(GROUP_ID),
                nullptr);

--- a/src/corelibs/U2View/src/ov_msa/find_pattern/FindPatternMsaWidgetFactory.h
+++ b/src/corelibs/U2View/src/ov_msa/find_pattern/FindPatternMsaWidgetFactory.h
@@ -25,14 +25,14 @@
 
 namespace U2 {
 
-class GObjectView;
+class GObjectViewController;
 
 class U2VIEW_EXPORT FindPatternMsaWidgetFactory : public OPWidgetFactory {
     Q_OBJECT
 public:
     FindPatternMsaWidgetFactory();
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 

--- a/src/corelibs/U2View/src/ov_msa/general_tab/MSAGeneralTabFactory.cpp
+++ b/src/corelibs/U2View/src/ov_msa/general_tab/MSAGeneralTabFactory.cpp
@@ -39,7 +39,7 @@ MSAGeneralTabFactory::MSAGeneralTabFactory() {
     objectViewOfWidget = ObjViewType_AlignmentEditor;
 }
 
-QWidget* MSAGeneralTabFactory::createWidget(GObjectView* objView, const QVariantMap& /*options*/) {
+QWidget* MSAGeneralTabFactory::createWidget(GObjectViewController* objView, const QVariantMap& /*options*/) {
     SAFE_POINT(objView != nullptr,
                QString("Internal error: unable to create widget for group '%1', object view is NULL.").arg(GROUP_ID),
                nullptr);

--- a/src/corelibs/U2View/src/ov_msa/general_tab/MSAGeneralTabFactory.h
+++ b/src/corelibs/U2View/src/ov_msa/general_tab/MSAGeneralTabFactory.h
@@ -30,7 +30,7 @@ class U2VIEW_EXPORT MSAGeneralTabFactory : public OPWidgetFactory {
 public:
     MSAGeneralTabFactory();
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 

--- a/src/corelibs/U2View/src/ov_msa/highlighting/MSAHighlightingTabFactory.cpp
+++ b/src/corelibs/U2View/src/ov_msa/highlighting/MSAHighlightingTabFactory.cpp
@@ -37,7 +37,7 @@ MSAHighlightingFactory::MSAHighlightingFactory() {
     objectViewOfWidget = ObjViewType_AlignmentEditor;
 }
 
-QWidget* MSAHighlightingFactory::createWidget(GObjectView* objView, const QVariantMap& /*options*/) {
+QWidget* MSAHighlightingFactory::createWidget(GObjectViewController* objView, const QVariantMap& /*options*/) {
     SAFE_POINT(objView != nullptr,
                QString("Internal error: unable to create widget for group '%1', object view is NULL.").arg(GROUP_ID),
                nullptr);

--- a/src/corelibs/U2View/src/ov_msa/highlighting/MSAHighlightingTabFactory.h
+++ b/src/corelibs/U2View/src/ov_msa/highlighting/MSAHighlightingTabFactory.h
@@ -34,7 +34,7 @@ class U2VIEW_EXPORT MSAHighlightingFactory : public OPWidgetFactory {
 public:
     MSAHighlightingFactory();
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 

--- a/src/corelibs/U2View/src/ov_msa/move_to_object/MoveToObjectMaController.cpp
+++ b/src/corelibs/U2View/src/ov_msa/move_to_object/MoveToObjectMaController.cpp
@@ -124,7 +124,7 @@ void MoveToObjectMaController::updateActions() {
     moveSelectionToNewFileAction->setEnabled(isMoveOk);
 }
 
-void MoveToObjectMaController::buildMenu(GObjectView*, QMenu* menu, const QString&) {
+void MoveToObjectMaController::buildMenu(GObjectViewController*, QMenu* menu, const QString&) {
     QMenu* exportMenu = GUIUtils::findSubMenu(menu, MSAE_MENU_EXPORT);
     SAFE_POINT(exportMenu != nullptr, "exportMenu is null", );
     QAction* menuAction = exportMenu->addMenu(buildMoveSelectionToAnotherObjectMenu());

--- a/src/corelibs/U2View/src/ov_msa/move_to_object/MoveToObjectMaController.h
+++ b/src/corelibs/U2View/src/ov_msa/move_to_object/MoveToObjectMaController.h
@@ -31,7 +31,7 @@
 namespace U2 {
 
 class MaEditorContext;
-class GObjectView;
+class GObjectViewController;
 
 /** Implements set of actions to move data between different MA objects in project. */
 class MoveToObjectMaController : public QObject, public MaEditorContext {
@@ -47,7 +47,7 @@ private slots:
     void runMoveSelectedRowsToNewFileDialog();
 
     /** Adds 'moveSelectionToAnotherObjectAction' to the export menu. */
-    void buildMenu(GObjectView* view, QMenu* menu, const QString& menuType);
+    void buildMenu(GObjectViewController* view, QMenu* menu, const QString& menuType);
 
     /** Updates all  si_updateActions from MaEditor. */
     void updateActions();

--- a/src/corelibs/U2View/src/ov_msa/pairwise_alignment/PairAlignFactory.cpp
+++ b/src/corelibs/U2View/src/ov_msa/pairwise_alignment/PairAlignFactory.cpp
@@ -35,7 +35,7 @@ PairAlignFactory::PairAlignFactory() {
     objectViewOfWidget = ObjViewType_AlignmentEditor;
 }
 
-QWidget* PairAlignFactory::createWidget(GObjectView* objView, const QVariantMap& /*options*/) {
+QWidget* PairAlignFactory::createWidget(GObjectViewController* objView, const QVariantMap& /*options*/) {
     SAFE_POINT(objView != nullptr,
                QString("Internal error: unable to create widget for group '%1', object view is NULL.").arg(GROUP_ID),
                nullptr);

--- a/src/corelibs/U2View/src/ov_msa/pairwise_alignment/PairAlignFactory.h
+++ b/src/corelibs/U2View/src/ov_msa/pairwise_alignment/PairAlignFactory.h
@@ -34,7 +34,7 @@ class U2VIEW_EXPORT PairAlignFactory : public OPWidgetFactory {
 public:
     PairAlignFactory();
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 

--- a/src/corelibs/U2View/src/ov_msa/phy_tree/MSAEditorTreeViewer.cpp
+++ b/src/corelibs/U2View/src/ov_msa/phy_tree/MSAEditorTreeViewer.cpp
@@ -53,15 +53,14 @@ MSAEditorTreeViewer::~MSAEditorTreeViewer() {
     }
 }
 
-QWidget* MSAEditorTreeViewer::createWidget() {
+QWidget* MSAEditorTreeViewer::createViewWidget(QWidget* parent) {
     SAFE_POINT(ui == nullptr, QString("MSAEditorTreeViewer::createWidget error"), nullptr);
     SAFE_POINT(editor != nullptr, "MSAEditor must be set in createWidget!", nullptr);
 
-    auto view = new QWidget();
+    auto view = new QWidget(parent);
     view->setObjectName("msa_editor_tree_view_container_widget");
 
-    auto viewLayout = new QVBoxLayout();
-    msaTreeViewerUi = new MSAEditorTreeViewerUI(this);
+    msaTreeViewerUi = new MSAEditorTreeViewerUI(this, view);
     ui = msaTreeViewerUi;
 
     auto toolBar = new QToolBar(tr("MSAEditor tree toolbar"));
@@ -81,6 +80,7 @@ QWidget* MSAEditorTreeViewer::createWidget() {
     toolBar->addAction(refreshTreeAction);
     toolBar->addAction(syncModeAction);
 
+    auto viewLayout = new QVBoxLayout();
     viewLayout->setSpacing(0);
     viewLayout->setMargin(0);
     viewLayout->addWidget(toolBar);
@@ -253,8 +253,8 @@ void MSAEditorTreeViewer::orderAlignmentByTree() {
 //---------------------------------------------
 // MSAEditorTreeViewerUI
 //---------------------------------------------
-MSAEditorTreeViewerUI::MSAEditorTreeViewerUI(MSAEditorTreeViewer* treeViewer)
-    : TreeViewerUI(treeViewer),
+MSAEditorTreeViewerUI::MSAEditorTreeViewerUI(MSAEditorTreeViewer* treeViewer, QWidget* parent)
+    : TreeViewerUI(treeViewer, parent),
       msaEditorTreeViewer(treeViewer) {
     setAlignment(Qt::AlignTop | Qt::AlignLeft);
 }

--- a/src/corelibs/U2View/src/ov_msa/phy_tree/MSAEditorTreeViewer.h
+++ b/src/corelibs/U2View/src/ov_msa/phy_tree/MSAEditorTreeViewer.h
@@ -70,7 +70,7 @@ public:
     void orderAlignmentByTree();
 
 protected:
-    QWidget* createWidget() override;
+    QWidget* createViewWidget(QWidget* parent) override;
 
 private slots:
 
@@ -133,7 +133,7 @@ class U2VIEW_EXPORT MSAEditorTreeViewerUI : public TreeViewerUI {
     Q_OBJECT
 
 public:
-    MSAEditorTreeViewerUI(MSAEditorTreeViewer* treeViewer);
+    MSAEditorTreeViewerUI(MSAEditorTreeViewer* treeViewer, QWidget* parent);
 
     /**
      * Return virtual grouping state for MSA that corresponds to the current tree state.

--- a/src/corelibs/U2View/src/ov_msa/phy_tree_tab/TreeOptionsWidgetFactory.cpp
+++ b/src/corelibs/U2View/src/ov_msa/phy_tree_tab/TreeOptionsWidgetFactory.cpp
@@ -39,7 +39,7 @@ MSATreeOptionsWidgetFactory::MSATreeOptionsWidgetFactory() {
     objectViewOfWidget = ObjViewType_AlignmentEditor;
 }
 
-QWidget* MSATreeOptionsWidgetFactory::createWidget(GObjectView* objView, const QVariantMap& /*options*/) {
+QWidget* MSATreeOptionsWidgetFactory::createWidget(GObjectViewController* objView, const QVariantMap& /*options*/) {
     SAFE_POINT(objView != nullptr,
                QString("Internal error: unable to create widget for group '%1', object view is NULL.").arg(GROUP_ID),
                nullptr);
@@ -64,7 +64,7 @@ TreeOptionsWidgetFactory::TreeOptionsWidgetFactory() {
     objectViewOfWidget = ObjViewType_PhylogeneticTree;
 }
 
-QWidget* TreeOptionsWidgetFactory::createWidget(GObjectView* objView, const QVariantMap& /*options*/) {
+QWidget* TreeOptionsWidgetFactory::createWidget(GObjectViewController* objView, const QVariantMap& /*options*/) {
     SAFE_POINT(objView != nullptr,
                QString("Internal error: unable to create widget for group '%1', object view is NULL.").arg(GROUP_ID),
                nullptr);
@@ -89,7 +89,7 @@ AddTreeWidgetFactory::AddTreeWidgetFactory() {
     objectViewOfWidget = ObjViewType_AlignmentEditor;
 }
 
-QWidget* AddTreeWidgetFactory::createWidget(GObjectView* objView, const QVariantMap& /*options*/) {
+QWidget* AddTreeWidgetFactory::createWidget(GObjectViewController* objView, const QVariantMap& /*options*/) {
     SAFE_POINT(objView != nullptr,
                QString("Internal error: unable to create widget for group '%1', object view is NULL.").arg(GROUP_ID),
                nullptr);

--- a/src/corelibs/U2View/src/ov_msa/phy_tree_tab/TreeOptionsWidgetFactory.h
+++ b/src/corelibs/U2View/src/ov_msa/phy_tree_tab/TreeOptionsWidgetFactory.h
@@ -30,7 +30,7 @@ class U2VIEW_EXPORT MSATreeOptionsWidgetFactory : public OPWidgetFactory {
 public:
     MSATreeOptionsWidgetFactory();
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 
@@ -45,7 +45,7 @@ class U2VIEW_EXPORT TreeOptionsWidgetFactory : public OPWidgetFactory {
 public:
     TreeOptionsWidgetFactory();
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 
@@ -60,7 +60,7 @@ class U2VIEW_EXPORT AddTreeWidgetFactory : public OPWidgetFactory {
 public:
     AddTreeWidgetFactory();
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 

--- a/src/corelibs/U2View/src/ov_msa/ref_seq_widget/RefSeqCommonWidget.cpp
+++ b/src/corelibs/U2View/src/ov_msa/ref_seq_widget/RefSeqCommonWidget.cpp
@@ -79,7 +79,7 @@ RefSeqCommonWidgetFactory::RefSeqCommonWidgetFactory(QList<QString> groupIds)
 RefSeqCommonWidgetFactory::~RefSeqCommonWidgetFactory() {
 }
 
-QWidget* RefSeqCommonWidgetFactory::createWidget(GObjectView* objView, const QVariantMap& /*options*/) {
+QWidget* RefSeqCommonWidgetFactory::createWidget(GObjectViewController* objView, const QVariantMap& /*options*/) {
     SAFE_POINT(objView != nullptr, QString("NULL object view!"), nullptr);
 
     auto msa = qobject_cast<MSAEditor*>(objView);

--- a/src/corelibs/U2View/src/ov_msa/ref_seq_widget/RefSeqCommonWidget.h
+++ b/src/corelibs/U2View/src/ov_msa/ref_seq_widget/RefSeqCommonWidget.h
@@ -50,7 +50,7 @@ public:
     RefSeqCommonWidgetFactory(QList<QString> groups);
     virtual ~RefSeqCommonWidgetFactory();
 
-    virtual QWidget* createWidget(GObjectView* objView, const QVariantMap& options);
+    virtual QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options);
 };
 
 }  // namespace U2

--- a/src/corelibs/U2View/src/ov_msa/statistics/SeqStatisticsWidgetFactory.cpp
+++ b/src/corelibs/U2View/src/ov_msa/statistics/SeqStatisticsWidgetFactory.cpp
@@ -39,7 +39,7 @@ SeqStatisticsWidgetFactory::SeqStatisticsWidgetFactory() {
     objectViewOfWidget = ObjViewType_AlignmentEditor;
 }
 
-QWidget* SeqStatisticsWidgetFactory::createWidget(GObjectView* objView, const QVariantMap& /*options*/) {
+QWidget* SeqStatisticsWidgetFactory::createWidget(GObjectViewController* objView, const QVariantMap& /*options*/) {
     SAFE_POINT(objView != nullptr,
                QString("Internal error: unable to create widget for group '%1', object view is NULL.").arg(GROUP_ID),
                nullptr);

--- a/src/corelibs/U2View/src/ov_msa/statistics/SeqStatisticsWidgetFactory.h
+++ b/src/corelibs/U2View/src/ov_msa/statistics/SeqStatisticsWidgetFactory.h
@@ -30,7 +30,7 @@ class U2VIEW_EXPORT SeqStatisticsWidgetFactory : public OPWidgetFactory {
 public:
     SeqStatisticsWidgetFactory();
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 

--- a/src/corelibs/U2View/src/ov_phyltree/TreeViewer.cpp
+++ b/src/corelibs/U2View/src/ov_phyltree/TreeViewer.cpp
@@ -72,7 +72,7 @@
 namespace U2 {
 
 TreeViewer::TreeViewer(const QString& viewName, PhyTreeObject* _phyObject)
-    : GObjectView(TreeViewerFactory::ID, viewName), phyObject(_phyObject) {
+    : GObjectViewController(TreeViewerFactory::ID, viewName), phyObject(_phyObject) {
     GCOUNTER(cvar, "PhylTreeViewer");
 
     createActions();
@@ -279,7 +279,7 @@ void TreeViewer::buildStaticToolbar(QToolBar* tb) {
 
 void TreeViewer::buildMenu(QMenu* m, const QString& type) {
     if (type != GObjectViewMenuType::STATIC) {
-        GObjectView::buildMenu(m, type);
+        GObjectViewController::buildMenu(m, type);
         return;
     }
     // Tree Settings
@@ -327,13 +327,13 @@ void TreeViewer::buildMenu(QMenu* m, const QString& type) {
 
     m->addSeparator();
 
-    GObjectView::buildMenu(m, type);
+    GObjectViewController::buildMenu(m, type);
     GUIUtils::disableEmptySubmenus(m);
 }
 
-QWidget* TreeViewer::createWidget() {
+QWidget* TreeViewer::createViewWidget(QWidget* parent) {
     SAFE_POINT(ui == nullptr, "createWidget: UI is not null", ui);
-    ui = new TreeViewerUI(this);
+    ui = new TreeViewerUI(this, parent);
 
     optionsPanel = new OptionsPanel(this);
     OPWidgetFactoryRegistry* opWidgetFactoryRegistry = AppContext::getOPWidgetFactoryRegistry();
@@ -463,8 +463,8 @@ static void storeOptionValueInAppSettings(const TreeViewOption& option, const QV
     }
 }
 
-TreeViewerUI::TreeViewerUI(TreeViewer* _treeViewer)
-    : phyObject(_treeViewer->getPhyObject()),
+TreeViewerUI::TreeViewerUI(TreeViewer* _treeViewer, QWidget* parent)
+    : QGraphicsView(parent), phyObject(_treeViewer->getPhyObject()),
       treeViewer(_treeViewer) {
     setWindowIcon(GObjectTypes::getTypeInfo(GObjectTypes::PHYLOGENETIC_TREE).icon);
     setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOn);

--- a/src/corelibs/U2View/src/ov_phyltree/TreeViewer.h
+++ b/src/corelibs/U2View/src/ov_phyltree/TreeViewer.h
@@ -42,14 +42,14 @@
 
 namespace U2 {
 
-class GObjectView;
+class GObjectViewController;
 class TreeViewerUI;
 class TvBranchItem;
 class TvNodeItem;
 class TvTextItem;
 class TvRectangularBranchItem;
 
-class TreeViewer : public GObjectView {
+class TreeViewer : public GObjectViewController {
     Q_OBJECT
 public:
     TreeViewer(const QString& viewName, PhyTreeObject* phyTreeObject);
@@ -89,7 +89,7 @@ public:
     }
 
 protected:
-    QWidget* createWidget() override;
+    QWidget* createViewWidget(QWidget* parent) override;
     void onObjectRenamed(GObject* obj, const QString& oldName) override;
 
 public:
@@ -147,7 +147,7 @@ class U2VIEW_EXPORT TreeViewerUI : public QGraphicsView {
     friend class TreeViewer;
 
 public:
-    explicit TreeViewerUI(TreeViewer* treeViewer);
+    explicit TreeViewerUI(TreeViewer* treeViewer, QWidget* parent);
     ~TreeViewerUI() override;
 
     /** Returns option value by looking up first in 'selectionSettings and next in the 'setting'. */

--- a/src/corelibs/U2View/src/ov_phyltree/TreeViewerTasks.cpp
+++ b/src/corelibs/U2View/src/ov_phyltree/TreeViewerTasks.cpp
@@ -164,7 +164,7 @@ void OpenSavedTreeViewerTask::updateRanges(const QVariantMap& stateData, TreeVie
 
 //////////////////////////////////////////////////////////////////////////
 // update
-UpdateTreeViewerTask::UpdateTreeViewerTask(GObjectView* v, const QString& stateName, const QVariantMap& stateData)
+UpdateTreeViewerTask::UpdateTreeViewerTask(GObjectViewController* v, const QString& stateName, const QVariantMap& stateData)
     : ObjectViewTask(v, stateName, stateData) {
 }
 

--- a/src/corelibs/U2View/src/ov_phyltree/TreeViewerTasks.h
+++ b/src/corelibs/U2View/src/ov_phyltree/TreeViewerTasks.h
@@ -81,7 +81,7 @@ public:
 
 class UpdateTreeViewerTask : public ObjectViewTask {
 public:
-    UpdateTreeViewerTask(GObjectView* v, const QString& stateName, const QVariantMap& stateData);
+    UpdateTreeViewerTask(GObjectViewController* v, const QString& stateName, const QVariantMap& stateData);
     void update() override;
 };
 

--- a/src/corelibs/U2View/src/ov_sequence/AnnotatedDNAView.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/AnnotatedDNAView.cpp
@@ -87,7 +87,7 @@
 namespace U2 {
 
 AnnotatedDNAView::AnnotatedDNAView(const QString& viewName, const QList<U2SequenceObject*>& dnaObjects)
-    : GObjectView(AnnotatedDNAViewFactory::ID, viewName) {
+    : GObjectViewController(AnnotatedDNAViewFactory::ID, viewName) {
     timerId = 0;
     hadExpandableSequenceWidgetsLastResize = false;
 
@@ -177,11 +177,11 @@ QAction* AnnotatedDNAView::createPasteAction() {
     return action;
 }
 
-QWidget* AnnotatedDNAView::createWidget() {
+QWidget* AnnotatedDNAView::createViewWidget(QWidget* parent) {
     GTIMER(c1, t1, "AnnotatedDNAView::createWidget");
-    assert(scrollArea == nullptr);
+    SAFE_POINT(viewWidget == nullptr, "Widget is already created", viewWidget);
 
-    mainSplitter = new QSplitter(Qt::Vertical);
+    mainSplitter = new QSplitter(Qt::Vertical, parent);
     mainSplitter->setObjectName("annotated_DNA_splitter");
     connect(mainSplitter, SIGNAL(splitterMoved(int, int)), SLOT(sl_splitterMoved(int, int)));
 
@@ -473,7 +473,7 @@ bool AnnotatedDNAView::onObjectRemoved(GObject* o) {
         }
     }
 
-    GObjectView::onObjectRemoved(o);
+    GObjectViewController::onObjectRemoved(o);
     return seqContexts.isEmpty();
 }
 
@@ -527,7 +527,7 @@ void AnnotatedDNAView::buildStaticToolbar(QToolBar* tb) {
         }
     }
 
-    GObjectView::buildStaticToolbar(tb);
+    GObjectViewController::buildStaticToolbar(tb);
 
     tb->addSeparator();
     syncViewManager->updateToolbar2(tb);
@@ -535,7 +535,7 @@ void AnnotatedDNAView::buildStaticToolbar(QToolBar* tb) {
 
 void AnnotatedDNAView::buildMenu(QMenu* m, const QString& type) {
     if (type != GObjectViewMenuType::STATIC) {
-        GObjectView::buildMenu(m, type);
+        GObjectViewController::buildMenu(m, type);
         return;
     }
     m->addAction(posSelectorAction);
@@ -551,7 +551,7 @@ void AnnotatedDNAView::buildMenu(QMenu* m, const QString& type) {
 
     annotationsView->adjustStaticMenu(m);
 
-    GObjectView::buildMenu(m, type);
+    GObjectViewController::buildMenu(m, type);
 }
 
 void AnnotatedDNAView::addAnalyseMenu(QMenu* m) {
@@ -651,7 +651,7 @@ void AnnotatedDNAView::saveWidgetState() {
 }
 
 bool AnnotatedDNAView::canAddObject(GObject* obj) {
-    if (GObjectView::canAddObject(obj)) {
+    if (GObjectViewController::canAddObject(obj)) {
         return true;
     }
     if (isChildWidgetObject(obj)) {
@@ -894,7 +894,7 @@ QString AnnotatedDNAView::addObject(GObject* o) {
             return tr("No sequence object found for annotations");
         }
     }
-    QString res = GObjectView::addObject(o);
+    QString res = GObjectViewController::addObject(o);
     if (!res.isEmpty()) {
         return res;
     }
@@ -1098,7 +1098,7 @@ void AnnotatedDNAView::addGraphs(ADVSequenceObjectContext* seqCtx) {
 }
 
 void AnnotatedDNAView::sl_onDocumentAdded(Document* d) {
-    GObjectView::sl_onDocumentAdded(d);
+    GObjectViewController::sl_onDocumentAdded(d);
     importDocAnnotations(d);
 }
 
@@ -1162,7 +1162,7 @@ void AnnotatedDNAView::createCodonTableAction() {
 void AnnotatedDNAView::sl_onDocumentLoadedStateChanged() {
     auto d = qobject_cast<Document*>(sender());
     importDocAnnotations(d);
-    GObjectView::sl_onDocumentLoadedStateChanged();
+    GObjectViewController::sl_onDocumentLoadedStateChanged();
 }
 
 QList<U2SequenceObject*> AnnotatedDNAView::getSequenceObjectsWithContexts() const {

--- a/src/corelibs/U2View/src/ov_sequence/AnnotatedDNAView.h
+++ b/src/corelibs/U2View/src/ov_sequence/AnnotatedDNAView.h
@@ -60,7 +60,7 @@ class OptionsPanel;
 
 class CodonTableView;
 
-class U2VIEW_EXPORT AnnotatedDNAView : public GObjectView {
+class U2VIEW_EXPORT AnnotatedDNAView : public GObjectViewController {
     Q_OBJECT
     friend class DetViewSequenceEditor;  // TODO_SVEDIT: remove this
 public:
@@ -168,7 +168,7 @@ public:
     }
 
 protected:
-    QWidget* createWidget() override;
+    QWidget* createViewWidget(QWidget* parent) override;
     bool onObjectRemoved(GObject* o) override;
     void onObjectRenamed(GObject* obj, const QString& oldName) override;
     bool eventFilter(QObject*, QEvent*) override;

--- a/src/corelibs/U2View/src/ov_sequence/AnnotationsTreeView.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/AnnotationsTreeView.cpp
@@ -870,7 +870,7 @@ void AnnotationsTreeView::updateColumnContextActions(AVItem* item, int col) {
     }
 }
 
-void AnnotationsTreeView::sl_onBuildMenu(GObjectView*, QMenu* m, const QString& type) {
+void AnnotationsTreeView::sl_onBuildMenu(GObjectViewController*, QMenu* m, const QString& type) {
     if (type != GObjectViewMenuType::CONTEXT) {
         return;
     }

--- a/src/corelibs/U2View/src/ov_sequence/AnnotationsTreeView.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/AnnotationsTreeView.cpp
@@ -44,8 +44,6 @@
 #include <U2Core/DBXRefRegistry.h>
 #include <U2Core/DNASequenceObject.h>
 #include <U2Core/DNASequenceSelection.h>
-#include <U2Core/DocumentModel.h>
-#include <U2Core/GObjectTypes.h>
 #include <U2Core/GenbankFeatures.h>
 #include <U2Core/L10n.h>
 #include <U2Core/QObjectScopedPointer.h>
@@ -146,7 +144,7 @@ AnnotationsTreeView::AnnotationsTreeView(AnnotatedDNAView* _ctx)
 
     restoreWidgetState();
 
-    connect(ctx, SIGNAL(si_buildMenu(GObjectView*, QMenu*, const QString&)), SLOT(sl_onBuildMenu(GObjectView*, QMenu*, const QString&)));
+    connect(ctx, &GObjectViewController::si_buildMenu, this, &AnnotationsTreeView::sl_onBuildMenu);
     connect(ctx, SIGNAL(si_annotationObjectAdded(AnnotationTableObject*)), SLOT(sl_onAnnotationObjectAdded(AnnotationTableObject*)));
     connect(ctx, SIGNAL(si_annotationObjectRemoved(AnnotationTableObject*)), SLOT(sl_onAnnotationObjectRemoved(AnnotationTableObject*)));
     connect(ctx, SIGNAL(si_sequenceAdded(ADVSequenceObjectContext*)), SLOT(sl_sequenceAdded(ADVSequenceObjectContext*)));

--- a/src/corelibs/U2View/src/ov_sequence/AnnotationsTreeView.h
+++ b/src/corelibs/U2View/src/ov_sequence/AnnotationsTreeView.h
@@ -43,7 +43,7 @@ class AVAnnotationItem;
 class AVGroupItem;
 class AVItem;
 class AVQualifierItem;
-class GObjectView;
+class GObjectViewController;
 class RemoveItemsTask;
 class U2Qualifier;
 
@@ -121,7 +121,7 @@ private slots:
     void sl_onAddAnnotationObjectToView();
     void sl_removeObjectFromView();
     void sl_removeAnnsAndQs();
-    void sl_onBuildMenu(GObjectView* thiz, QMenu* menu, const QString& type);
+    void sl_onBuildMenu(GObjectViewController* thiz, QMenu* menu, const QString& type);
     void sl_onCopyQualifierValue();
     void sl_onCopyQualifierURL();
     void sl_onToggleQualifierColumn();

--- a/src/corelibs/U2View/src/ov_sequence/PanView.h
+++ b/src/corelibs/U2View/src/ov_sequence/PanView.h
@@ -37,7 +37,7 @@ namespace U2 {
 
 class PanViewRenderArea;
 class GScrollBar;
-class GObjectView;
+class GObjectViewController;
 class PVRowsManager;
 class ADVSingleSequenceWidget;
 class PVRowData;

--- a/src/corelibs/U2View/src/ov_sequence/annot_highlight/AnnotHighlightWidgetFactory.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/annot_highlight/AnnotHighlightWidgetFactory.cpp
@@ -39,7 +39,7 @@ AnnotHighlightWidgetFactory::AnnotHighlightWidgetFactory() {
     objectViewOfWidget = ObjViewType_SequenceView;
 }
 
-QWidget* AnnotHighlightWidgetFactory::createWidget(GObjectView* objView, const QVariantMap& /*options*/) {
+QWidget* AnnotHighlightWidgetFactory::createWidget(GObjectViewController* objView, const QVariantMap& /*options*/) {
     SAFE_POINT(objView != nullptr,
                QString("Internal error: unable to create widget for group '%1', object view is NULL.").arg(GROUP_ID),
                nullptr);

--- a/src/corelibs/U2View/src/ov_sequence/annot_highlight/AnnotHighlightWidgetFactory.h
+++ b/src/corelibs/U2View/src/ov_sequence/annot_highlight/AnnotHighlightWidgetFactory.h
@@ -30,7 +30,7 @@ class U2VIEW_EXPORT AnnotHighlightWidgetFactory : public OPWidgetFactory {
 public:
     AnnotHighlightWidgetFactory();
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 

--- a/src/corelibs/U2View/src/ov_sequence/find_pattern/FindPatternWidgetFactory.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/find_pattern/FindPatternWidgetFactory.cpp
@@ -39,7 +39,7 @@ FindPatternWidgetFactory::FindPatternWidgetFactory() {
     objectViewOfWidget = ObjViewType_SequenceView;
 }
 
-QWidget* FindPatternWidgetFactory::createWidget(GObjectView* objView, const QVariantMap& /*options*/) {
+QWidget* FindPatternWidgetFactory::createWidget(GObjectViewController* objView, const QVariantMap& /*options*/) {
     SAFE_POINT(objView != nullptr,
                QString("Internal error: unable to create widget for group '%1', object view is NULL.").arg(GROUP_ID),
                nullptr);

--- a/src/corelibs/U2View/src/ov_sequence/find_pattern/FindPatternWidgetFactory.h
+++ b/src/corelibs/U2View/src/ov_sequence/find_pattern/FindPatternWidgetFactory.h
@@ -25,14 +25,14 @@
 
 namespace U2 {
 
-class GObjectView;
+class GObjectViewController;
 
 class U2VIEW_EXPORT FindPatternWidgetFactory : public OPWidgetFactory {
     Q_OBJECT
 public:
     FindPatternWidgetFactory();
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 

--- a/src/corelibs/U2View/src/ov_sequence/sequence_info/SequenceInfoFactory.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/sequence_info/SequenceInfoFactory.cpp
@@ -39,7 +39,7 @@ SequenceInfoFactory::SequenceInfoFactory() {
     objectViewOfWidget = ObjViewType_SequenceView;
 }
 
-QWidget* SequenceInfoFactory::createWidget(GObjectView* objView, const QVariantMap& /*options*/) {
+QWidget* SequenceInfoFactory::createWidget(GObjectViewController* objView, const QVariantMap& /*options*/) {
     SAFE_POINT(objView != nullptr,
                QString("Internal error: unable to create widget for group '%1', object view is NULL.").arg(GROUP_ID),
                nullptr);

--- a/src/corelibs/U2View/src/ov_sequence/sequence_info/SequenceInfoFactory.h
+++ b/src/corelibs/U2View/src/ov_sequence/sequence_info/SequenceInfoFactory.h
@@ -30,7 +30,7 @@ class U2VIEW_EXPORT SequenceInfoFactory : public OPWidgetFactory {
 public:
     SequenceInfoFactory();
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 

--- a/src/corelibs/U2View/src/ov_text/SimpleTextObjectView.cpp
+++ b/src/corelibs/U2View/src/ov_text/SimpleTextObjectView.cpp
@@ -89,7 +89,7 @@ Task* SimpleTextObjectViewFactory::createViewTask(const QString& viewName, const
 /// Simple Text View
 
 SimpleTextObjectView::SimpleTextObjectView(const QString& name, TextObject* to, const QVariantMap& _state)
-    : GObjectView(SimpleTextObjectViewFactory::ID, name), textObject(to), openState(_state), selection(to) {
+    : GObjectViewController(SimpleTextObjectViewFactory::ID, name), textObject(to), openState(_state), selection(to) {
     GCOUNTER(cvar, "SimpleTextView");
     textEdit = nullptr;
     firstShow = true;
@@ -98,9 +98,9 @@ SimpleTextObjectView::SimpleTextObjectView(const QString& name, TextObject* to, 
     requiredObjects.append(to);
 }
 
-QWidget* SimpleTextObjectView::createWidget() {
-    assert(textEdit == nullptr);
-    textEdit = new QPlainTextEdit();
+QWidget* SimpleTextObjectView::createViewWidget(QWidget* parent) {
+    SAFE_POINT(textEdit == nullptr, "Widget is already created", textEdit);
+    textEdit = new QPlainTextEdit(parent);
     textEdit->setLineWrapMode(QPlainTextEdit::NoWrap);
     textEdit->setWordWrapMode(QTextOption::NoWrap);
     try {

--- a/src/corelibs/U2View/src/ov_text/SimpleTextObjectView.h
+++ b/src/corelibs/U2View/src/ov_text/SimpleTextObjectView.h
@@ -52,7 +52,7 @@ public:
     }
 };
 
-class U2VIEW_EXPORT SimpleTextObjectView : public GObjectView {
+class U2VIEW_EXPORT SimpleTextObjectView : public GObjectViewController {
     Q_OBJECT
 
     friend class SimpleTextObjectViewFactory;
@@ -68,7 +68,7 @@ public:
         return selection;
     }
 
-    virtual QWidget* createWidget();
+    QWidget* createViewWidget(QWidget* parent) override;
 
     void updateView(const QVariantMap& stateData);
 

--- a/src/corelibs/U2View/src/ov_text/SimpleTextObjectViewTasks.cpp
+++ b/src/corelibs/U2View/src/ov_text/SimpleTextObjectViewTasks.cpp
@@ -115,7 +115,7 @@ void OpenSimpleTextObjectViewTask::open() {
 //////////////////////////////////////////////////////////////////////////
 // update view task
 
-UpdateSimpleTextObjectViewTask::UpdateSimpleTextObjectViewTask(GObjectView* v, const QString& stateName, const QVariantMap& stateData)
+UpdateSimpleTextObjectViewTask::UpdateSimpleTextObjectViewTask(GObjectViewController* v, const QString& stateName, const QVariantMap& stateData)
     : ObjectViewTask(v, stateName, stateData) {
 }
 

--- a/src/corelibs/U2View/src/ov_text/SimpleTextObjectViewTasks.h
+++ b/src/corelibs/U2View/src/ov_text/SimpleTextObjectViewTasks.h
@@ -47,7 +47,7 @@ private:
 
 class UpdateSimpleTextObjectViewTask : public ObjectViewTask {
 public:
-    UpdateSimpleTextObjectViewTask(GObjectView* v, const QString& stateName, const QVariantMap& stateData);
+    UpdateSimpleTextObjectViewTask(GObjectViewController* v, const QString& stateName, const QVariantMap& stateData);
 
     virtual void update();
 };

--- a/src/plugins/GUITestBase/src/GTUtilsDocument.cpp
+++ b/src/plugins/GUITestBase/src/GTUtilsDocument.cpp
@@ -81,7 +81,7 @@ void GTUtilsDocument::checkDocument(HI::GUITestOpStatus& os, const QString& docu
     if (id.isEmpty()) {
         return;
     }
-    GObjectView* view = nullptr;
+    GObjectViewController* view = nullptr;
     for (int time = 0; time < GT_OP_WAIT_MILLIS && view == nullptr; time += GT_OP_CHECK_MILLIS) {
         GTGlobals::sleep(time > 0 ? GT_OP_CHECK_MILLIS : 0);
         view = getDocumentGObjectView(os, document);
@@ -117,11 +117,11 @@ void GTUtilsDocument::removeDocument(HI::GUITestOpStatus& os, const QString& doc
 #undef GT_METHOD_NAME
 
 #define GT_METHOD_NAME "getDocumentGObjectView"
-GObjectView* GTUtilsDocument::getDocumentGObjectView(HI::GUITestOpStatus& os, Document* d) {
+GObjectViewController* GTUtilsDocument::getDocumentGObjectView(HI::GUITestOpStatus& os, Document* d) {
     GT_CHECK_RESULT(d != nullptr, "Document* is NULL", nullptr);
 
-    QList<GObjectView*> gObjectViews = getAllGObjectViews();
-    foreach (GObjectView* view, gObjectViews) {
+    QList<GObjectViewController*> gObjectViews = getAllGObjectViews();
+    foreach (GObjectViewController* view, gObjectViews) {
         if (view->containsDocumentObjects(d)) {
             return view;
         }
@@ -208,15 +208,15 @@ void GTUtilsDocument::checkIfDocumentIsLocked(GUITestOpStatus& os, const QString
 }
 #undef GT_METHOD_NAME
 
-QList<GObjectView*> GTUtilsDocument::getAllGObjectViews() {
-    QList<GObjectView*> gObjectViews;
+QList<GObjectViewController*> GTUtilsDocument::getAllGObjectViews() {
+    QList<GObjectViewController*> gObjectViews;
 
     MWMDIManager* mwMDIManager = AppContext::getMainWindow()->getMDIManager();
     QList<MWMDIWindow*> windows = mwMDIManager->getWindows();
 
     foreach (MWMDIWindow* w, windows) {
         if (auto gObjectViewWindow = qobject_cast<GObjectViewWindow*>(w)) {
-            if (GObjectView* gObjectView = gObjectViewWindow->getObjectView()) {
+            if (GObjectViewController* gObjectView = gObjectViewWindow->getObjectView()) {
                 gObjectViews.append(gObjectView);
             }
         }

--- a/src/plugins/GUITestBase/src/GTUtilsDocument.h
+++ b/src/plugins/GUITestBase/src/GTUtilsDocument.h
@@ -28,7 +28,7 @@
 namespace U2 {
 using namespace HI;
 
-class GObjectView;
+class GObjectViewController;
 class Document;
 
 class GTUtilsDocument {
@@ -58,10 +58,10 @@ public:
     static void checkIfDocumentIsLocked(HI::GUITestOpStatus& os, const QString& documentName, bool isLocked);
 
 protected:
-    static GObjectView* getDocumentGObjectView(HI::GUITestOpStatus& os, Document* d);
+    static GObjectViewController* getDocumentGObjectView(HI::GUITestOpStatus& os, Document* d);
 
 private:
-    static QList<GObjectView*> getAllGObjectViews();
+    static QList<GObjectViewController*> getAllGObjectViews();
 };
 
 }  // namespace U2

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/undo_redo/GTTestsUndoRedo.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/undo_redo/GTTestsUndoRedo.cpp
@@ -56,7 +56,7 @@ GUI_TEST_CLASS_DEFINITION(test_0001) {  // DIFFERENCE: lock document is checked
     // 1. Open document COI.aln
     GTFileDialog::openFile(os, dataDir + "samples/CLUSTALW", "COI.aln");
     GTUtilsTaskTreeView::waitTaskFinished(os);
-    // 2. Insert seversl spaces somewhere
+    // 2. Insert several spaces.
     GTUtilsMSAEditorSequenceArea::click(os, QPoint(0, 0));
     for (int i = 0; i < 6; i++) {
         GTKeyboardDriver::keyClick(Qt::Key_Space);

--- a/src/plugins/annotator/src/AnnotatorPlugin.cpp
+++ b/src/plugins/annotator/src/AnnotatorPlugin.cpp
@@ -87,7 +87,7 @@ AnnotatorViewContext::AnnotatorViewContext(QObject* p, bool customAutoAnnotation
     : GObjectViewWindowContext(p, ANNOTATED_DNA_VIEW_FACTORY_ID), customFeaturesAvailable(customAutoAnnotations) {
 }
 
-void AnnotatorViewContext::initViewContext(GObjectView* v) {
+void AnnotatorViewContext::initViewContext(GObjectViewController* v) {
     auto av = qobject_cast<AnnotatedDNAView*>(v);
     ADVGlobalAction* findRegionsAction = new ADVGlobalAction(av, QIcon(":annotator/images/regions.png"), tr("Find annotated regions..."), 30);
     connect(findRegionsAction, SIGNAL(triggered()), SLOT(sl_showCollocationDialog()));

--- a/src/plugins/annotator/src/AnnotatorPlugin.h
+++ b/src/plugins/annotator/src/AnnotatorPlugin.h
@@ -51,7 +51,7 @@ protected slots:
     void sl_showCustomAutoAnnotationDialog();
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 };
 
 class AnnotatorTests {

--- a/src/plugins/biostruct3d_view/src/BioStruct3DSplitter.h
+++ b/src/plugins/biostruct3d_view/src/BioStruct3DSplitter.h
@@ -35,7 +35,7 @@ class BioStruct3DObject;
 class BioStruct3DGLWidget;
 class AnnotatedDNAView;
 class GObject;
-class GObjectView;
+class GObjectViewController;
 class SplitterHeaderWidget;
 class Document;
 class GLFrameManager;

--- a/src/plugins/biostruct3d_view/src/BioStruct3DViewPlugin.cpp
+++ b/src/plugins/biostruct3d_view/src/BioStruct3DViewPlugin.cpp
@@ -95,7 +95,7 @@ BioStruct3DViewContext::BioStruct3DViewContext(QObject* p)
     : GObjectViewWindowContext(p, ANNOTATED_DNA_VIEW_FACTORY_ID) {
 }
 
-void BioStruct3DViewContext::initViewContext(GObjectView* v) {
+void BioStruct3DViewContext::initViewContext(GObjectViewController* v) {
     auto av = qobject_cast<AnnotatedDNAView*>(v);
     U2SequenceObject* dna = av->getActiveSequenceContext()->getSequenceObject();
 
@@ -120,13 +120,13 @@ void BioStruct3DViewContext::initViewContext(GObjectView* v) {
     }
 }
 
-bool BioStruct3DViewContext::canHandle(GObjectView* v, GObject* o) {
+bool BioStruct3DViewContext::canHandle(GObjectViewController* v, GObject* o) {
     Q_UNUSED(v);
     bool res = qobject_cast<BioStruct3DObject*>(o) != nullptr;
     return res;
 }
 
-void BioStruct3DViewContext::onObjectAdded(GObjectView* view, GObject* obj) {
+void BioStruct3DViewContext::onObjectAdded(GObjectViewController* view, GObject* obj) {
     // todo: add sequence & all objects associated with sequence to the view?
 
     auto obj3d = qobject_cast<BioStruct3DObject*>(obj);
@@ -147,7 +147,7 @@ void BioStruct3DViewContext::onObjectAdded(GObjectView* view, GObject* obj) {
     splitterMap.insert(view, splitter);
 }
 
-void BioStruct3DViewContext::onObjectRemoved(GObjectView* v, GObject* obj) {
+void BioStruct3DViewContext::onObjectRemoved(GObjectViewController* v, GObject* obj) {
     auto obj3d = qobject_cast<BioStruct3DObject*>(obj);
     if (obj3d == nullptr) {
         return;
@@ -160,7 +160,7 @@ void BioStruct3DViewContext::onObjectRemoved(GObjectView* v, GObject* obj) {
     }
 }
 
-void BioStruct3DViewContext::unregister3DView(GObjectView* view, BioStruct3DSplitter* splitter) {
+void BioStruct3DViewContext::unregister3DView(GObjectViewController* view, BioStruct3DSplitter* splitter) {
     assert(splitter->getChildWidgets().isEmpty());
     splitter->close();
     auto av = qobject_cast<AnnotatedDNAView*>(view);
@@ -169,7 +169,7 @@ void BioStruct3DViewContext::unregister3DView(GObjectView* view, BioStruct3DSpli
     splitter->deleteLater();
 }
 
-QAction* BioStruct3DViewContext::getClose3DViewAction(GObjectView* view) {
+QAction* BioStruct3DViewContext::getClose3DViewAction(GObjectViewController* view) {
     QList<QObject*> resources = viewResources.value(view);
     foreach (QObject* r, resources) {
         auto a = qobject_cast<GObjectViewAction*>(r);
@@ -185,7 +185,7 @@ QAction* BioStruct3DViewContext::getClose3DViewAction(GObjectView* view) {
 
 void BioStruct3DViewContext::sl_close3DView() {
     auto action = qobject_cast<GObjectViewAction*>(sender());
-    GObjectView* ov = action->getObjectView();
+    GObjectViewController* ov = action->getObjectView();
     QList<GObject*> objects = ov->getObjects();
     foreach (GObject* obj, objects) {
         if (obj->getGObjectType() == GObjectTypes::BIOSTRUCTURE_3D) {
@@ -197,7 +197,7 @@ void BioStruct3DViewContext::sl_close3DView() {
 void BioStruct3DViewContext::sl_windowClosing(MWMDIWindow* w) {
     auto gvw = qobject_cast<GObjectViewWindow*>(w);
     if (gvw) {
-        GObjectView* view = gvw->getObjectView();
+        GObjectViewController* view = gvw->getObjectView();
         // safe to remove: splitter will be deleted with ADV
         splitterMap.remove(view);
     }

--- a/src/plugins/biostruct3d_view/src/BioStruct3DViewPlugin.h
+++ b/src/plugins/biostruct3d_view/src/BioStruct3DViewPlugin.h
@@ -46,22 +46,22 @@ private:
 
 class BioStruct3DViewContext : public GObjectViewWindowContext {
     Q_OBJECT
-    QMap<GObjectView*, BioStruct3DSplitter*> splitterMap;
+    QMap<GObjectViewController*, BioStruct3DSplitter*> splitterMap;
 
 public:
     BioStruct3DViewContext(QObject* p);
 
-    bool canHandle(GObjectView* v, GObject* o) override;
+    bool canHandle(GObjectViewController* v, GObject* o) override;
 
-    void onObjectAdded(GObjectView* v, GObject* obj) override;
-    void onObjectRemoved(GObjectView* v, GObject* obj) override;
+    void onObjectAdded(GObjectViewController* v, GObject* obj) override;
+    void onObjectRemoved(GObjectViewController* v, GObject* obj) override;
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 
-    void unregister3DView(GObjectView* view, BioStruct3DSplitter* view3d);
+    void unregister3DView(GObjectViewController* view, BioStruct3DSplitter* view3d);
 
-    QAction* getClose3DViewAction(GObjectView* view);
+    QAction* getClose3DViewAction(GObjectViewController* view);
 
 protected slots:
     void sl_close3DView();

--- a/src/plugins/chroma_view/src/ChromaViewPlugin.cpp
+++ b/src/plugins/chroma_view/src/ChromaViewPlugin.cpp
@@ -61,7 +61,7 @@ ChromaViewContext::ChromaViewContext(QObject* p)
     : GObjectViewWindowContext(p, ANNOTATED_DNA_VIEW_FACTORY_ID) {
 }
 
-void ChromaViewContext::initViewContext(GObjectView* v) {
+void ChromaViewContext::initViewContext(GObjectViewController* v) {
     auto av = qobject_cast<AnnotatedDNAView*>(v);
     foreach (ADVSequenceWidget* w, av->getSequenceWidgets()) {
         sl_sequenceWidgetAdded(w);
@@ -130,7 +130,7 @@ void ChromaViewContext::sl_showChromatogram() {
     }
 }
 
-bool ChromaViewContext::canHandle(GObjectView* v, GObject* o) {
+bool ChromaViewContext::canHandle(GObjectViewController* v, GObject* o) {
     Q_UNUSED(v);
     return qobject_cast<DNAChromatogramObject*>(o) != nullptr;
 }

--- a/src/plugins/chroma_view/src/ChromaViewPlugin.h
+++ b/src/plugins/chroma_view/src/ChromaViewPlugin.h
@@ -46,13 +46,13 @@ class ChromaViewContext : public GObjectViewWindowContext {
 public:
     ChromaViewContext(QObject* p);
 
-    bool canHandle(GObjectView* v, GObject* o) override;
+    bool canHandle(GObjectViewController* v, GObject* o) override;
 protected slots:
     void sl_showChromatogram();
     void sl_sequenceWidgetAdded(ADVSequenceWidget*);
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 };
 
 class ChromaViewAction : public ADVSequenceWidgetAction {

--- a/src/plugins/chroma_view/src/ChromatogramView.cpp
+++ b/src/plugins/chroma_view/src/ChromatogramView.cpp
@@ -362,7 +362,7 @@ void ChromatogramView::sl_removeChanges() {
     indexOfChangedChars.clear();
 }
 
-void ChromatogramView::sl_onObjectRemoved(GObjectView* view, GObject* obj) {
+void ChromatogramView::sl_onObjectRemoved(GObjectViewController* view, GObject* obj) {
     Q_UNUSED(view);
 
     CHECK(obj == editDNASeq, );

--- a/src/plugins/chroma_view/src/ChromatogramView.cpp
+++ b/src/plugins/chroma_view/src/ChromatogramView.cpp
@@ -29,13 +29,11 @@
 #include <U2Core/DNASequenceSelection.h>
 #include <U2Core/DocumentUtils.h>
 #include <U2Core/GObject.h>
-#include <U2Core/GObjectTypes.h>
 #include <U2Core/GObjectUtils.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/IOAdapter.h>
 #include <U2Core/L10n.h>
 #include <U2Core/LoadDocumentTask.h>
-#include <U2Core/Log.h>
 #include <U2Core/ProjectModel.h>
 #include <U2Core/Task.h>
 #include <U2Core/TaskSignalMapper.h>
@@ -115,7 +113,7 @@ ChromatogramView::ChromatogramView(QWidget* p, ADVSequenceObjectContext* v, GSeq
     removeChanges = new QAction(tr("Undo changes"), this);
     connect(removeChanges, SIGNAL(triggered()), SLOT(sl_removeChanges()));
 
-    connect(dnaView, SIGNAL(si_objectRemoved(GObjectView*, GObject*)), SLOT(sl_onObjectRemoved(GObjectView*, GObject*)));
+    connect(dnaView, &GObjectViewController::si_objectRemoved, this, &ChromatogramView::sl_onObjectRemoved);
     pack();
 
     addActionToLocalToolbar(showQVAction);

--- a/src/plugins/chroma_view/src/ChromatogramView.h
+++ b/src/plugins/chroma_view/src/ChromatogramView.h
@@ -33,7 +33,7 @@ namespace U2 {
 class ADVSequenceObjectContext;
 class ChromatogramViewRenderArea;
 class AnnotatedDNAView;
-class GObjectView;
+class GObjectViewController;
 class Task;
 
 struct ChromatogramViewSettings {
@@ -79,7 +79,7 @@ private slots:
     void sl_onSequenceObjectLoaded(Task*);
     void sl_clearEditableSequence();
     void sl_removeChanges();
-    void sl_onObjectRemoved(GObjectView*, GObject*);
+    void sl_onObjectRemoved(GObjectViewController*, GObject*);
     void sl_showHideTrace();
     void sl_showAllTraces();
 

--- a/src/plugins/circular_view/src/CircularViewPlugin.cpp
+++ b/src/plugins/circular_view/src/CircularViewPlugin.cpp
@@ -92,7 +92,7 @@ CircularViewSettings* CircularViewContext::getSettings(AnnotatedDNAView* view) {
     return viewSettings.value(view);
 }
 
-void CircularViewContext::initViewContext(GObjectView* v) {
+void CircularViewContext::initViewContext(GObjectViewController* v) {
     auto av = qobject_cast<AnnotatedDNAView*>(v);
     SAFE_POINT(!viewSettings.contains(av), "Unexpected sequence view", );
 
@@ -171,7 +171,7 @@ void CircularViewContext::sl_sequenceWidgetRemoved(ADVSequenceWidget* w) {
     }
 }
 
-CircularViewSplitter* CircularViewContext::getView(GObjectView* view, bool create) {
+CircularViewSplitter* CircularViewContext::getView(GObjectViewController* view, bool create) {
     CircularViewSplitter* circularView = nullptr;
     QList<QObject*> resources = viewResources.value(view);
     foreach (QObject* r, resources) {
@@ -195,7 +195,7 @@ CircularViewSplitter* CircularViewContext::getView(GObjectView* view, bool creat
 }
 
 //////////////////////////////////////////////////////////////////////////
-void CircularViewContext::buildStaticOrContextMenu(GObjectView* v, QMenu* m) {
+void CircularViewContext::buildStaticOrContextMenu(GObjectViewController* v, QMenu* m) {
     bool empty = true;
     QList<QObject*> resources = viewResources.value(v);
     foreach (QObject* r, resources) {
@@ -223,7 +223,7 @@ void CircularViewContext::buildStaticOrContextMenu(GObjectView* v, QMenu* m) {
 }
 //////////////////////////////////////////////////////////////////////////
 
-void CircularViewContext::removeCircularView(GObjectView* view) {
+void CircularViewContext::removeCircularView(GObjectViewController* view) {
     QList<QObject*> resources = viewResources.value(view);
     foreach (QObject* r, resources) {
         auto circularView = qobject_cast<CircularViewSplitter*>(r);

--- a/src/plugins/circular_view/src/CircularViewPlugin.h
+++ b/src/plugins/circular_view/src/CircularViewPlugin.h
@@ -103,10 +103,10 @@ protected slots:
     void sl_onDNAViewClosed(AnnotatedDNAView* v);
 
 protected:
-    void initViewContext(GObjectView* view) override;
-    void buildStaticOrContextMenu(GObjectView* view, QMenu* menu) override;
-    CircularViewSplitter* getView(GObjectView* view, bool create);
-    void removeCircularView(GObjectView* view);
+    void initViewContext(GObjectViewController* view) override;
+    void buildStaticOrContextMenu(GObjectViewController* view, QMenu* menu) override;
+    CircularViewSplitter* getView(GObjectViewController* view, bool create);
+    void removeCircularView(GObjectViewController* view);
     void toggleViews(AnnotatedDNAView* view);
 
 private:

--- a/src/plugins/circular_view/src/CircularViewSettingsWidgetFactory.cpp
+++ b/src/plugins/circular_view/src/CircularViewSettingsWidgetFactory.cpp
@@ -40,7 +40,7 @@ CircularViewSettingsWidgetFactory::CircularViewSettingsWidgetFactory(CircularVie
     objectViewOfWidget = ObjViewType_SequenceView;
 }
 
-QWidget* CircularViewSettingsWidgetFactory::createWidget(GObjectView* objView, const QVariantMap& /*options*/) {
+QWidget* CircularViewSettingsWidgetFactory::createWidget(GObjectViewController* objView, const QVariantMap& /*options*/) {
     SAFE_POINT(objView != nullptr, tr("Object view is NULL"), nullptr);
 
     CircularViewSplitter* cvSplitter = ctx->getView(objView, false);

--- a/src/plugins/circular_view/src/CircularViewSettingsWidgetFactory.h
+++ b/src/plugins/circular_view/src/CircularViewSettingsWidgetFactory.h
@@ -33,7 +33,7 @@ class CircularViewSettingsWidgetFactory : public OPWidgetFactory {
 public:
     CircularViewSettingsWidgetFactory(CircularViewContext* context);
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 

--- a/src/plugins/dna_export/src/ExportAlignmentViewItems.cpp
+++ b/src/plugins/dna_export/src/ExportAlignmentViewItems.cpp
@@ -56,14 +56,14 @@ ExportAlignmentViewItemsController::ExportAlignmentViewItemsController(QObject* 
     : GObjectViewWindowContext(p, MsaEditorFactory::ID) {
 }
 
-void ExportAlignmentViewItemsController::initViewContext(GObjectView* v) {
+void ExportAlignmentViewItemsController::initViewContext(GObjectViewController* v) {
     auto msaEditor = qobject_cast<MSAEditor*>(v);
     SAFE_POINT(msaEditor != nullptr, "Invalid GObjectView", );
     auto msaExportContext = new MSAExportContext(msaEditor);
     addViewResource(msaEditor, msaExportContext);
 }
 
-void ExportAlignmentViewItemsController::buildStaticOrContextMenu(GObjectView* v, QMenu* m) {
+void ExportAlignmentViewItemsController::buildStaticOrContextMenu(GObjectViewController* v, QMenu* m) {
     QList<QObject*> resources = viewResources.value(v);
     assert(resources.size() == 1);
     QObject* r = resources.first();

--- a/src/plugins/dna_export/src/ExportAlignmentViewItems.h
+++ b/src/plugins/dna_export/src/ExportAlignmentViewItems.h
@@ -40,9 +40,9 @@ public:
     ExportAlignmentViewItemsController(QObject* p);
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 
-    void buildStaticOrContextMenu(GObjectView* view, QMenu* menu) override;
+    void buildStaticOrContextMenu(GObjectViewController* view, QMenu* menu) override;
 };
 
 class MSAExportContext : public QObject {

--- a/src/plugins/dna_export/src/ExportSequenceViewItems.cpp
+++ b/src/plugins/dna_export/src/ExportSequenceViewItems.cpp
@@ -75,13 +75,13 @@ ExportSequenceViewItemsController::ExportSequenceViewItemsController(QObject* p)
       av(nullptr) {
 }
 
-void ExportSequenceViewItemsController::initViewContext(GObjectView* v) {
+void ExportSequenceViewItemsController::initViewContext(GObjectViewController* v) {
     av = qobject_cast<AnnotatedDNAView*>(v);
     ADVExportContext* vc = new ADVExportContext(av);
     addViewResource(av, vc);
 }
 
-void ExportSequenceViewItemsController::buildStaticOrContextMenu(GObjectView* v, QMenu* m) {
+void ExportSequenceViewItemsController::buildStaticOrContextMenu(GObjectViewController* v, QMenu* m) {
     QList<QObject*> resources = viewResources.value(v);
     assert(resources.size() == 1);
     QObject* r = resources.first();

--- a/src/plugins/dna_export/src/ExportSequenceViewItems.h
+++ b/src/plugins/dna_export/src/ExportSequenceViewItems.h
@@ -43,9 +43,9 @@ public:
     void init() override;
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 
-    void buildStaticOrContextMenu(GObjectView* view, QMenu* menu) override;
+    void buildStaticOrContextMenu(GObjectViewController* view, QMenu* menu) override;
 
 private:
     AnnotatedDNAView* av;

--- a/src/plugins/dna_export/src/McaEditorContext.cpp
+++ b/src/plugins/dna_export/src/McaEditorContext.cpp
@@ -46,7 +46,7 @@ void McaEditorContext::sl_exportMca2Msa() {
     ExportUtils::launchExportMca2MsaTask(mcaObject);
 }
 
-void McaEditorContext::initViewContext(GObjectView* view) {
+void McaEditorContext::initViewContext(GObjectViewController* view) {
     McaEditor* mcaEditor = qobject_cast<McaEditor*>(view);
     SAFE_POINT(nullptr != mcaEditor, "Mca Editor is NULL", );
     CHECK(nullptr != mcaEditor->getMaObject(), );
@@ -56,7 +56,7 @@ void McaEditorContext::initViewContext(GObjectView* view) {
     addViewAction(action);
 }
 
-void McaEditorContext::buildStaticOrContextMenu(GObjectView* view, QMenu* menu) {
+void McaEditorContext::buildStaticOrContextMenu(GObjectViewController* view, QMenu* menu) {
     McaEditor* mcaEditor = qobject_cast<McaEditor*>(view);
     SAFE_POINT(nullptr != mcaEditor, "Mca Editor is NULL", );
     SAFE_POINT(nullptr != menu, "Menu is NULL", );

--- a/src/plugins/dna_export/src/McaEditorContext.h
+++ b/src/plugins/dna_export/src/McaEditorContext.h
@@ -34,8 +34,8 @@ private slots:
     void sl_exportMca2Msa();
 
 private:
-    void initViewContext(GObjectView* view) override;
-    void buildStaticOrContextMenu(GObjectView* view, QMenu* menu) override;
+    void initViewContext(GObjectViewController* view) override;
+    void buildStaticOrContextMenu(GObjectViewController* view, QMenu* menu) override;
 };
 
 }  // namespace U2

--- a/src/plugins/dna_flexibility/src/DNAFlexPlugin.cpp
+++ b/src/plugins/dna_flexibility/src/DNAFlexPlugin.cpp
@@ -81,7 +81,7 @@ void DNAFlexViewContext::sl_showDNAFlexDialog() {
     }
 }
 
-void DNAFlexViewContext::initViewContext(GObjectView* view) {
+void DNAFlexViewContext::initViewContext(GObjectViewController* view) {
     auto annotView = qobject_cast<AnnotatedDNAView*>(view);
 
     // Adding the graphs item

--- a/src/plugins/dna_flexibility/src/DNAFlexPlugin.h
+++ b/src/plugins/dna_flexibility/src/DNAFlexPlugin.h
@@ -52,7 +52,7 @@ private slots:
 private:
     GSequenceGraphFactory* graphFactory;
 
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 };
 
 }  // namespace U2

--- a/src/plugins/dna_graphpack/src/DNAGraphPackPlugin.cpp
+++ b/src/plugins/dna_graphpack/src/DNAGraphPackPlugin.cpp
@@ -69,7 +69,7 @@ DNAGraphPackViewContext::DNAGraphPackViewContext(QObject* p)
     //    graphFactories.append(new CumulativeSkewGraphFactory(CumulativeSkewGraphFactory::AT, this));
 }
 
-void DNAGraphPackViewContext::initViewContext(GObjectView* view) {
+void DNAGraphPackViewContext::initViewContext(GObjectViewController* view) {
     auto annotView = qobject_cast<AnnotatedDNAView*>(view);
     connect(annotView,
             SIGNAL(si_sequenceWidgetAdded(ADVSequenceWidget*)),

--- a/src/plugins/dna_graphpack/src/DNAGraphPackPlugin.h
+++ b/src/plugins/dna_graphpack/src/DNAGraphPackPlugin.h
@@ -36,7 +36,7 @@
 namespace U2 {
 
 class MWMDIWindow;
-class GObjectView;
+class GObjectViewController;
 class GSequenceGraphFactory;
 class GSequenceGraphData;
 class GraphAction;
@@ -60,7 +60,7 @@ public:
 private:
     QList<GSequenceGraphFactory*> graphFactories;
 
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 
 private slots:
     void sl_sequenceWidgetAdded(ADVSequenceWidget*);

--- a/src/plugins/dna_stat/src/DNAStatPlugin.cpp
+++ b/src/plugins/dna_stat/src/DNAStatPlugin.cpp
@@ -65,7 +65,7 @@ DNAStatMSAEditorContext::DNAStatMSAEditorContext(QObject* p)
     : GObjectViewWindowContext(p, MsaEditorFactory::ID) {
 }
 
-void DNAStatMSAEditorContext::initViewContext(GObjectView* v) {
+void DNAStatMSAEditorContext::initViewContext(GObjectViewController* v) {
     auto msaed = qobject_cast<MSAEditor*>(v);
     if (msaed != nullptr && !msaed->getMaObject())
         return;
@@ -77,7 +77,7 @@ void DNAStatMSAEditorContext::initViewContext(GObjectView* v) {
     addViewAction(profileAction);
 }
 
-void DNAStatMSAEditorContext::buildStaticOrContextMenu(GObjectView* v, QMenu* m) {
+void DNAStatMSAEditorContext::buildStaticOrContextMenu(GObjectViewController* v, QMenu* m) {
     auto msaed = qobject_cast<MSAEditor*>(v);
     if (msaed != nullptr && !msaed->getMaObject())
         return;
@@ -106,7 +106,7 @@ DistanceMatrixMSAEditorContext::DistanceMatrixMSAEditorContext(QObject* p)
     : GObjectViewWindowContext(p, MsaEditorFactory::ID) {
 }
 
-void DistanceMatrixMSAEditorContext::initViewContext(GObjectView* v) {
+void DistanceMatrixMSAEditorContext::initViewContext(GObjectViewController* v) {
     auto msaed = qobject_cast<MSAEditor*>(v);
     if (msaed != nullptr && !msaed->getMaObject())
         return;
@@ -117,7 +117,7 @@ void DistanceMatrixMSAEditorContext::initViewContext(GObjectView* v) {
     addViewAction(profileAction);
 }
 
-void DistanceMatrixMSAEditorContext::buildStaticOrContextMenu(GObjectView* v, QMenu* m) {
+void DistanceMatrixMSAEditorContext::buildStaticOrContextMenu(GObjectViewController* v, QMenu* m) {
     auto msaed = qobject_cast<MSAEditor*>(v);
     if (msaed != nullptr && !msaed->getMaObject())
         return;

--- a/src/plugins/dna_stat/src/DNAStatPlugin.h
+++ b/src/plugins/dna_stat/src/DNAStatPlugin.h
@@ -44,10 +44,10 @@ public:
 
 protected slots:
     void sl_showMSAProfileDialog();
-    void buildStaticOrContextMenu(GObjectView* view, QMenu* menu) override;
+    void buildStaticOrContextMenu(GObjectViewController* view, QMenu* menu) override;
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 
 private:
     /* Alignment length limint for opening grid report in UGENE */
@@ -61,10 +61,10 @@ public:
 
 protected slots:
     void sl_showDistanceMatrixDialog();
-    void buildStaticOrContextMenu(GObjectView* view, QMenu* menu) override;
+    void buildStaticOrContextMenu(GObjectViewController* view, QMenu* menu) override;
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 };
 
 }  // namespace U2

--- a/src/plugins/dotplot/src/DotPlotPlugin.cpp
+++ b/src/plugins/dotplot/src/DotPlotPlugin.cpp
@@ -160,7 +160,7 @@ void DotPlotViewContext::sl_buildDotPlot() {
     showBuildDotPlotDialog(action->getObjectView());
 }
 
-void DotPlotViewContext::showBuildDotPlotDialog(GObjectView* ov) {
+void DotPlotViewContext::showBuildDotPlotDialog(GObjectViewController* ov) {
     auto dnaView = qobject_cast<AnnotatedDNAView*>(ov);
     CHECK(dnaView != nullptr, )
 
@@ -213,7 +213,7 @@ void DotPlotViewContext::sl_removeDotPlot() {
 #define BUILD_DOT_PLOT_ACTION_NAME "build_dotplot_action"
 
 // new view context is opened
-void DotPlotViewContext::initViewContext(GObjectView* v) {
+void DotPlotViewContext::initViewContext(GObjectViewController* v) {
     auto av = qobject_cast<AnnotatedDNAView*>(v);
     Q_ASSERT(av);
 
@@ -241,7 +241,7 @@ void DotPlotViewContext::initViewContext(GObjectView* v) {
 }
 
 // create if needed and return DotPlotSplitter in the dnaView
-DotPlotSplitter* DotPlotViewContext::getView(GObjectView* view, bool create) {
+DotPlotSplitter* DotPlotViewContext::getView(GObjectViewController* view, bool create) {
     DotPlotSplitter* dotPlotView = nullptr;
 
     // search for DotPlotSpliter in the view
@@ -267,7 +267,7 @@ DotPlotSplitter* DotPlotViewContext::getView(GObjectView* view, bool create) {
 }
 
 // context menu opened
-void DotPlotViewContext::buildStaticOrContextMenu(GObjectView* v, QMenu* m) {
+void DotPlotViewContext::buildStaticOrContextMenu(GObjectViewController* v, QMenu* m) {
     QList<QObject*> resources = viewResources.value(v);
     foreach (QObject* r, resources) {
         auto dotPlotView = qobject_cast<DotPlotSplitter*>(r);
@@ -279,7 +279,7 @@ void DotPlotViewContext::buildStaticOrContextMenu(GObjectView* v, QMenu* m) {
 }
 
 // remove a splitter from the view
-void DotPlotViewContext::removeDotPlotView(GObjectView* view) {
+void DotPlotViewContext::removeDotPlotView(GObjectViewController* view) {
     QList<QObject*> resources = viewResources.value(view);
     foreach (QObject* r, resources) {
         auto dotPlotView = qobject_cast<DotPlotSplitter*>(r);
@@ -302,7 +302,7 @@ void DotPlotViewContext::sl_windowActivated(MWMDIWindow* w) {
     // check if we need to show DP dialog for this window
     auto ow = qobject_cast<GObjectViewWindow*>(w);
     CHECK(ow != nullptr, )
-    GObjectView* view = ow->getObjectView();
+    GObjectViewController* view = ow->getObjectView();
     if (view->property(SHOW_BUILD_DOT_PLOT_DIALOG_FLAG).toInt() != 1) {
         return;
     }

--- a/src/plugins/dotplot/src/DotPlotPlugin.h
+++ b/src/plugins/dotplot/src/DotPlotPlugin.h
@@ -49,12 +49,12 @@ public:
     DotPlotViewContext(QObject* p);
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 
     void createSplitter();
-    void buildStaticOrContextMenu(GObjectView* view, QMenu* menu) override;
-    DotPlotSplitter* getView(GObjectView* view, bool create);
-    void removeDotPlotView(GObjectView* view);
+    void buildStaticOrContextMenu(GObjectViewController* view, QMenu* menu) override;
+    DotPlotSplitter* getView(GObjectViewController* view, bool create);
+    void removeDotPlotView(GObjectViewController* view);
 
 private slots:
     void sl_buildDotPlot();
@@ -65,7 +65,7 @@ private slots:
     void sl_windowActivated(MWMDIWindow* w);
 
 private:
-    void showBuildDotPlotDialog(GObjectView* v);
+    void showBuildDotPlotDialog(GObjectViewController* v);
 
     bool createdByWizard;
     QString firstFile;

--- a/src/plugins/dotplot/src/DotPlotSplitter.h
+++ b/src/plugins/dotplot/src/DotPlotSplitter.h
@@ -30,7 +30,7 @@ class QToolButton;
 
 namespace U2 {
 
-class GObjectView;
+class GObjectViewController;
 class DotPlotWidget;
 class ADVSequenceObjectContext;
 

--- a/src/plugins/dotplot/src/DotPlotWidget.h
+++ b/src/plugins/dotplot/src/DotPlotWidget.h
@@ -35,7 +35,7 @@ namespace U2 {
 class Task;
 class ADVSequenceObjectContext;
 class ADVSequenceWidget;
-class GObjectView;
+class GObjectViewController;
 class LRegionsSelection;
 
 class DotPlotImageExportSettings;

--- a/src/plugins/enzymes/src/EnzymesPlugin.cpp
+++ b/src/plugins/enzymes/src/EnzymesPlugin.cpp
@@ -175,7 +175,7 @@ EnzymesADVContext::EnzymesADVContext(QObject* p, const QList<QAction*>& actions)
     : GObjectViewWindowContext(p, ANNOTATED_DNA_VIEW_FACTORY_ID), cloningActions(actions) {
 }
 
-void EnzymesADVContext::initViewContext(GObjectView* view) {
+void EnzymesADVContext::initViewContext(GObjectViewController* view) {
     auto av = qobject_cast<AnnotatedDNAView*>(view);
     ADVGlobalAction* a = new ADVGlobalAction(av, QIcon(":enzymes/images/enzymes.png"), tr("Find restriction sites..."), 50);
     a->setObjectName("Find restriction sites");
@@ -203,7 +203,7 @@ void EnzymesADVContext::sl_search() {
 // TODO: move definitions to core
 #define PRIMER_ANNOTATION_GROUP_NAME "pair"
 
-void EnzymesADVContext::buildStaticOrContextMenu(GObjectView* v, QMenu* m) {
+void EnzymesADVContext::buildStaticOrContextMenu(GObjectViewController* v, QMenu* m) {
     auto av = qobject_cast<AnnotatedDNAView*>(v);
     SAFE_POINT(nullptr != av, "Invalid sequence view", );
     CHECK(av->getActiveSequenceContext()->getAlphabet()->isNucleic(), );

--- a/src/plugins/enzymes/src/EnzymesPlugin.h
+++ b/src/plugins/enzymes/src/EnzymesPlugin.h
@@ -58,9 +58,9 @@ protected slots:
     void sl_createPCRProduct();
 
 protected:
-    void buildStaticOrContextMenu(GObjectView* view, QMenu* menu) override;
+    void buildStaticOrContextMenu(GObjectViewController* view, QMenu* menu) override;
 
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 
     QList<QAction*> cloningActions;
 };

--- a/src/plugins/external_tool_support/src/blast/BlastSupport.cpp
+++ b/src/plugins/external_tool_support/src/blast/BlastSupport.cpp
@@ -240,7 +240,7 @@ BlastSupportContext::BlastSupportContext(QObject* p)
     connect(fetchSequenceByIdAction, SIGNAL(triggered()), SLOT(sl_fetchSequenceById()));
 }
 
-void BlastSupportContext::initViewContext(GObjectView* view) {
+void BlastSupportContext::initViewContext(GObjectViewController* view) {
     SAFE_POINT(qobject_cast<AnnotatedDNAView*>(view) != nullptr, "Object view is not an AnnotatedDNAView", );
 
     auto queryAction = new ExternalToolSupportAction(this, view, tr("Query with local BLAST..."), 2000, searchToolIds);
@@ -261,7 +261,7 @@ static QString getCommaSeparatedIdsFromAnnotations(const QList<Annotation*>& ann
     return idList.join(",");
 }
 
-void BlastSupportContext::buildStaticOrContextMenu(GObjectView* view, QMenu* m) {
+void BlastSupportContext::buildStaticOrContextMenu(GObjectViewController* view, QMenu* m) {
     auto dnaView = qobject_cast<AnnotatedDNAView*>(view);
     CHECK(dnaView != nullptr, );
 

--- a/src/plugins/external_tool_support/src/blast/BlastSupport.h
+++ b/src/plugins/external_tool_support/src/blast/BlastSupport.h
@@ -75,8 +75,8 @@ protected slots:
     void sl_fetchSequenceById();
 
 protected:
-    void initViewContext(GObjectView* view) override;
-    void buildStaticOrContextMenu(GObjectView* view, QMenu* menu) override;
+    void initViewContext(GObjectViewController* view) override;
+    void buildStaticOrContextMenu(GObjectViewController* view, QMenu* menu) override;
 
 private:
     QStringList searchToolIds;

--- a/src/plugins/external_tool_support/src/clustalo/ClustalOSupport.cpp
+++ b/src/plugins/external_tool_support/src/clustalo/ClustalOSupport.cpp
@@ -116,7 +116,7 @@ ClustalOSupportContext::ClustalOSupportContext(QObject* p)
     : GObjectViewWindowContext(p, MsaEditorFactory::ID) {
 }
 
-void ClustalOSupportContext::initViewContext(GObjectView* view) {
+void ClustalOSupportContext::initViewContext(GObjectViewController* view) {
     auto msaEditor = qobject_cast<MSAEditor*>(view);
     SAFE_POINT(msaEditor != nullptr, "Invalid GObjectView", );
 

--- a/src/plugins/external_tool_support/src/clustalo/ClustalOSupport.h
+++ b/src/plugins/external_tool_support/src/clustalo/ClustalOSupport.h
@@ -60,7 +60,7 @@ protected slots:
     void sl_addAlignmentToAlignment();
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 
 private:
     /**

--- a/src/plugins/external_tool_support/src/clustalw/ClustalWSupport.cpp
+++ b/src/plugins/external_tool_support/src/clustalw/ClustalWSupport.cpp
@@ -118,7 +118,7 @@ ClustalWSupportContext::ClustalWSupportContext(QObject* p)
     : GObjectViewWindowContext(p, MsaEditorFactory::ID) {
 }
 
-void ClustalWSupportContext::initViewContext(GObjectView* view) {
+void ClustalWSupportContext::initViewContext(GObjectViewController* view) {
     auto msaEditor = qobject_cast<MSAEditor*>(view);
     SAFE_POINT(msaEditor != nullptr, "Invalid GObjectView", );
     msaEditor->registerActionProvider(this);

--- a/src/plugins/external_tool_support/src/clustalw/ClustalWSupport.h
+++ b/src/plugins/external_tool_support/src/clustalw/ClustalWSupport.h
@@ -56,7 +56,7 @@ protected slots:
     void sl_align();
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 };
 
 }  // namespace U2

--- a/src/plugins/external_tool_support/src/hmmer/HmmerSupport.cpp
+++ b/src/plugins/external_tool_support/src/hmmer/HmmerSupport.cpp
@@ -275,7 +275,7 @@ HmmerMsaEditorContext::HmmerMsaEditorContext(QObject* parent)
     : GObjectViewWindowContext(parent, MsaEditorFactory::ID) {
 }
 
-void HmmerMsaEditorContext::initViewContext(GObjectView* view) {
+void HmmerMsaEditorContext::initViewContext(GObjectViewController* view) {
     auto msaEditor = qobject_cast<MSAEditor*>(view);
     SAFE_POINT(msaEditor != nullptr, "Msa Editor is NULL", );
     CHECK(msaEditor->getMaObject() != nullptr, );
@@ -287,7 +287,7 @@ void HmmerMsaEditorContext::initViewContext(GObjectView* view) {
     addViewAction(action);
 }
 
-void HmmerMsaEditorContext::buildStaticOrContextMenu(GObjectView* view, QMenu* menu) {
+void HmmerMsaEditorContext::buildStaticOrContextMenu(GObjectViewController* view, QMenu* menu) {
     auto msaEditor = qobject_cast<MSAEditor*>(view);
     SAFE_POINT(msaEditor != nullptr, "Msa Editor is NULL", );
     SAFE_POINT(menu != nullptr, "Menu is NULL", );
@@ -318,7 +318,7 @@ HmmerAdvContext::HmmerAdvContext(QObject* parent)
     : GObjectViewWindowContext(parent, AnnotatedDNAViewFactory::ID) {
 }
 
-void HmmerAdvContext::initViewContext(GObjectView* view) {
+void HmmerAdvContext::initViewContext(GObjectViewController* view) {
     auto adv = qobject_cast<AnnotatedDNAView*>(view);
     SAFE_POINT(adv != nullptr, "AnnotatedDNAView is NULL", );
 

--- a/src/plugins/external_tool_support/src/hmmer/HmmerSupport.h
+++ b/src/plugins/external_tool_support/src/hmmer/HmmerSupport.h
@@ -63,8 +63,8 @@ private slots:
     void sl_build();
 
 private:
-    void initViewContext(GObjectView* view) override;
-    void buildStaticOrContextMenu(GObjectView* view, QMenu* menu) override;
+    void initViewContext(GObjectViewController* view) override;
+    void buildStaticOrContextMenu(GObjectViewController* view, QMenu* menu) override;
 };
 
 class HmmerAdvContext : public GObjectViewWindowContext {
@@ -76,7 +76,7 @@ private slots:
     void sl_search();
 
 private:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 
     QWidget* getParentWidget(QObject* sender);
     U2SequenceObject* getSequenceInFocus(QObject* sender);

--- a/src/plugins/external_tool_support/src/mafft/MAFFTSupport.cpp
+++ b/src/plugins/external_tool_support/src/mafft/MAFFTSupport.cpp
@@ -118,7 +118,7 @@ MAFFTSupportContext::MAFFTSupportContext(QObject* p)
     : GObjectViewWindowContext(p, MsaEditorFactory::ID) {
 }
 
-void MAFFTSupportContext::initViewContext(GObjectView* view) {
+void MAFFTSupportContext::initViewContext(GObjectViewController* view) {
     auto msaEditor = qobject_cast<MSAEditor*>(view);
     SAFE_POINT(msaEditor != nullptr, "Invalid GObjectView", );
     msaEditor->registerActionProvider(this);

--- a/src/plugins/external_tool_support/src/mafft/MAFFTSupport.h
+++ b/src/plugins/external_tool_support/src/mafft/MAFFTSupport.h
@@ -56,7 +56,7 @@ protected slots:
     void sl_align_with_MAFFT();
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 };
 
 }  // namespace U2

--- a/src/plugins/external_tool_support/src/spidey/SpideySupport.cpp
+++ b/src/plugins/external_tool_support/src/spidey/SpideySupport.cpp
@@ -100,7 +100,7 @@ SpideySupportContext::SpideySupportContext(QObject* p)
     : GObjectViewWindowContext(p, AnnotatedDNAViewFactory::ID) {
 }
 
-void SpideySupportContext::initViewContext(GObjectView* view) {
+void SpideySupportContext::initViewContext(GObjectViewController* view) {
     auto dnaView = qobject_cast<AnnotatedDNAView*>(view);
     assert(dnaView != nullptr);
     if (dnaView->getActiveSequenceContext() == nullptr) {
@@ -116,7 +116,7 @@ void SpideySupportContext::initViewContext(GObjectView* view) {
     connect(alignAction, SIGNAL(triggered()), SLOT(sl_align_with_Spidey()));
 }
 
-void SpideySupportContext::buildStaticOrContextMenu(GObjectView* view, QMenu* m) {
+void SpideySupportContext::buildStaticOrContextMenu(GObjectViewController* view, QMenu* m) {
     QList<GObjectViewAction*> actions = getViewActions(view);
     QMenu* alignMenu = GUIUtils::findSubMenu(m, ADV_MENU_ALIGN);
     SAFE_POINT(alignMenu != nullptr, "alignMenu", );

--- a/src/plugins/external_tool_support/src/spidey/SpideySupport.h
+++ b/src/plugins/external_tool_support/src/spidey/SpideySupport.h
@@ -54,9 +54,9 @@ protected slots:
     void sl_align_with_Spidey();
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 
-    void buildStaticOrContextMenu(GObjectView* view, QMenu* menu) override;
+    void buildStaticOrContextMenu(GObjectViewController* view, QMenu* menu) override;
 };
 
 }  // namespace U2

--- a/src/plugins/external_tool_support/src/tcoffee/TCoffeeSupport.cpp
+++ b/src/plugins/external_tool_support/src/tcoffee/TCoffeeSupport.cpp
@@ -103,7 +103,7 @@ TCoffeeSupportContext::TCoffeeSupportContext(QObject* p)
     : GObjectViewWindowContext(p, MsaEditorFactory::ID) {
 }
 
-void TCoffeeSupportContext::initViewContext(GObjectView* view) {
+void TCoffeeSupportContext::initViewContext(GObjectViewController* view) {
     auto msaEditor = qobject_cast<MSAEditor*>(view);
     SAFE_POINT(msaEditor != nullptr, "Invalid GObjectView", );
     msaEditor->registerActionProvider(this);

--- a/src/plugins/external_tool_support/src/tcoffee/TCoffeeSupport.h
+++ b/src/plugins/external_tool_support/src/tcoffee/TCoffeeSupport.h
@@ -56,7 +56,7 @@ protected slots:
     void sl_align_with_TCoffee();
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 };
 
 }  // namespace U2

--- a/src/plugins/external_tool_support/src/utils/ExternalToolSupportAction.cpp
+++ b/src/plugins/external_tool_support/src/utils/ExternalToolSupportAction.cpp
@@ -27,7 +27,7 @@
 
 namespace U2 {
 
-ExternalToolSupportAction::ExternalToolSupportAction(QObject* p, GObjectView* v, const QString& _text, int order, const QStringList& _toolIds)
+ExternalToolSupportAction::ExternalToolSupportAction(QObject* p, GObjectViewController* v, const QString& _text, int order, const QStringList& _toolIds)
     : GObjectViewAction(p, v, _text, order),
       toolIds(_toolIds) {
     bool isAnyToolConfigured = checkTools(true);

--- a/src/plugins/external_tool_support/src/utils/ExternalToolSupportAction.h
+++ b/src/plugins/external_tool_support/src/utils/ExternalToolSupportAction.h
@@ -30,7 +30,7 @@ namespace U2 {
 class ExternalToolSupportAction : public GObjectViewAction {
     Q_OBJECT
 public:
-    ExternalToolSupportAction(QObject* p, GObjectView* v, const QString& _text, int order, const QStringList& _toolIds);
+    ExternalToolSupportAction(QObject* p, GObjectViewController* v, const QString& _text, int order, const QStringList& _toolIds);
     ExternalToolSupportAction(const QString& text, QObject* p, const QStringList& _toolIds);
 
     const QStringList getToolIds() const {

--- a/src/plugins/genecut/src/GenecutOPWidgetFactory.cpp
+++ b/src/plugins/genecut/src/GenecutOPWidgetFactory.cpp
@@ -41,7 +41,7 @@ GenecutOPWidgetFactory::GenecutOPWidgetFactory()
     objectViewOfWidget = ObjViewType_SequenceView;
 }
 
-QWidget* GenecutOPWidgetFactory::createWidget(GObjectView* objView, const QVariantMap& ) {
+QWidget* GenecutOPWidgetFactory::createWidget(GObjectViewController* objView, const QVariantMap& ) {
     auto annotatedDnaView = qobject_cast<AnnotatedDNAView*>(objView);
     SAFE_POINT(annotatedDnaView != nullptr, L10N::nullPointerError("AnnotatedDNAView"), nullptr);
 

--- a/src/plugins/genecut/src/GenecutOPWidgetFactory.h
+++ b/src/plugins/genecut/src/GenecutOPWidgetFactory.h
@@ -30,7 +30,7 @@ class GenecutOPWidgetFactory : public OPWidgetFactory {
 public:
     GenecutOPWidgetFactory();
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 

--- a/src/plugins/orf_marker/src/ORFMarkerPlugin.cpp
+++ b/src/plugins/orf_marker/src/ORFMarkerPlugin.cpp
@@ -92,7 +92,7 @@ ORFViewContext::ORFViewContext(QObject* p)
     : GObjectViewWindowContext(p, ANNOTATED_DNA_VIEW_FACTORY_ID) {
 }
 
-void ORFViewContext::initViewContext(GObjectView* v) {
+void ORFViewContext::initViewContext(GObjectViewController* v) {
     auto av = qobject_cast<AnnotatedDNAView*>(v);
     ADVGlobalAction* a = new ADVGlobalAction(av, QIcon(":orf_marker/images/orf_marker.png"), tr("Find ORFs..."), 20);
     a->setObjectName("Find ORFs");

--- a/src/plugins/orf_marker/src/ORFMarkerPlugin.h
+++ b/src/plugins/orf_marker/src/ORFMarkerPlugin.h
@@ -48,7 +48,7 @@ protected slots:
     void sl_showDialog();
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 };
 
 class ORFMarkerTests {

--- a/src/plugins/pcr/src/InSilicoPcrOPWidgetFactory.cpp
+++ b/src/plugins/pcr/src/InSilicoPcrOPWidgetFactory.cpp
@@ -37,7 +37,7 @@ InSilicoPcrOPWidgetFactory::InSilicoPcrOPWidgetFactory()
     objectViewOfWidget = ObjViewType_SequenceView;
 }
 
-QWidget* InSilicoPcrOPWidgetFactory::createWidget(GObjectView* objView, const QVariantMap& options) {
+QWidget* InSilicoPcrOPWidgetFactory::createWidget(GObjectViewController* objView, const QVariantMap& options) {
     Q_UNUSED(options);
 
     auto annotatedDnaView = qobject_cast<AnnotatedDNAView*>(objView);

--- a/src/plugins/pcr/src/InSilicoPcrOPWidgetFactory.h
+++ b/src/plugins/pcr/src/InSilicoPcrOPWidgetFactory.h
@@ -30,7 +30,7 @@ class InSilicoPcrOPWidgetFactory : public OPWidgetFactory {
 public:
     InSilicoPcrOPWidgetFactory();
 
-    QWidget* createWidget(GObjectView* objView, const QVariantMap& options) override;
+    QWidget* createWidget(GObjectViewController* objView, const QVariantMap& options) override;
 
     OPGroupParameters getOPGroupParameters() override;
 

--- a/src/plugins/query_designer/src/QueryDesignerPlugin.cpp
+++ b/src/plugins/query_designer/src/QueryDesignerPlugin.cpp
@@ -100,7 +100,7 @@ QueryDesignerViewContext::QueryDesignerViewContext(QObject* p)
     : GObjectViewWindowContext(p, ANNOTATED_DNA_VIEW_FACTORY_ID) {
 }
 
-void QueryDesignerViewContext::initViewContext(GObjectView* view) {
+void QueryDesignerViewContext::initViewContext(GObjectViewController* view) {
     auto av = qobject_cast<AnnotatedDNAView*>(view);
     auto action = new ADVGlobalAction(av,
                                       QIcon(":query_designer/images/query_designer.png"),

--- a/src/plugins/query_designer/src/QueryDesignerPlugin.h
+++ b/src/plugins/query_designer/src/QueryDesignerPlugin.h
@@ -50,7 +50,7 @@ public:
     QueryDesignerViewContext(QObject* p);
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 
 private slots:
     void sl_showDialog();

--- a/src/plugins/remote_blast/src/RemoteBLASTPlugin.cpp
+++ b/src/plugins/remote_blast/src/RemoteBLASTPlugin.cpp
@@ -98,7 +98,7 @@ RemoteBLASTViewContext::RemoteBLASTViewContext(QObject* p)
     : GObjectViewWindowContext(p, ANNOTATED_DNA_VIEW_FACTORY_ID) {
 }
 
-void RemoteBLASTViewContext::initViewContext(GObjectView* view) {
+void RemoteBLASTViewContext::initViewContext(GObjectViewController* view) {
     auto av = qobject_cast<AnnotatedDNAView*>(view);
     ADVGlobalAction* a = new ADVGlobalAction(av, QIcon(":/remote_blast/images/remote_db_request.png"), tr("Query NCBI BLAST database..."), 60);
     a->setObjectName("Query NCBI BLAST database");

--- a/src/plugins/remote_blast/src/RemoteBLASTPlugin.h
+++ b/src/plugins/remote_blast/src/RemoteBLASTPlugin.h
@@ -52,7 +52,7 @@ public:
     RemoteBLASTViewContext(QObject* p);
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 
 private slots:
     void sl_showDialog();

--- a/src/plugins/repeat_finder/src/RepeatFinderPlugin.cpp
+++ b/src/plugins/repeat_finder/src/RepeatFinderPlugin.cpp
@@ -96,7 +96,7 @@ RepeatViewContext::RepeatViewContext(QObject* p)
     : GObjectViewWindowContext(p, AnnotatedDNAViewFactory::ID) {
 }
 
-void RepeatViewContext::initViewContext(GObjectView* v) {
+void RepeatViewContext::initViewContext(GObjectViewController* v) {
     auto av = qobject_cast<AnnotatedDNAView*>(v);
     ADVGlobalAction* a = new ADVGlobalAction(av, QIcon(":repeat_finder/images/repeats.png"), tr("Find repeats..."), 40);
     a->addAlphabetFilter(DNAAlphabet_NUCL);

--- a/src/plugins/repeat_finder/src/RepeatFinderPlugin.h
+++ b/src/plugins/repeat_finder/src/RepeatFinderPlugin.h
@@ -46,7 +46,7 @@ protected slots:
     void sl_showTandemDialog();
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 };
 
 }  // namespace U2

--- a/src/plugins/smith_waterman/src/SWAlgorithmPlugin.cpp
+++ b/src/plugins/smith_waterman/src/SWAlgorithmPlugin.cpp
@@ -110,7 +110,7 @@ SWAlgorithmADVContext::SWAlgorithmADVContext(QObject* p)
     : GObjectViewWindowContext(p, ANNOTATED_DNA_VIEW_FACTORY_ID), dialogConfig() {
 }
 
-void SWAlgorithmADVContext::initViewContext(GObjectView* view) {
+void SWAlgorithmADVContext::initViewContext(GObjectViewController* view) {
     auto av = qobject_cast<AnnotatedDNAView*>(view);
     assert(av != nullptr);
     auto a = new ADVGlobalAction(av, QIcon(":core/images/sw.png"), tr("Find pattern [Smith-Waterman]..."), 15);

--- a/src/plugins/smith_waterman/src/SWAlgorithmPlugin.h
+++ b/src/plugins/smith_waterman/src/SWAlgorithmPlugin.h
@@ -60,7 +60,7 @@ protected slots:
     void sl_search();
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 
 private:
     SWDialogConfig dialogConfig;

--- a/src/plugins/weight_matrix/src/WeightMatrixPlugin.cpp
+++ b/src/plugins/weight_matrix/src/WeightMatrixPlugin.cpp
@@ -103,7 +103,7 @@ WeightMatrixADVContext::WeightMatrixADVContext(QObject* p)
     : GObjectViewWindowContext(p, ANNOTATED_DNA_VIEW_FACTORY_ID) {
 }
 
-void WeightMatrixADVContext::initViewContext(GObjectView* view) {
+void WeightMatrixADVContext::initViewContext(GObjectViewController* view) {
     auto av = qobject_cast<AnnotatedDNAView*>(view);
     ADVGlobalAction* a = new ADVGlobalAction(av, QIcon(":weight_matrix/images/weight_matrix.png"), tr("Find TFBS with matrices..."), 80);
     a->addAlphabetFilter(DNAAlphabet_NUCL);

--- a/src/plugins/weight_matrix/src/WeightMatrixPlugin.h
+++ b/src/plugins/weight_matrix/src/WeightMatrixPlugin.h
@@ -53,7 +53,7 @@ protected slots:
     void sl_search();
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 };
 
 class WeightMatrixAlgorithmTests {

--- a/src/plugins_3rdparty/hmm2/src/uHMMPlugin.cpp
+++ b/src/plugins_3rdparty/hmm2/src/uHMMPlugin.cpp
@@ -134,7 +134,7 @@ void uHMMPlugin::sl_build() {
     if (w != NULL) {
         auto ow = qobject_cast<GObjectViewWindow*>(w);
         if (ow != NULL) {
-            GObjectView* ov = ow->getObjectView();
+            GObjectViewController* ov = ow->getObjectView();
             auto av = qobject_cast<MSAEditor*>(ov);
             if (av != NULL) {
                 MultipleSequenceAlignmentObject* maObj = av->getMaObject();
@@ -162,7 +162,7 @@ void uHMMPlugin::sl_search() {
     if (w != NULL) {
         auto ow = qobject_cast<GObjectViewWindow*>(w);
         if (ow != NULL) {
-            GObjectView* ov = ow->getObjectView();
+            GObjectViewController* ov = ow->getObjectView();
             auto av = qobject_cast<AnnotatedDNAView*>(ov);
             if (av != NULL) {
                 seqCtx = av->getActiveSequenceContext();
@@ -200,7 +200,7 @@ HMMMSAEditorContext::HMMMSAEditorContext(QObject* p)
     : GObjectViewWindowContext(p, MsaEditorFactory::ID) {
 }
 
-void HMMMSAEditorContext::initViewContext(GObjectView* view) {
+void HMMMSAEditorContext::initViewContext(GObjectViewController* view) {
     auto msaed = qobject_cast<MSAEditor*>(view);
     SAFE_POINT(msaed != NULL, "Invalid GObjectView", );
     CHECK(msaed->getMaObject() != NULL, );
@@ -212,7 +212,7 @@ void HMMMSAEditorContext::initViewContext(GObjectView* view) {
     addViewAction(a);
 }
 
-void HMMMSAEditorContext::buildStaticOrContextMenu(GObjectView* v, QMenu* m) {
+void HMMMSAEditorContext::buildStaticOrContextMenu(GObjectViewController* v, QMenu* m) {
     auto msaed = qobject_cast<MSAEditor*>(v);
     SAFE_POINT(NULL != msaed && NULL != m, "Invalid GObjectVeiw or QMenu", );
     CHECK(msaed->getMaObject() != NULL, );
@@ -243,7 +243,7 @@ HMMADVContext::HMMADVContext(QObject* p)
     : GObjectViewWindowContext(p, ANNOTATED_DNA_VIEW_FACTORY_ID) {
 }
 
-void HMMADVContext::initViewContext(GObjectView* view) {
+void HMMADVContext::initViewContext(GObjectViewController* view) {
     auto av = qobject_cast<AnnotatedDNAView*>(view);
     ADVGlobalAction* a = new ADVGlobalAction(av, QIcon(":/hmm2/images/hmmer_16.png"), tr("Find HMM signals with HMMER2..."), 70);
     connect(a, SIGNAL(triggered()), SLOT(sl_search()));

--- a/src/plugins_3rdparty/hmm2/src/uHMMPlugin.h
+++ b/src/plugins_3rdparty/hmm2/src/uHMMPlugin.h
@@ -60,8 +60,8 @@ protected slots:
     void sl_build();
 
 protected:
-    void initViewContext(GObjectView* view) override;
-    void buildStaticOrContextMenu(GObjectView* view, QMenu* menu) override;
+    void initViewContext(GObjectViewController* view) override;
+    void buildStaticOrContextMenu(GObjectViewController* view, QMenu* menu) override;
 };
 
 class HMMADVContext : public GObjectViewWindowContext {
@@ -73,7 +73,7 @@ protected slots:
     void sl_search();
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 };
 
 }  // namespace U2

--- a/src/plugins_3rdparty/kalign/src/KalignPlugin.cpp
+++ b/src/plugins_3rdparty/kalign/src/KalignPlugin.cpp
@@ -134,7 +134,7 @@ KalignMSAEditorContext::KalignMSAEditorContext(QObject* p)
     : GObjectViewWindowContext(p, MsaEditorFactory::ID) {
 }
 
-void KalignMSAEditorContext::initViewContext(GObjectView* view) {
+void KalignMSAEditorContext::initViewContext(GObjectViewController* view) {
     auto msaed = qobject_cast<MSAEditor*>(view);
     SAFE_POINT(msaed != NULL, "Invalid GObjectView", );
     CHECK(msaed->getMaObject() != NULL, );

--- a/src/plugins_3rdparty/kalign/src/KalignPlugin.h
+++ b/src/plugins_3rdparty/kalign/src/KalignPlugin.h
@@ -60,13 +60,13 @@ protected slots:
     void sl_align();
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 };
 
 class KalignAction : public GObjectViewAction {
     Q_OBJECT
 public:
-    KalignAction(QObject* p, GObjectView* v, const QString& text, int order)
+    KalignAction(QObject* p, GObjectViewController* v, const QString& text, int order)
         : GObjectViewAction(p, v, text, order) {
     }
     MSAEditor* getMSAEditor() const;

--- a/src/plugins_3rdparty/primer3/src/Primer3Plugin.cpp
+++ b/src/plugins_3rdparty/primer3/src/Primer3Plugin.cpp
@@ -85,7 +85,7 @@ Primer3ADVContext::Primer3ADVContext(QObject* p)
     : GObjectViewWindowContext(p, ANNOTATED_DNA_VIEW_FACTORY_ID) {
 }
 
-void Primer3ADVContext::initViewContext(GObjectView* v) {
+void Primer3ADVContext::initViewContext(GObjectViewController* v) {
     auto av = qobject_cast<AnnotatedDNAView*>(v);
     ADVGlobalAction* a = new ADVGlobalAction(av, QIcon(":/primer3/images/primer3.png"), tr("Primer3..."), 95);
     a->setObjectName("primer3_action");

--- a/src/plugins_3rdparty/primer3/src/Primer3Plugin.h
+++ b/src/plugins_3rdparty/primer3/src/Primer3Plugin.h
@@ -53,7 +53,7 @@ protected slots:
     void sl_showDialog();
 
 protected:
-    void initViewContext(GObjectView* v) override;
+    void initViewContext(GObjectViewController* v) override;
 };
 
 class Primer3Tests {

--- a/src/plugins_3rdparty/sitecon/src/SiteconPlugin.cpp
+++ b/src/plugins_3rdparty/sitecon/src/SiteconPlugin.cpp
@@ -111,7 +111,7 @@ SiteconADVContext::SiteconADVContext(QObject* p)
     : GObjectViewWindowContext(p, ANNOTATED_DNA_VIEW_FACTORY_ID) {
 }
 
-void SiteconADVContext::initViewContext(GObjectView* view) {
+void SiteconADVContext::initViewContext(GObjectViewController* view) {
     auto av = qobject_cast<AnnotatedDNAView*>(view);
     ADVGlobalAction* a = new ADVGlobalAction(av, QIcon(":sitecon/images/sitecon.png"), tr("Find TFBS with SITECON..."), 80);
     a->setObjectName("SITECON");

--- a/src/plugins_3rdparty/sitecon/src/SiteconPlugin.h
+++ b/src/plugins_3rdparty/sitecon/src/SiteconPlugin.h
@@ -63,7 +63,7 @@ protected slots:
     void sl_search();
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 };
 
 class SiteconAlgorithmTests {

--- a/src/plugins_3rdparty/umuscle/src/MusclePlugin.cpp
+++ b/src/plugins_3rdparty/umuscle/src/MusclePlugin.cpp
@@ -108,7 +108,7 @@ void MusclePlugin::sl_runWithExtFileSpecify() {
     AppContext::getTaskScheduler()->registerTopLevelTask(muscleTask);
 }
 
-MuscleAction::MuscleAction(QObject* p, GObjectView* v, const QString& text, int order, bool isAlignSelectionAction)
+MuscleAction::MuscleAction(QObject* p, GObjectViewController* v, const QString& text, int order, bool isAlignSelectionAction)
     : GObjectViewAction(p, v, text, order) {
     setIcon(QIcon(":umuscle/images/muscle_16.png"));
 
@@ -130,7 +130,7 @@ MuscleMSAEditorContext::MuscleMSAEditorContext(QObject* p)
     : GObjectViewWindowContext(p, MsaEditorFactory::ID) {
 }
 
-void MuscleMSAEditorContext::initViewContext(GObjectView* view) {
+void MuscleMSAEditorContext::initViewContext(GObjectViewController* view) {
     view->registerActionProvider(this);
 
     auto alignAction = new MuscleAction(this, view, tr("Align with MUSCLE…"), 1000);

--- a/src/plugins_3rdparty/umuscle/src/MusclePlugin.h
+++ b/src/plugins_3rdparty/umuscle/src/MusclePlugin.h
@@ -63,13 +63,13 @@ protected slots:
     void sl_alignSelectedSequences();
 
 protected:
-    void initViewContext(GObjectView* view) override;
+    void initViewContext(GObjectViewController* view) override;
 };
 
 class MuscleAction : public GObjectViewAction {
     Q_OBJECT
 public:
-    MuscleAction(QObject* p, GObjectView* v, const QString& text, int order, bool isAlignSelectionAction = false);
+    MuscleAction(QObject* p, GObjectViewController* v, const QString& text, int order, bool isAlignSelectionAction = false);
 
     MSAEditor* getMSAEditor() const;
 };

--- a/src/ugeneui/src/project_support/ProjectImpl.cpp
+++ b/src/ugeneui/src/project_support/ProjectImpl.cpp
@@ -255,7 +255,7 @@ QString ProjectImpl::genNextObjectId() {
 }
 
 void ProjectImpl::sl_onViewRenamed(const QString& oldName) {
-    auto view = qobject_cast<GObjectView*>(sender());
+    auto view = qobject_cast<GObjectViewController*>(sender());
     updateGObjectViewStates(oldName, view->getName());
 }
 

--- a/src/ugeneui/src/project_view/ProjectViewImpl.cpp
+++ b/src/ugeneui/src/project_view/ProjectViewImpl.cpp
@@ -721,13 +721,13 @@ public:
 
 class AddToViewContext : public QObject {
 public:
-    AddToViewContext(QObject* p, GObjectView* v, QList<GObject*> objs)
+    AddToViewContext(QObject* p, GObjectViewController* v, QList<GObject*> objs)
         : QObject(p), view(v) {
         foreach (GObject* o, objs) {
             objects.append(o);
         }
     }
-    QPointer<GObjectView> view;
+    QPointer<GObjectViewController> view;
     QList<QPointer<GObject>> objects;
 };
 
@@ -1062,7 +1062,7 @@ void ProjectViewImpl::sl_addToView() {
     // TODO: create specialized action classes instead of using ->data().value<void*>() casts
     QAction* action = (QAction*)sender();
     auto ac = static_cast<AddToViewContext*>(action->data().value<void*>());
-    GObjectView* view = ac->view;
+    GObjectViewController* view = ac->view;
     if (view == nullptr) {
         return;
     }


### PR DESCRIPTION
This is no-op patch. It should not change anything, but only make widget creations more robust (widgets get correct parent from the moment of construction)