### PR TITLE
UGENE-7910 SAFE_POINT on adding enzymes in Site Restriction dialog

### DIFF
--- a/src/plugins/enzymes/src/FindEnzymesDialog.cpp
+++ b/src/plugins/enzymes/src/FindEnzymesDialog.cpp
@@ -267,6 +267,8 @@ void EnzymesSelectorWidget::setEnzymesList(const QList<SEnzymeData>& enzymes) {
     connect(tree, SIGNAL(itemChanged(QTreeWidgetItem*, int)), SLOT(sl_itemChanged(QTreeWidgetItem*, int)));
     connect(tree, &QTreeWidget::itemSelectionChanged, this, [this]() {
         auto item = tree->currentItem();
+        CHECK(item != nullptr, );
+
         EnzymeTreeItem* ei = dynamic_cast<EnzymeTreeItem*>(item);
         EnzymeGroupTreeItem* gi = dynamic_cast<EnzymeGroupTreeItem*>(item);
         if (ei != nullptr) {


### PR DESCRIPTION
No accurate scenario, it happens if you click tree widget in some weird way (difficult to reproduce, just sometimes it happens), so I didn't write a GUI test.