### PR TITLE
Close write channel for an external tool to avoid the tool waiting for an input

### DIFF
--- a/src/corelibs/U2Core/src/tasks/ExternalToolRunTask.cpp
+++ b/src/corelibs/U2Core/src/tasks/ExternalToolRunTask.cpp
@@ -118,6 +118,7 @@ void ExternalToolRunTask::run() {
         }
         return;
     }
+    externalToolProcess->closeWriteChannel();
     while (!externalToolProcess->waitForFinished(1000)) {
         if (isCanceled()) {
             killProcess(externalToolProcess);


### PR DESCRIPTION
This is a blocker for kalign3 tool integration as an external tool

Kalign binary awaits for all available input when run with QProcess and never finishes.

Closing the input stream for the tool makes it complete successfully.