### PR TITLE
UGENE-7924 Incorrect timeout for Query NCBI BLAST database...

### DIFF
--- a/src/plugins/remote_blast/src/HttpRequestBLAST.cpp
+++ b/src/plugins/remote_blast/src/HttpRequestBLAST.cpp
@@ -111,7 +111,6 @@ void HttpRequestBLAST::sendRequest(const QString& params, const QString& query) 
     SAFE_POINT(rTask != nullptr, "Not a RemoteBlastHttpRequestTask", );
     int checkTimeSeconds = qMax(5, estimatedRunTimeSeconds / 10);
     rTask->resetProgress();
-    rTask->setTimeOut(10 * estimatedRunTimeSeconds);
     int iteration = 0;
     int startTime = QDateTime::currentSecsSinceEpoch();
     do {


### PR DESCRIPTION
Also, I've got a suspicion, that test **remote-request/test_0002.xml** started to fail because of this line. But I'm not sure, it could be something else