### PR TITLE
Fix huge GUI test log output in case of failed test.

### DIFF
--- a/src/libs_3rdparty/QSpec/src/GTGlobals.h
+++ b/src/libs_3rdparty/QSpec/src/GTGlobals.h
@@ -117,6 +117,12 @@ public:
         } \
     }
 
+#define CHECK_NO_OS_ERROR(result) \
+    if (os.hasError()) { \
+        os.setError(QString("Can't continue when os.hasError. Location: %1:%2").arg(__FILE__).arg(__LINE__)); \
+        return result;\
+    }
+
 /** Unconditionally marks active test as failed. Prints 'errorMessage' into the log. */
 #define GT_FAIL(errorMessage, result) \
     GT_DEBUG_MESSAGE(false, errorMessage, result); \

--- a/src/libs_3rdparty/QSpec/src/core/GUITestOpStatus.h
+++ b/src/libs_3rdparty/QSpec/src/core/GUITestOpStatus.h
@@ -30,11 +30,12 @@ namespace HI {
 
 class HI_EXPORT GUITestOpStatus {
 public:
-    GUITestOpStatus() {
-    }
-
     virtual void setError(const QString& err) {
-        error = err;
+        if (!error.isEmpty()) {
+            qWarning("Can't override error! Current error: %s, new error: %s", error.toLocal8Bit().constData(), err.toLocal8Bit().constData());
+        } else {
+            error = err;
+        }
         throw this;
     }
 

--- a/src/libs_3rdparty/QSpec/src/core/MainThreadRunnable.cpp
+++ b/src/libs_3rdparty/QSpec/src/core/MainThreadRunnable.cpp
@@ -61,7 +61,7 @@ void MainThreadRunnable::doRequest() {
 }
 
 void MainThreadRunnable::run() {
-    if (Q_UNLIKELY(NULL == scenario)) {
+    if (scenario == nullptr) {
         os.setError("Scenario is NULL");
         return;
     }
@@ -69,7 +69,8 @@ void MainThreadRunnable::run() {
 }
 
 void MainThreadRunnable::runInMainThread(GUITestOpStatus& os, CustomScenario* scenario) {
-    if (Q_UNLIKELY(NULL == scenario)) {
+    CHECK_NO_OS_ERROR();
+    if (scenario == nullptr) {
         os.setError("Custom scenario is NULL");
         return;
     }
@@ -77,8 +78,7 @@ void MainThreadRunnable::runInMainThread(GUITestOpStatus& os, CustomScenario* sc
     mainThreadRunnable.doRequest();
 }
 
-MainThreadRunnableObject::MainThreadRunnableObject()
-    : QObject(NULL) {
+MainThreadRunnableObject::MainThreadRunnableObject() {
 }
 
 void MainThreadRunnableObject::sl_requestAsked(MainThreadRunnable* runnable) {

--- a/src/libs_3rdparty/QSpec/src/primitives/GTWidget.cpp
+++ b/src/libs_3rdparty/QSpec/src/primitives/GTWidget.cpp
@@ -100,6 +100,7 @@ void GTWidget::setFocus(GUITestOpStatus& os, QWidget* w) {
 
 #define GT_METHOD_NAME "findWidget"
 QWidget* GTWidget::findWidget(GUITestOpStatus& os, const QString& objectName, QWidget* parentWidget, const GTGlobals::FindOptions& options) {
+    CHECK_NO_OS_ERROR(nullptr);
     QPointer<QWidget> parentWidgetPtr(parentWidget);
     QWidget* widget = nullptr;
     for (int time = 0; time < GT_OP_WAIT_MILLIS && widget == nullptr; time += GT_OP_CHECK_MILLIS) {
@@ -111,7 +112,7 @@ QWidget* GTWidget::findWidget(GUITestOpStatus& os, const QString& objectName, QW
 #ifdef _DEBUG
         if (matchedWidgets.size() >= 2)
 #endif
-        GT_CHECK_RESULT(matchedWidgets.size() < 2, QString("There are %1 widgets with name '%2'").arg(matchedWidgets.size()).arg(objectName), nullptr);
+            GT_CHECK_RESULT(matchedWidgets.size() < 2, QString("There are %1 widgets with name '%2'").arg(matchedWidgets.size()).arg(objectName), nullptr);
         widget = matchedWidgets.isEmpty() ? nullptr : matchedWidgets[0];
         if (!options.failIfNotFound) {
             break;
@@ -244,14 +245,14 @@ QPoint GTWidget::getWidgetCenter(QWidget* widget) {
     return widget->mapToGlobal(widget->rect().center());
 }
 
-QPoint GTWidget::getWidgetVisibleCenter(QWidget *widget) {
+QPoint GTWidget::getWidgetVisibleCenter(QWidget* widget) {
     return widget->mapFromGlobal(getWidgetVisibleCenterGlobal(widget));
 }
 
 QPoint GTWidget::getWidgetVisibleCenterGlobal(QWidget* widget) {
     QRect rect = widget->rect();
     QRect gRect(widget->mapToGlobal(rect.topLeft()), rect.size());
-    QWidget *parent = widget->parentWidget();
+    QWidget* parent = widget->parentWidget();
     while (parent) {
         QRect pRect = parent->rect();
         QRect gParentRect(widget->mapToGlobal(pRect.topLeft()), pRect.size());
@@ -308,20 +309,18 @@ void GTWidget::close(GUITestOpStatus& os, QWidget* widget) {
 
     class Scenario : public CustomScenario {
     public:
-        Scenario(QWidget* widget)
-            : widget(widget) {
+        Scenario(QWidget* _widget)
+            : widget(_widget) {
         }
 
-        void run(GUITestOpStatus& os) {
-            CHECK_SET_ERR(widget != nullptr, "Widget is NULL");
+        void run(GUITestOpStatus&) override {
             widget->close();
             GTGlobals::sleep(100);
         }
 
     private:
-        QWidget* widget;
+        QWidget* widget = nullptr;
     };
-
     GTThread::runInMainThread(os, new Scenario(widget));
 }
 #undef GT_METHOD_NAME
@@ -425,7 +424,7 @@ QImage GTWidget::createSubImage(GUITestOpStatus& os, const QImage& image, const 
 #ifdef _DEBUG
     if (!image.rect().contains(rect))
 #endif
-    GT_CHECK_RESULT(image.rect().contains(rect), "Invalid sub-image rect: " + GTUtilsText::rectToString(rect), QImage());
+        GT_CHECK_RESULT(image.rect().contains(rect), "Invalid sub-image rect: " + GTUtilsText::rectToString(rect), QImage());
     int offset = rect.x() * image.depth() / 8 + rect.y() * image.bytesPerLine();
     return QImage(image.bits() + offset, rect.width(), rect.height(), image.bytesPerLine(), image.format());
 }

--- a/src/libs_3rdparty/QSpec/src/utils/GTUtilsDialog.cpp
+++ b/src/libs_3rdparty/QSpec/src/utils/GTUtilsDialog.cpp
@@ -110,23 +110,8 @@ void GUIDialogWaiter::checkDialog() {
 
             timer.stop();
             GTUtilsDialog::waiterList.removeOne(this);
-
-            try {
-                GTThread::waitForMainThread();
-                runnable->run();
-            } catch (GUITestOpStatus*) {
-                QWidget* popupWidget = QApplication::activePopupWidget();
-                while (popupWidget != nullptr) {
-                    GTWidget::close(os, popupWidget);
-                    popupWidget = QApplication::activePopupWidget();
-                }
-
-                QWidget* modalWidget = QApplication::activeModalWidget();
-                while (modalWidget != nullptr) {
-                    GTWidget::close(os, modalWidget);
-                    modalWidget = QApplication::activeModalWidget();
-                }
-            }
+            GTThread::waitForMainThread();
+            runnable->run();
         } else {
             waitingTime += DIALOG_CHECK_PERIOD;
             if (waitingTime > settings.timeout) {
@@ -139,6 +124,7 @@ void GUIDialogWaiter::checkDialog() {
             }
         }
     } catch (GUITestOpStatus*) {
+        qWarning("Caught exception in GUIDialogWaiter::checkDialog");
     }
 }
 #undef GT_METHOD_NAME
@@ -185,7 +171,6 @@ void GTUtilsDialog::clickButtonBox(GUITestOpStatus& os, QWidget* dialog, QDialog
     }
 #else
     QDialogButtonBox* box = buttonBox(os, dialog);
-    GT_CHECK(box != nullptr, "buttonBox is NULL");
     QPushButton* pushButton = box->button(button);
     GT_CHECK(pushButton != nullptr, "pushButton is NULL");
     GTWidget::click(os, pushButton);

--- a/src/plugins/GUITestBase/src/tests/PosteriorActions.cpp
+++ b/src/plugins/GUITestBase/src/tests/PosteriorActions.cpp
@@ -32,19 +32,15 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QProcess>
-#include <QTreeView>
 
 #include <U2Core/AppContext.h>
 #include <U2Core/Log.h>
-#include <U2Core/Task.h>
 
 #include "GTUtilsMdi.h"
 #include "GTUtilsProjectTreeView.h"
 #include "GTUtilsTaskTreeView.h"
 #include "PosteriorActions.h"
-#include "runnables/ugene/ugeneui/AnyDialogFiller.h"
 #include "runnables/ugene/ugeneui/SaveProjectDialogFiller.h"
-#include "utils/GTUtilsMac.h"
 
 namespace U2 {
 namespace GUITest_posterior_actions {
@@ -77,13 +73,19 @@ POSTERIOR_ACTION_DEFINITION(post_action_0001) {
     // Clear the clipboard
 
     QWidget* popupWidget = QApplication::activePopupWidget();
-    while (popupWidget != nullptr) {
+    for (int i = 0; popupWidget != nullptr; i++) {
+        if (i > 0) {
+            GTGlobals::sleep(100);
+        }
         GTWidget::close(os, popupWidget);
         popupWidget = QApplication::activePopupWidget();
     }
 
     QWidget* modalWidget = QApplication::activeModalWidget();
-    while (modalWidget != nullptr) {
+    for (int i = 0; modalWidget != nullptr; i++) {
+        if (i > 0) {
+            GTGlobals::sleep(100);
+        }
         GTWidget::close(os, modalWidget);
         modalWidget = QApplication::activeModalWidget();
     }

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_4001_5000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_4001_5000.cpp
@@ -985,8 +985,6 @@ GUI_TEST_CLASS_DEFINITION(test_4116) {
         void run(HI::GUITestOpStatus& os) override {
             // Expected: the dialog is modal, the "OK" button is disabled.
             QWidget* dialog = GTWidget::getActiveModalWidget(os);
-            CHECK_SET_ERR(GTUtilsDialog::buttonBox(os, dialog) != nullptr, "ButtonBox is NULL");
-
             QWidget* okButton = GTUtilsDialog::buttonBox(os, dialog)->button(QDialogButtonBox::Ok);
             CHECK_SET_ERR(okButton != nullptr, "Export button is NULL");
             CHECK_SET_ERR(!okButton->isEnabled(), "Export button is unexpectedly enabled");


### PR DESCRIPTION
When there were many failed tests logs for some of them grew > 50mb (per test)
The reason are

1) Test continued to wait & check even after error happened.
2) Test had no sleep() between repeated checks.

This patch introduces 'CHECK_NO_OS_ERROR' to break the wait chain in hot methods and fixes no-sleep loops I found.