### PR TITLE
UGENE-7908 Enzyme is found, but shouldn't be

### DIFF
--- a/src/corelibs/U2Algorithm/src/misc/EnzymeModel.cpp
+++ b/src/corelibs/U2Algorithm/src/misc/EnzymeModel.cpp
@@ -39,4 +39,27 @@ const QString EnzymeSettings::MIN_HIT_VALUE("plugin_enzymes/min_hit_value");
 const QString EnzymeSettings::MAX_RESULTS("plugin_enzymes/max_results");
 const QString EnzymeSettings::COMMON_ENZYMES("ClaI,BamHI,BglII,DraI,EcoRI,EcoRV,HindIII,PstI,SalI,SmaI,XmaI");
 
+int EnzymeData::getFullLength() const {
+    int leadingNsNumber = 0;
+    int trailingNsNumber = 0;
+    int seqSize = seq.size();
+    if (cutDirect != ENZYME_CUT_UNKNOWN) {
+        if (cutDirect < 0) {
+            leadingNsNumber = qAbs(cutDirect);
+        } else if (cutDirect > seqSize) {
+            trailingNsNumber = cutDirect - seqSize;
+        }
+    }
+    if (cutComplement != ENZYME_CUT_UNKNOWN) {
+        if (cutComplement < 0) {
+            trailingNsNumber = qMax(trailingNsNumber, qAbs(cutComplement));
+        } else if (cutComplement > seqSize) {
+            leadingNsNumber = qMax(leadingNsNumber, cutComplement - seqSize);
+        }
+    }
+
+    return leadingNsNumber + seqSize + trailingNsNumber;
+}
+
+
 }  // namespace U2

--- a/src/corelibs/U2Algorithm/src/misc/EnzymeModel.h
+++ b/src/corelibs/U2Algorithm/src/misc/EnzymeModel.h
@@ -113,6 +113,17 @@ public:
     bool nondegenerate = false;
 
     static constexpr const char UNDEFINED_BASE = 'N';
+
+    /*
+     * Calculates full enzyme length (with leading and trailing N).
+     * For example, "AbaSI" has only one defined nucleotide, but 11 trailing N's:
+     * 5'  C NNNNNNNNN NN 3'
+     * 3'  G NNNNNNNNN    5'
+     * Which means, that sequence length is 1, but full enzyme length is 1 + 11 = 12.
+     * \return Returns full enzyme length - leading N's number + enzyme length + trailing N's number
+     */
+    int getFullLength() const;
+
 };
 
 typedef QSharedDataPointer<EnzymeData> SEnzymeData;

--- a/src/plugins/enzymes/src/EnzymesTests.cpp
+++ b/src/plugins/enzymes/src/EnzymesTests.cpp
@@ -211,6 +211,7 @@ QList<Task*> GTest_FindEnzymes::onSubTaskFinished(Task* subTask) {
     cfg.minHitCount = minHits;
     cfg.maxHitCount = maxHits;
     cfg.excludedRegions = excludedRegions;
+    cfg.circular = seqObj->isCircular();
 
     FindEnzymesToAnnotationsTask* t = new FindEnzymesToAnnotationsTask(aObj, seqObj->getSequenceRef(), enzymesToSearch, cfg);
     res.append(t);

--- a/src/plugins/enzymes/src/FindEnzymesAlgorithm.h
+++ b/src/plugins/enzymes/src/FindEnzymesAlgorithm.h
@@ -46,7 +46,7 @@ public:
      * Callback, which handle FindEnzymesAlgorithm::run(...) result finding.
      *
      * \param pos Start position of enzyme, which was found.
-     * \param enzyme The enzyme, wich was found.
+     * \param enzyme The enzyme, which was found.
      * \param strand Strand (direct of reverse-complement) the enzyme was found on.
      * \param stop This argument signals to FindEnzymesAlgorithm::run(...) to stop enzymes searching (without errors or cancels).
     **/
@@ -115,25 +115,6 @@ public:
                 CHECK(!stop, );
             }
             CHECK_OP(ti, );
-        }
-        if (sequence.circular) {
-            if (region.startPos + region.length == sequence.length()) {
-                QByteArray buf;
-                const QByteArray& dnaseq = sequence.seq;
-                int size = plen - 1;
-                int startPos = dnaseq.length() - size;
-                buf.append(dnaseq.mid(startPos));
-                buf.append(dnaseq.mid(0, size));
-                for (int s = 0; s < size; s++) {
-                    bool match = matchSite(buf.constData() + s, pattern, plen, unknownChar, fn);
-                    if (match) {
-                        bool stop = false;
-                        resultListener->onResult(resultPosShift + s + startPos, enzyme, stand, stop);
-                        CHECK(!stop, );
-                    }
-                    CHECK_OP(ti, );
-                }
-            }
         }
     }
 

--- a/src/plugins/enzymes/src/FindEnzymesTask.cpp
+++ b/src/plugins/enzymes/src/FindEnzymesTask.cpp
@@ -257,9 +257,10 @@ void FindSingleEnzymeTask::prepare() {
     SequenceDbiWalkerConfig sequenceWalkerConfig;
     sequenceWalkerConfig.seqRef = sequenceObjectRef;
     sequenceWalkerConfig.range = region;
-    sequenceWalkerConfig.chunkSize = qMax(enzyme->seq.size(), chunkSize);
+    int enzymeFullLength = enzyme->getFullLength();
+    sequenceWalkerConfig.chunkSize = qMax(enzymeFullLength, chunkSize);
     sequenceWalkerConfig.lastChunkExtraLen = sequenceWalkerConfig.chunkSize / 2;
-    sequenceWalkerConfig.overlapSize = enzyme->seq.size() - 1;
+    sequenceWalkerConfig.overlapSize = enzymeFullLength - 1;
     sequenceWalkerConfig.walkCircular = isCircular;
     sequenceWalkerConfig.walkCircularDistance = sequenceWalkerConfig.overlapSize;
 

--- a/tests/enzymes/dna_exact/test013.xml
+++ b/tests/enzymes/dna_exact/test013.xml
@@ -1,0 +1,10 @@
+<multi-test>
+
+    <load-document index="doc" url="enzymes/7908.gb" io="local_file" format="genbank"/>
+
+    <find-object-by-name index="seq" doc="doc" name="7908" type="OT_SEQUENCE"/>
+
+    <find-enzymes url="enzymes/2023_02_25.bairoch.gz" sequence="seq" enzymes="Esp3I"
+                  result="" expected-error="Enzymes selection is not found" />
+
+</multi-test>


### PR DESCRIPTION
`SequenceDbiWalkerTask` appends a beginning of sequence as a postfix to the whole sequence if `SequenceDbiWalkerConfig::walkCircular` is set to true - this simulates that our sequence is circular. From the over hand, we do the same thing [here](https://github.com/ugeneunipro/ugene/blob/d91b87af14a470b27c5af906f6000d3b8c803933/src/plugins/enzymes/src/FindEnzymesAlgorithm.h#L126) when we are already calculating enzymes on junction point. I decided to remove this handling from `SequenceDbiWalkerTask` because when you are looking to `FindEnzymesAlgorithm::run(...)` it is not clear where this postfix already come from, you need to investigate it for a while.