### PR TITLE
Support dynamic ignore lists for GUI tests

### DIFF
--- a/src/libs_3rdparty/QSpec/src/core/GUITest.h
+++ b/src/libs_3rdparty/QSpec/src/core/GUITest.h
@@ -43,7 +43,7 @@ public:
     const int timeout;
 
     /** Set of test labels. */
-    const QSet<QString> labelSet;
+    QSet<QString> labelSet;
 
     static QString getFullTestName(const QString& suiteName, const QString& testName) {
         return suiteName + ":" + testName;

--- a/src/plugins/GUITestBase/src/harness/GUITestLauncher.cpp
+++ b/src/plugins/GUITestBase/src/harness/GUITestLauncher.cpp
@@ -240,11 +240,14 @@ bool GUITestLauncher::initTestList() {
         int nIgnoredTests = 0;
         QStringList ignoreListEntries = ignoreListFileContent.split("\n");
         for (const QString& entry : qAsConst(ignoreListEntries)) {
+            if (entry.isEmpty() || entry.startsWith("#")) {
+                continue;
+            }
             for (auto test : qAsConst(testList)) {
                 QString teamcityTestName = UGUITest::getTeamcityTestName(test->suite, test->name);
                 if (test->getFullName().startsWith(entry) || teamcityTestName.startsWith(entry)) {
                     test->labelSet.insert(UGUITestLabels::Ignored);
-                    coreLog.details(QString("Adding Ignore label to test %1").arg(teamcityTestName));
+                    coreLog.details(QString("Adding Ignore label to test '%1', entry: '%2'").arg(teamcityTestName).arg(entry));
                     nIgnoredTests++;
                 }
             }

--- a/src/plugins/GUITestBase/src/harness/GUITestLauncher.cpp
+++ b/src/plugins/GUITestBase/src/harness/GUITestLauncher.cpp
@@ -31,6 +31,7 @@
 #include <U2Core/CMDLineCoreOptions.h>
 #include <U2Core/CmdlineTaskRunner.h>
 #include <U2Core/ExternalToolRegistry.h>
+#include <U2Core/IOAdapterUtils.h>
 #include <U2Core/Timer.h>
 #include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
@@ -231,6 +232,25 @@ bool GUITestLauncher::initTestList() {
         testList = guiTestBase->getTests(UGUITestBase::Normal, labelList);
     }
 
+    // Apply dynamic ignore list. Ignored tests are reported to Teamcity as 'ignored' and are not run at all.
+    QString ignoreListFilePath = qgetenv("UGENE_GUI_TEST_IGNORE_LIST_FILE");
+    if (!ignoreListFilePath.isEmpty()) {
+        QString ignoreListFileContent = IOAdapterUtils::readTextFile(ignoreListFilePath);
+        coreLog.details("Applying ignore list:\n" + ignoreListFileContent);
+        int nIgnoredTests = 0;
+        QStringList ignoreListEntries = ignoreListFileContent.split("\n");
+        for (const QString& entry : qAsConst(ignoreListEntries)) {
+            for (auto test : qAsConst(testList)) {
+                QString teamcityTestName = UGUITest::getTeamcityTestName(test->suite, test->name);
+                if (test->getFullName().startsWith(entry) || teamcityTestName.startsWith(entry)) {
+                    test->labelSet.insert(UGUITestLabels::Ignored);
+                    coreLog.details(QString("Adding Ignore label to test %1").arg(teamcityTestName));
+                    nIgnoredTests++;
+                }
+            }
+        }
+        coreLog.details(QString("Matched %1 tests to ignore").arg(nIgnoredTests));
+    }
     return true;
 }
 


### PR DESCRIPTION
This change is needed to simplify GUI tests enabling on MacOS 