### PR TITLE
UGENE-7904 CMD crash handler version could be shown instead of GUI one

### DIFF
--- a/src/corelibs/U2Private/src/crash_handler/CrashHandler.cpp
+++ b/src/corelibs/U2Private/src/crash_handler/CrashHandler.cpp
@@ -21,6 +21,7 @@
 
 #include "CrashHandler.h"
 
+#include <QApplication>
 #include <QTextStream>
 
 #include <U2Core/AppContext.h>
@@ -227,9 +228,15 @@ void CrashHandler::runMonitorProcess(const CrashHandlerArgsHelper& helper) {
     const QString path = AppContext::getWorkingDirectoryPath() + "/ugenem.exe";
 #endif
 
+    auto args = helper.getArguments();
+    if (qobject_cast<QApplication*>(qApp) != nullptr) {
+        // See ugenem -> main.cpp -> useGui
+        args << "--use-gui";
+    }
+
     static QMutex mutex;
     QMutexLocker lock(&mutex);
-    QProcess::startDetached(path, helper.getArguments());
+    QProcess::startDetached(path, args);
 }
 
 void CrashHandler::getSubTasks(Task* t, QString& list, int lvl) {

--- a/src/ugenem/src/main.cpp
+++ b/src/ugenem/src/main.cpp
@@ -42,11 +42,8 @@ QString loadReport(int argc, char* argv[]) {
 int main(int argc, char* argv[]) {
     bool useGui = true;
 #if defined(Q_OS_UNIX)
-    useGui = (getenv("DISPLAY") != 0);
-    if (!useGui && argc == 1) {
-        printf("Use \"ugeneui\" to start Unipro UGENE graphical interface or \"ugenecl\" to use the command-line interface.");
-        return 1;
-    }
+    // See CrashHandler::runMonitorProcess
+    useGui = QString(argv[argc - 1]) == "--use-gui";
 #endif
 
     QApplication a(argc, argv, useGui);


### PR DESCRIPTION
Read issue for details. Tested on ugene-cuda, ugene-macbook-1, ugene-macbook-2 and my Windows station