### PR TITLE
Fix Clang compiler warning on macOS about unused function

### DIFF
--- a/src/corelibs/U2View/src/ov_phyltree/TreeViewer.cpp
+++ b/src/corelibs/U2View/src/ov_phyltree/TreeViewer.cpp
@@ -1242,20 +1242,6 @@ void TreeViewerUI::changeLabelsAlignment() {
     }
 }
 
-/** Expands every collapsed branch in tree. */
-static void makeLayoutNotCollapsed(TvBranchItem* branch) {
-    CHECK(branch != nullptr, );
-    if (branch->isCollapsed()) {
-        branch->toggleCollapsedState();
-    }
-    QList<QGraphicsItem*> childItems = branch->childItems();
-    for (auto child : qAsConst(childItems)) {
-        if (auto childBranch = dynamic_cast<TvBranchItem*>(child)) {
-            makeLayoutNotCollapsed(childBranch);
-        }
-    }
-}
-
 /** Recalculates distanceToViewScale, minDistance, maxDistance. */
 static double computeDistanceToViewScale(TvRectangularBranchItem* rectRoot) {
     static constexpr int DEFAULT_MAX_WIDTH_PER_BRANCH = 500;


### PR DESCRIPTION
The function is unused and we have Clang compiler warning (a red Warnings build)