### PR TITLE
fix: lack cstdint

### DIFF
--- a/src/libs_3rdparty/breakpad/src/client/linux/handler/minidump_descriptor.h
+++ b/src/libs_3rdparty/breakpad/src/client/linux/handler/minidump_descriptor.h
@@ -34,6 +34,7 @@
 #include <sys/types.h>
 
 #include <string>
+#include <cstdint>
 
 #include "client/linux/handler/microdump_extra_info.h"
 #include "common/using_std_string.h"


### PR DESCRIPTION
 - gcc: `13.1.1 20230429`

error reports here

```
In file included from src/client/linux/handler/minidump_descriptor.cc:32:
src/client/linux/handler/minidump_descriptor.h:115:3: error: ‘uintptr_t’ does not name a type
  115 |   uintptr_t address_within_principal_mapping() const {
      |   ^~~~~~~~~
src/client/linux/handler/minidump_descriptor.h:40:1: note: ‘uintptr_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   39 | #include "common/using_std_string.h"
  +++ |+#include <cstdint>
   40 | 
src/client/linux/handler/minidump_descriptor.h:119:7: error: ‘uintptr_t’ has not been declared
  119 |       uintptr_t address_within_principal_mapping) {
      |       ^~~~~~~~~
src/client/linux/handler/minidump_descriptor.h:171:3: error: ‘uintptr_t’ does not name a type
  171 |   uintptr_t address_within_principal_mapping_;
      |   ^~~~~~~~~
```