### PR TITLE
Ugene 7567 r 47.0

### DIFF
--- a/src/plugins/external_tool_support/src/ExternalToolSupportSettings.cpp
+++ b/src/plugins/external_tool_support/src/ExternalToolSupportSettings.cpp
@@ -71,10 +71,10 @@ void ExternalToolSupportSettings::loadExternalToolsFromAppConfig() {
         QString toolIndex = QString::number(i);
         QString id = settings->getValue(PREFIX_EXTERNAL_TOOL_ID + toolIndex, QVariant(""), true).toString();
         QString path = settings->getValue(PREFIX_EXTERNAL_TOOL_PATH + toolIndex, QVariant(""), true, true).toString();
-        bool isValid = settings->getValue(PREFIX_EXTERNAL_TOOL_IS_VALID + toolIndex, QVariant(false), true).toBool();
-        bool isChecked = settings->getValue(PREFIX_EXTERNAL_TOOL_IS_CHECKED + toolIndex, QVariant(false), true).toBool();
-        QString version = settings->getValue(PREFIX_EXTERNAL_TOOL_VERSION + toolIndex, QVariant("unknown"), true).toString();
-        StrStrMap additionalInfo = settings->getValue(PREFIX_EXTERNAL_TOOL_ADDITIONAL_INFO + toolIndex, QVariant::fromValue<StrStrMap>(StrStrMap()), true).value<StrStrMap>();
+        bool isValid = settings->getValue(PREFIX_EXTERNAL_TOOL_IS_VALID + toolIndex, QVariant(false), true, true).toBool();
+        bool isChecked = settings->getValue(PREFIX_EXTERNAL_TOOL_IS_CHECKED + toolIndex, QVariant(false), true, true).toBool();
+        QString version = settings->getValue(PREFIX_EXTERNAL_TOOL_VERSION + toolIndex, QVariant("unknown"), true, true).toString();
+        StrStrMap additionalInfo = settings->getValue(PREFIX_EXTERNAL_TOOL_ADDITIONAL_INFO + toolIndex, QVariant::fromValue<StrStrMap>(StrStrMap()), true, true).value<StrStrMap>();
         ExternalTool* tool = AppContext::getExternalToolRegistry()->getById(id);
         if (tool != nullptr) {
             tool->setPath(path);
@@ -99,12 +99,12 @@ void ExternalToolSupportSettings::saveExternalToolsToAppConfig() {
             ExternalTool* tool = externalToolList[i];
             settings->setValue(PREFIX_EXTERNAL_TOOL_ID + toolIndex, tool->getId(), true);
             settings->setValue(PREFIX_EXTERNAL_TOOL_PATH + toolIndex, tool->getPath(), true, true);
-            settings->setValue(PREFIX_EXTERNAL_TOOL_IS_VALID + toolIndex, tool->isValid(), true);
-            settings->setValue(PREFIX_EXTERNAL_TOOL_IS_CHECKED + toolIndex, tool->isChecked(), true);
-            settings->setValue(PREFIX_EXTERNAL_TOOL_VERSION + toolIndex, tool->getVersion(), true);
+            settings->setValue(PREFIX_EXTERNAL_TOOL_IS_VALID + toolIndex, tool->isValid(), true, true);
+            settings->setValue(PREFIX_EXTERNAL_TOOL_IS_CHECKED + toolIndex, tool->isChecked(), true, true);
+            settings->setValue(PREFIX_EXTERNAL_TOOL_VERSION + toolIndex, tool->getVersion(), true, true);
             StrStrMap additionalInfo = tool->getAdditionalInfo();
             if (!additionalInfo.isEmpty()) {
-                settings->setValue(PREFIX_EXTERNAL_TOOL_ADDITIONAL_INFO + toolIndex, QVariant::fromValue<StrStrMap>(additionalInfo), true);
+                settings->setValue(PREFIX_EXTERNAL_TOOL_ADDITIONAL_INFO + toolIndex, QVariant::fromValue<StrStrMap>(additionalInfo), true, true);
             }
         } else {
             settings->remove(PREFIX_EXTERNAL_TOOL_ID + toolIndex);


### PR DESCRIPTION
Поправил доп. флаги для внешних инструментов, теперь они тоже зависят от пути инструмента.
То что Эвелина писала в таблице
>  /usr/bin/perl тоже должен обнуляться? Он по логике не является pathValue.

Мне кажется перл ничем не отличается от любого другого инструмента и может быть в системе в нескольких версиях и так же может быть различным в различных установленных юджинах. Поэтому думаю что по этому поводу ничего не надо менять.