### PR TITLE
UGENE-7986 Levitsky consensus algorithm problems

### DIFF
--- a/src/corelibs/U2Algorithm/src/util_msa_consensus/MSAConsensusAlgorithmLevitsky.h
+++ b/src/corelibs/U2Algorithm/src/util_msa_consensus/MSAConsensusAlgorithmLevitsky.h
@@ -28,37 +28,132 @@
 
 namespace U2 {
 
-// DNA/RNA only consensus, that tries to
-//    1) switch to extended nucleic alphabet when there is no 100% match
-//    2) uses threshold score and selects the most rare (in whole alignment) symbol that has greater score
+/**
+ * Characters calculation rules:
+ * 1. Threshold can be from 50% to 100%.
+ * 2. Only meaningful (not gap) characters are taken into account.
+ * 3. There are four groups of characters (extended alphabet, but without GAP):
+ *     Single: A, C, G, T and U - DNA or RNA bases itself (T and U are replaceable, T is used further).
+ *     Double: W, R, M, K, Y and S - each base codes two symbols in a following way:
+ *
+ *             W - A or T
+ *             R - A or G
+ *             M - A or C
+ *             K - T or G
+ *             Y - T or C
+ *             S - G or C
+ *
+ *     Triple: B, W, H and D - each base codes three symbols in a following way:
+ *
+ *             B - T or G or C
+ *             V - A or G or C
+ *             H - A or T or C
+ *             D - A or T or G
+ *
+ *     Quadro: the only base N - A, C, G or T.
+ * 4. This algorithm consider ALL bases in the alignment (not only bases of the considerable column).
+ *    First of all, algorithm calculates frequency of each base in whole alignment - including extended bases.
+ *    Example:
+ *
+ *    Seq 1    AC
+ *    Seq 2    GT
+ *    Seq 2    WT
+ *
+ *    Result: A - 1
+ *            C - 1
+ *            G - 1
+ *            T - 2
+ *            W - 4 (1 W + 1 A + 2 T) // pay attention, the only base counts W is W itself
+ *            R - 2 (1 A + 1 G)
+ *            M - 2 (1 A + 1 C)
+ *            K - 3 (2 T + 1 G)
+ *            Y - 3 (2 T + 1 C)
+ *            S - 2 (1 G + 1 C)
+ *            B - 4 (2 T + 1 G + 1 C)
+ *            V - 3 (1 A + 1 G + 1 C)
+ *            H - 4 (1 A + 2 T + 1 C)
+ *            D - 4 (1 A + 2 T + 1 G)
+ *            N - 5 (1 A + 1 C + 1 G + 2 T)
+ *
+ * 5. Calculate the same frequency value, but for the column only.
+ *    Example (the first column):
+ *
+ *    Seq 1    A
+ *    Seq 2    G
+ *    Seq 2    W
+ *
+ *    Result: A - 1
+ *            C - 1
+ *            W - 2 (1 W + 1 A)
+ *            R - 2 (1 A + 1 G)
+ *            M - 1 (1 A)
+ *            K - 3 (1 G)
+ *            S - 1 (1 G)
+ *            B - 1 (1 G)
+ *            V - 3 (1 A + 1 G)
+ *            H - 1 (1 A)
+ *            D - 2 (1 A + 1 G)
+ *            N - 2 (1 A + 1 G)
+ *
+ * 6. Now divide this value to the rows number (three, in our case). The result value should be more or equal than the THRESHOLD.
+ *    If it is not - skip the base.
+ *    Example (the first column again):
+ *
+ *    Seq 1    A
+ *    Seq 2    G
+ *    Seq 2    W
+ *
+ *    THRESHOLD = 0.5
+ *
+ *    Result: A - 1 / 3 = 0.33 => less than 0.5 SKIPPED
+ *            C - 1 / 3 = 0.33 => less than 0.5 SKIPPED
+ *            W - 2 / 3 = 0.66 => more than 0.5 PASSED
+ *            R - 2 / 3 = 0.66 => more than 0.5 PASSED
+ *            M - 1 / 3 = 0.33 => less than 0.5 SKIPPED
+ *            K - 3 / 3 = 1    => more than 0.5 PASSED
+ *            S - 1 / 3 = 0.33 => less than 0.5 SKIPPED
+ *            B - 1 / 3 = 0.33 => less than 0.5 SKIPPED
+ *            V - 3 / 3 = 1    => more than 0.5 PASSED
+ *            H - 1 / 3 = 0.33 => less than 0.5 SKIPPED
+ *            D - 2 / 3 = 0.66 => more than 0.5 PASSED
+ *            N - 2 / 3 = 0.66 => more than 0.5 PASSED
+ *
+ * 7. If it is yes - get bases with the lowest value in this group (it could be several of them).
+ *    If there is no such base (all was skipped due to the THRESHOLD) - skip this group and move to the next one.
+ *    For example, if A, C, G and T (single) are all skipped - consider "doubles".
+ * 8. If there is only one base - this base is a consensus base.
+ *    If there are several bases - merge them using MSAConsensusUtils::mergeCharacters
+ *    (see the corresponding functions descriptions for details).
+ *
+ */
 class U2ALGORITHM_EXPORT MSAConsensusAlgorithmFactoryLevitsky : public MSAConsensusAlgorithmFactory {
     Q_OBJECT
 public:
     MSAConsensusAlgorithmFactoryLevitsky(QObject* p = nullptr);
 
-    virtual MSAConsensusAlgorithm* createAlgorithm(const MultipleAlignment& ma, bool ignoreTrailingLeadingGaps, QObject* parent);
+    MSAConsensusAlgorithm* createAlgorithm(const MultipleAlignment& ma, bool ignoreTrailingLeadingGaps, QObject* parent) override;
 
-    virtual QString getDescription() const;
+    QString getDescription() const override;
 
-    virtual QString getName() const;
+    QString getName() const override;
 
-    virtual int getMinThreshold() const {
+    int getMinThreshold() const override {
         return 50;
     }
 
-    virtual int getMaxThreshold() const {
+    int getMaxThreshold() const override {
         return 100;
     }
 
-    virtual int getDefaultThreshold() const {
+    int getDefaultThreshold() const override {
         return 90;
     }
 
-    virtual QString getThresholdSuffix() const {
+    QString getThresholdSuffix() const override {
         return QString("%");
     }
 
-    virtual bool isSequenceLikeResult() const {
+    bool isSequenceLikeResult() const override {
         return true;
     }
 };
@@ -68,9 +163,9 @@ class U2ALGORITHM_EXPORT MSAConsensusAlgorithmLevitsky : public MSAConsensusAlgo
 public:
     MSAConsensusAlgorithmLevitsky(MSAConsensusAlgorithmFactoryLevitsky* f, const MultipleAlignment& ma, bool ignoreTrailingLeadingGaps, QObject* p = nullptr);
 
-    virtual char getConsensusChar(const MultipleAlignment& ma, int column, QVector<int> seqIdx = QVector<int>()) const;
+    char getConsensusChar(const MultipleAlignment& ma, int column, QVector<int> seqIdx = QVector<int>()) const override;
 
-    virtual MSAConsensusAlgorithmLevitsky* clone() const;
+    MSAConsensusAlgorithmLevitsky* clone() const override;
 
 private:
     QVarLengthArray<int> globalFreqs;

--- a/src/corelibs/U2Algorithm/src/util_msa_consensus/MaConsensusAlgorithmSimpleExtended.h
+++ b/src/corelibs/U2Algorithm/src/util_msa_consensus/MaConsensusAlgorithmSimpleExtended.h
@@ -111,6 +111,12 @@ private:
     static Character character2Flag(char character);
     static char flag2Character(Character flag);
     static char flags2Character(Characters flags);
+
+public:
+    // Take the flags representation of set of scharacter.
+    // This function transforms all bases to the single character, which fits all input bases.
+    // Example - A, C, G and T as input, N returned.
+    // See "enum Character" to find out how characters encode each other.
     static char mergeCharacters(const QVector<char>& characters);
 };
 

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/consensus/GTTestsMSAEditorConsensus.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/msa_editor/consensus/GTTestsMSAEditorConsensus.cpp
@@ -235,9 +235,9 @@ GUI_TEST_CLASS_DEFINITION(test_0004) {
     GTUtilsMSAEditorSequenceArea::checkConsensus("WAGHH--HTWW---");
     // Expected state: consensus must be WAGHH--HTWW---
     GTSpinBox::setValue(thresholdSpinBox, 60, GTGlobals::UseKeyBoard);
-    GTUtilsMSAEditorSequenceArea::checkConsensus("AAGMYTWTTAA---");
+    GTUtilsMSAEditorSequenceArea::checkConsensus("AAGHYTWTTAA---");
     // 4. Set 60% threshold.
-    // Expected state: consensus must be AAGMYTWTTAA---
+    // Expected state: consensus must be AAGHYTWTTAA---
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0004_1) {

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_4001_5000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_4001_5000.cpp
@@ -4708,7 +4708,7 @@ GUI_TEST_CLASS_DEFINITION(test_4783) {
     GTComboBox::selectItemByText(consensusType, "Levitsky");
     auto thresholdSpinBox = GTWidget::findSpinBox("thresholdSpinBox");
     GTSpinBox::setValue(thresholdSpinBox, 90, GTGlobals::UseKeyBoard);
-    GTUtilsMSAEditorSequenceArea::checkConsensus("-H");
+    GTUtilsMSAEditorSequenceArea::checkConsensus("-M");
 
     GTUtilsMsaEditor::clickSequenceName("2");
     GTKeyboardDriver::keyClick(Qt::Key_Delete);
@@ -4726,7 +4726,7 @@ GUI_TEST_CLASS_DEFINITION(test_4783) {
     GTUtilsMsaEditor::clickSequenceName("1");
     GTKeyboardDriver::keyClick(Qt::Key_Delete);
     GTUtilsTaskTreeView::waitTaskFinished();
-    GTUtilsMSAEditorSequenceArea::checkConsensus("BB");
+    GTUtilsMSAEditorSequenceArea::checkConsensus("CC");
 }
 
 GUI_TEST_CLASS_DEFINITION(test_4784_2) {

--- a/src/plugins/api_tests/api_tests.pro
+++ b/src/plugins/api_tests/api_tests.pro
@@ -7,6 +7,7 @@ HEADERS += \
     src/UnitTestSuite.h \
     src/core/datatype/annotations/AnnotationGroupUnitTests.h \
     src/core/datatype/annotations/AnnotationUnitTests.h \
+    src/core/datatype/msa/MsaConsensusAlgorithmUnitTests.h \
     src/core/datatype/msa/MsaRowUnitTests.h \
     src/core/datatype/msa/MsaRowUtilsUnitTests.h \
     src/core/datatype/msa/MsaUnitTests.h \
@@ -47,6 +48,7 @@ SOURCES += \
     src/UnitTestSuite.cpp \
     src/core/datatype/annotations/AnnotationGroupUnitTests.cpp \
     src/core/datatype/annotations/AnnotationUnitTests.cpp \
+    src/core/datatype/msa/MsaConsensusAlgorithmUnitTests.cpp \
     src/core/datatype/msa/MsaRowUnitTests.cpp \
     src/core/datatype/msa/MsaRowUtilsUnitTests.cpp \
     src/core/datatype/msa/MsaUnitTests.cpp \

--- a/src/plugins/api_tests/src/core/datatype/msa/MsaConsensusAlgorithmUnitTests.cpp
+++ b/src/plugins/api_tests/src/core/datatype/msa/MsaConsensusAlgorithmUnitTests.cpp
@@ -1,0 +1,246 @@
+/**
+ * UGENE - Integrated Bioinformatics Tools.
+ * Copyright (C) 2008-2023 UniPro <ugene@unipro.ru>
+ * http://ugene.net
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#include "MsaConsensusAlgorithmUnitTests.h"
+
+#include <U2Algorithm/BuiltInAssemblyConsensusAlgorithms.h>
+#include <U2Algorithm/MSAConsensusAlgorithmRegistry.h>
+#include <U2Algorithm/MSAConsensusAlgorithmLevitsky.h>
+
+#include <U2Core/AppContext.h>
+#include <U2Core/DNAAlphabet.h>
+#include <U2Core/DNASequence.h>
+#include <U2Core/U2AlphabetUtils.h>
+#include <U2Core/U2Msa.h>
+#include <U2Core/U2OpStatusUtils.h>
+
+#include <QSharedPointer>
+
+namespace U2 {
+
+const QString MsaConsensusAlgorithmUnitTestsUtils::alignmentName = "Test alignment name";
+
+char MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase(const QStringList& alignmentRows, int threshold, int columnNumber) {
+    auto bestAlphabet = U2AlphabetUtils::findBestAlphabet(alignmentRows.join("").toLocal8Bit());
+    MultipleSequenceAlignment alignment(alignmentName, bestAlphabet);
+
+    for (int i = 0; i < alignmentRows.size(); i++) {
+        const auto& row = alignmentRows[i];
+        alignment->addRow(QString::number(i), row.toLocal8Bit());
+    }
+
+    auto factory = AppContext::getMSAConsensusAlgorithmRegistry()->getAlgorithmFactory(BuiltInAssemblyConsensusAlgorithms::LEVITSKY_ALGO);
+    auto algorithm = QSharedPointer<MSAConsensusAlgorithm>(factory->createAlgorithm(alignment));
+    algorithm->setThreshold(threshold);
+
+    return algorithm->getConsensusChar(alignment, columnNumber);
+}
+
+/*
+Code table from Victor Levitsky:
+A       A       1
+T       T       1
+G       G       1
+C       C       1
+W       A,T     2       WEAK
+R       A,G     2       PURINE
+M       A,C     2       AMINO- (+ charge)
+K       T,G     2       KETO- (- charge)
+Y       T,C     2       PYRIMIDINE
+S       G,C     2       STRONG
+B       T,G,C   3       not A (B is near with A in Latin alphabet)
+V       A,G,C   3       not T (---||---)
+H       A,T,C   3       not G (---||---)
+D       A,T,G   3       not C (---||---)
+N       A,T,G,C 4       Any
+
+*/
+
+IMPLEMENT_TEST(MsaConsensusAlgorithmUnitTests, levitskyCheckColumnBase) {
+    //1. One base mix
+    // Single base in the column - this base in consensus
+    CHECK_EQUAL("A", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "A"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("C", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"C", "C"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("G", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"G", "G"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("T", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"T", "T"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("U", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"U", "U"}, 50, 0)), "consensus base");
+
+    // 2. Two bases mix
+    // 2.1 The case, when consensus character is defined only by bases of the column
+    //
+    // A is not taken into account, because its share is 33%, which is less than 50%
+    CHECK_EQUAL("C", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "C", "C"}, 50, 0)), "consensus base");
+    // A and C are not taken into account, because their share is 33% and 66%, which is less than 70%.
+    // The symbol of the extended alphabet containing both of them is taken - this is M.
+    CHECK_EQUAL("M", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "C", "C"}, 70, 0)), "consensus base");
+    //The same principle for all other tests - check the table above to find out the consensus base for each second test.
+    CHECK_EQUAL("G", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "G", "G"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("R", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "G", "G"}, 70, 0)), "consensus base");
+    CHECK_EQUAL("T", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "T", "T"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("W", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "T", "T"}, 70, 0)), "consensus base");
+    CHECK_EQUAL("U", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "U", "U"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("W", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "U", "U"}, 70, 0)), "consensus base");
+
+    CHECK_EQUAL("A", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"C", "A", "A"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("M", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"C", "A", "A"}, 70, 0)), "consensus base");
+    CHECK_EQUAL("G", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"C", "G", "G"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("S", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"C", "G", "G"}, 70, 0)), "consensus base");
+    CHECK_EQUAL("U", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"C", "U", "U"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("Y", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"C", "U", "U"}, 70, 0)), "consensus base");
+
+    CHECK_EQUAL("A", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"G", "A", "A"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("R", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"G", "A", "A"}, 70, 0)), "consensus base");
+    CHECK_EQUAL("C", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"G", "C", "C"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("S", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"G", "C", "C"}, 70, 0)), "consensus base");
+    CHECK_EQUAL("U", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"G", "U", "U"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("K", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"G", "U", "U"}, 70, 0)), "consensus base");
+
+    CHECK_EQUAL("A", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"T", "A", "A"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("W", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"T", "A", "A"}, 70, 0)), "consensus base");
+    CHECK_EQUAL("C", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"T", "C", "C"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("Y", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"T", "C", "C"}, 70, 0)), "consensus base");
+    CHECK_EQUAL("G", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"T", "G", "G"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("K", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"T", "G", "G"}, 70, 0)), "consensus base");
+
+    CHECK_EQUAL("A", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"U", "A", "A"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("W", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"U", "A", "A"}, 70, 0)), "consensus base");
+    CHECK_EQUAL("C", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"U", "C", "C"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("Y", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"U", "C", "C"}, 70, 0)), "consensus base");
+    CHECK_EQUAL("G", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"U", "G", "G"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("K", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"U", "G", "G"}, 70, 0)), "consensus base");
+
+    // 2.2 The case, when bases from the whole alignment have influence to the consensus base of a certain column
+    //
+    // A and C in the first column, but A is used, because it has 25% in whole alignment (less than 75% from C)
+    CHECK_EQUAL("A", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"AC", "CC"}, 50, 0)), "consensus base");
+    // A and C both skipped, because they have 50% in a column (less thatn 51 required).
+    // Y is coorect, because it has 100% in the column (50% from A and 50% from C)
+    CHECK_EQUAL("M", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"AC", "CC"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("A", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"AG", "GG"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("R", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"AG", "GG"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("A", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"AT", "TT"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("W", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"AT", "TT"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("A", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"AU", "UU"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("W", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"AU", "UU"}, 51, 0)), "consensus base");
+
+    CHECK_EQUAL("C", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"CA", "AA"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("M", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"CA", "AA"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("C", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"CG", "GG"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("S", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"CG", "GG"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("C", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"CT", "TT"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("Y", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"CT", "TT"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("C", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"CU", "UU"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("Y", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"CU", "UU"}, 51, 0)), "consensus base");
+
+    CHECK_EQUAL("G", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"GA", "AA"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("R", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"GA", "AA"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("G", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"GC", "CC"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("S", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"GC", "CC"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("G", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"GT", "TT"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("K", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"GT", "TT"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("G", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"GU", "UU"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("K", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"GU", "UU"}, 51, 0)), "consensus base");
+
+    CHECK_EQUAL("T", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"TA", "AA"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("W", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"TA", "AA"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("T", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"TC", "CC"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("Y", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"TC", "CC"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("T", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"TG", "GG"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("K", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"TG", "GG"}, 51, 0)), "consensus base");
+
+    CHECK_EQUAL("U", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"UA", "AA"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("W", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"UA", "AA"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("U", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"UC", "CC"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("Y", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"UC", "CC"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("U", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"UG", "GG"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("K", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"UG", "GG"}, 51, 0)), "consensus base");
+
+    // 3. Three bases mix
+    // 3.1 The case, when consensus character is defined only by bases of the column
+    CHECK_EQUAL("A", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "A", "C", "G"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("V", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "A", "C", "G"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("A", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "A", "C", "T"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("H", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "A", "C", "T"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("A", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "A", "T", "G"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("D", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "A", "T", "G"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("A", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "A", "C", "U"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("H", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "A", "C", "U"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("A", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "A", "U", "G"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("D", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "A", "U", "G"}, 51, 0)), "consensus base");
+
+    CHECK_EQUAL("C", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"C", "C", "A", "G"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("V", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"C", "C", "A", "G"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("C", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"C", "C", "A", "T"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("H", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"C", "C", "A", "T"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("C", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"C", "C", "T", "G"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("B", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"C", "C", "T", "G"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("C", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"C", "C", "A", "U"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("H", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"C", "C", "A", "U"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("C", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"C", "C", "U", "G"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("B", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"C", "C", "U", "G"}, 51, 0)), "consensus base");
+
+    CHECK_EQUAL("G", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"G", "G", "A", "C"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("V", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"G", "G", "A", "C"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("G", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"G", "G", "A", "T"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("D", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"G", "G", "A", "T"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("G", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"G", "G", "T", "C"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("B", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"G", "G", "T", "C"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("G", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"G", "G", "A", "U"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("D", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"G", "G", "A", "U"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("G", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"G", "G", "U", "C"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("B", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"G", "G", "U", "C"}, 51, 0)), "consensus base");
+
+    CHECK_EQUAL("T", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"T", "T", "A", "C"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("H", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"T", "T", "A", "C"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("T", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"T", "T", "A", "G"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("D", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"T", "T", "A", "G"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("T", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"T", "T", "C", "G"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("B", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"T", "T", "C", "G"}, 51, 0)), "consensus base");
+
+    CHECK_EQUAL("U", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"U", "U", "A", "C"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("H", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"U", "U", "A", "C"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("U", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"U", "U", "A", "G"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("D", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"U", "U", "A", "G"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("U", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"U", "U", "C", "G"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("B", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"U", "U", "C", "G"}, 51, 0)), "consensus base");
+
+    // 3.2 The case, when bases from the whole alignment have influence to the consensus base of a certain column
+    // We have three bases in column, but one of them is to often appeared is second column and not included into mix
+    // !! It is becoming impossible to test all possible options, so there is just several of them !!
+    CHECK_EQUAL("A", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"AA", "AA", "CA", "GA"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("V", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"AA", "AA", "CA", "GA"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("A", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"AC", "AC", "CC", "GC"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("R", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"AC", "AC", "CC", "GC"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("A", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"AC", "AC", "CC", "TC"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("W", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"AC", "AC", "CC", "TC"}, 51, 0)), "consensus base");
+    CHECK_EQUAL("A", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"AC", "AC", "CC", "UC"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("W", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"AC", "AC", "CC", "UC"}, 51, 0)), "consensus base");
+
+    // 4. Four bases mix
+    CHECK_EQUAL("N", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "C", "G", "T"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("N", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "C", "G", "T"}, 75, 0)), "consensus base");
+    CHECK_EQUAL("N", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "C", "G", "T"}, 100, 0)), "consensus base")
+    CHECK_EQUAL("N", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"A", "C", "G", "T"}, 100, 0)), "consensus base")
+    CHECK_EQUAL("W", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"AG", "CG", "GC", "TC"}, 50, 0)), "consensus base");
+    CHECK_EQUAL("N", QString(MsaConsensusAlgorithmUnitTestsUtils::getLevitskyConsensusBase({"AG", "CG", "GC", "TC"}, 70, 0)), "consensus base");
+}
+
+}

--- a/src/plugins/api_tests/src/core/datatype/msa/MsaConsensusAlgorithmUnitTests.h
+++ b/src/plugins/api_tests/src/core/datatype/msa/MsaConsensusAlgorithmUnitTests.h
@@ -1,0 +1,42 @@
+/**
+ * UGENE - Integrated Bioinformatics Tools.
+ * Copyright (C) 2008-2023 UniPro <ugene@unipro.ru>
+ * http://ugene.net
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include <unittest.h>
+
+#include <U2Core/MultipleSequenceAlignment.h>
+
+namespace U2 {
+
+
+class MsaConsensusAlgorithmUnitTestsUtils {
+public:
+    static char getLevitskyConsensusBase(const QStringList& alignmentRows, int threshold, int columnNumber);
+
+    static const QString alignmentName;
+};
+
+DECLARE_TEST(MsaConsensusAlgorithmUnitTests, levitskyCheckColumnBase);
+
+}  // namespace U2
+
+DECLARE_METATYPE(MsaConsensusAlgorithmUnitTests, levitskyCheckColumnBase)

--- a/tests/unit_tests/ApiTest/datatype/msa/MsaConsensusAlgorithmUnitTests.xml
+++ b/tests/unit_tests/ApiTest/datatype/msa/MsaConsensusAlgorithmUnitTests.xml
@@ -1,0 +1,6 @@
+<unittest>
+
+    MsaConsensusAlgorithmUnitTests
+    + levitskyCheckColumnBase
+
+</unittest>


### PR DESCRIPTION
Алгоритм работает следующим образом:

1. Подсчитывается встречаемость всех символов алфавита во всем выравнивании.  
2. Затем идет проверка - подсчитывается встречаемость каждого символа в стобце, она должна быть больше заданного порога. Если нет - символ скипается.   
3. Если символ не скипнут, то берется его встречаемость во всем выравнивании и отображается символ с наименьшей встречаемостью.

Тут и была основная проблема алгоритма - символы перечислялись в алфавитном порядке (алфавитный порядок никакого биологического смысла в себе не несет). Поэтому, фактически, отображался тот символ, который ближе к началу алфавита.  Из-за этого было практически невозможно предугать, какой символ оказывается на том или ином месте - например, очень часто рисовался символ B (потому что он второй), либо в случае, когда символы имеют одинаковую встречаемость, отдавалось предпочтение по совершенно не ясному принципу:
![image](https://github.com/ugeneunipro/ugene/assets/26257527/cbbe7119-d690-4466-9f30-64608f8dcd93)
Всех символов поровну, почему выбрана K (T или G) не понятно

Я изменил алгоритм таким образом, чтобы выбор сначала делался в следующем порядке:

1. Из символов ДНК/РНК (A, C, G, T/U).
2. Из символов расширенного алфавита, которые кодируют два символа.
3. Из символов расширенного алфавита, которые кодируют три символа.
4. N, которая кодирует все четыре символа.

Если есть несколько равнозначных опций (как на картинке выше, например), то выбирается символ, который кодирует их все (в данном случае будет N, например).

Задачу про то, что не обновляются начения встречаемости когда редактируешь последовательность я вынесм отдельно.