### PR TITLE
UGENE-8026 Levitsky consensus algorithm values are not updated when alignment is being changed

### DIFF
--- a/src/corelibs/U2Algorithm/src/util_msa_consensus/MSAConsensusAlgorithm.h
+++ b/src/corelibs/U2Algorithm/src/util_msa_consensus/MSAConsensusAlgorithm.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include <U2Core/MaModificationInfo.h>
 #include <U2Core/MultipleAlignment.h>
 #include <U2Core/U2Region.h>
 

--- a/src/corelibs/U2Algorithm/src/util_msa_consensus/MSAConsensusAlgorithm.h
+++ b/src/corelibs/U2Algorithm/src/util_msa_consensus/MSAConsensusAlgorithm.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <U2Core/MaModificationInfo.h>
 #include <U2Core/MultipleAlignment.h>
 #include <U2Core/U2Region.h>
 
@@ -100,6 +101,10 @@ public:
     virtual char getConsensusCharAndScore(const MultipleAlignment& ma, int column, int& score) const;
 
     virtual char getConsensusChar(const MultipleAlignment& ma, int column) const = 0;
+
+    virtual void reinitializeData(const MultipleAlignment&) {}
+
+    virtual void recalculateData(const MultipleAlignment&, const MultipleAlignment&, const MaModificationInfo&) {}
 
     virtual MSAConsensusAlgorithm* clone() const = 0;
 

--- a/src/corelibs/U2Algorithm/src/util_msa_consensus/MSAConsensusAlgorithm.h
+++ b/src/corelibs/U2Algorithm/src/util_msa_consensus/MSAConsensusAlgorithm.h
@@ -104,8 +104,6 @@ public:
 
     virtual void reinitializeData(const MultipleAlignment&) {}
 
-    virtual void recalculateData(const MultipleAlignment&, const MultipleAlignment&, const MaModificationInfo&) {}
-
     virtual MSAConsensusAlgorithm* clone() const = 0;
 
     virtual QString getDescription() const {

--- a/src/corelibs/U2Algorithm/src/util_msa_consensus/MSAConsensusAlgorithmLevitsky.cpp
+++ b/src/corelibs/U2Algorithm/src/util_msa_consensus/MSAConsensusAlgorithmLevitsky.cpp
@@ -306,15 +306,26 @@ void MSAConsensusAlgorithmLevitsky::reinitializeData(const MultipleAlignment& ma
 }
 
 void MSAConsensusAlgorithmLevitsky::recalculateData(const MultipleAlignment& oldMa, const MultipleAlignment& newMa, const MaModificationInfo& mi) {
-    // It looks like a bug - sometimes @mi.alignmentLengthChanged is true,
-    // but length hasn't been changed
-    // TODO: fix it
-    if (mi.alignmentLengthChanged && oldMa->getLength() != newMa->getLength()) {
-        // If alignment length has been changed, we need to recalculate all alignment
-        // TODO: improve MaModificationInfo and provide additional info and prevent general recalculation
+    // When we recalculate a row, we first do @unregisterHit() for all bases, and then @registerHit().
+    // That means, that we need to do 2 times more ticks for a row if we recalculate it than if we just clean in and do @registerHit() from scratch.
+    // That means, that we have a calculation time profit only if we recalculate half as many sequences as in the entire alignment.
+    // Otherwise, it is better just to recalculate the whole alignment.
+    if (mi.modifiedRowIds.size() > newMa->getRowCount() / 2) {
         reinitializeData(newMa);
         return;
     }
+
+    //return;
+    // It looks like a bug - sometimes @mi.alignmentLengthChanged is true,
+    // but length hasn't been changed
+    // TODO: fix it
+    //if (mi.alignmentLengthChanged && oldMa->getLength() != newMa->getLength()) {
+        // If alignment length has been changed, we need to recalculate all alignment
+        // This code is unreachable until the problem above is fixed
+        // TODO: improve MaModificationInfo and provide additional info and prevent general recalculation
+        //reinitializeData(newMa);
+        //return;
+    //}
 
     // If alphabet has been changed by clicking "--> DNA"/"--> RNA"/ buttons,
     // we could easily just switch 'T' and 'U' counters, but, for now,

--- a/src/corelibs/U2Algorithm/src/util_msa_consensus/MSAConsensusAlgorithmLevitsky.cpp
+++ b/src/corelibs/U2Algorithm/src/util_msa_consensus/MSAConsensusAlgorithmLevitsky.cpp
@@ -22,7 +22,6 @@
 #include "MSAConsensusAlgorithmLevitsky.h"
 
 #include <U2Core/MultipleSequenceAlignment.h>
-#include <U2Core/U2OpStatusUtils.h>
 
 namespace U2 {
 

--- a/src/corelibs/U2Algorithm/src/util_msa_consensus/MSAConsensusAlgorithmLevitsky.h
+++ b/src/corelibs/U2Algorithm/src/util_msa_consensus/MSAConsensusAlgorithmLevitsky.h
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <QVarLengthArray>
-#include <QList>
 
 #include "BuiltInConsensusAlgorithms.h"
 #include "MSAConsensusAlgorithm.h"

--- a/src/corelibs/U2Algorithm/src/util_msa_consensus/MSAConsensusAlgorithmLevitsky.h
+++ b/src/corelibs/U2Algorithm/src/util_msa_consensus/MSAConsensusAlgorithmLevitsky.h
@@ -75,8 +75,6 @@ public:
 
     void reinitializeData(const MultipleAlignment& ma) override;
 
-    void recalculateData(const MultipleAlignment& oldMa, const MultipleAlignment& newMa, const MaModificationInfo& mi) override;
-
 private:
     QVarLengthArray<int> globalFreqs;
 };

--- a/src/corelibs/U2Algorithm/src/util_msa_consensus/MSAConsensusAlgorithmLevitsky.h
+++ b/src/corelibs/U2Algorithm/src/util_msa_consensus/MSAConsensusAlgorithmLevitsky.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <QVarLengthArray>
+#include <QList>
 
 #include "BuiltInConsensusAlgorithms.h"
 #include "MSAConsensusAlgorithm.h"
@@ -71,6 +72,10 @@ public:
     char getConsensusChar(const MultipleAlignment& ma, int column) const override;
 
     MSAConsensusAlgorithmLevitsky* clone() const override;
+
+    void reinitializeData(const MultipleAlignment& ma) override;
+
+    void recalculateData(const MultipleAlignment& oldMa, const MultipleAlignment& newMa, const MaModificationInfo& mi) override;
 
 private:
     QVarLengthArray<int> globalFreqs;

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusCache.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusCache.cpp
@@ -35,7 +35,7 @@ MSAEditorConsensusCache::MSAEditorConsensusCache(QObject* p, MultipleAlignmentOb
     : QObject(p), curCacheSize(0), aliObj(o), algorithm(nullptr) {
     setConsensusAlgorithm(factory);
 
-    connect(aliObj, &MultipleAlignmentObject::si_alignmentChanged, this, &MSAEditorConsensusCache::sl_alignmentChanged);
+    connect(aliObj, SIGNAL(si_alignmentChanged(const MultipleAlignment&, const MaModificationInfo&)), SLOT(sl_alignmentChanged()));
     connect(aliObj, SIGNAL(si_invalidateAlignmentObject()), SLOT(sl_invalidateAlignmentObject()));
 
     curCacheSize = aliObj->getLength();
@@ -68,17 +68,8 @@ QByteArray MSAEditorConsensusCache::getConsensusLine(const U2Region& region, boo
     return res;
 }
 
-void MSAEditorConsensusCache::sl_alignmentChanged(const MultipleAlignment& oldCachedMa, const MaModificationInfo& mi) {
-    SAFE_POINT(!mi.middleState, "Should not be middle state", );
-
-    // Undo-Redo Framework does not provide detailed change info.
-    // In this case we can only recalculate all.
-    bool isUnknownChange = mi.type == MaModificationType_Undo || mi.type == MaModificationType_Redo;
-    if (isUnknownChange) {
-        algorithm->reinitializeData(aliObj->getMultipleAlignment());
-    } else {
-        algorithm->recalculateData(oldCachedMa, aliObj->getMultipleAlignment(), mi);
-    }
+void MSAEditorConsensusCache::sl_alignmentChanged() {
+    algorithm->reinitializeData(aliObj->getMultipleAlignment());
 
     if (curCacheSize != aliObj->getLength()) {
         curCacheSize = aliObj->getLength();

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusCache.h
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusCache.h
@@ -64,7 +64,7 @@ signals:
     void si_cacheResized(int newSize);
 
 private slots:
-    void sl_alignmentChanged(const MultipleAlignment&, const MaModificationInfo&);
+    void sl_alignmentChanged();
     void sl_thresholdChanged(int newValue);
     void sl_invalidateAlignmentObject();
 

--- a/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusCache.h
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditorConsensusCache.h
@@ -64,7 +64,7 @@ signals:
     void si_cacheResized(int newSize);
 
 private slots:
-    void sl_alignmentChanged();
+    void sl_alignmentChanged(const MultipleAlignment&, const MaModificationInfo&);
     void sl_thresholdChanged(int newValue);
     void sl_invalidateAlignmentObject();
 

--- a/src/plugins/api_tests/src/core/datatype/msa/MsaConsensusAlgorithmUnitTests.h
+++ b/src/plugins/api_tests/src/core/datatype/msa/MsaConsensusAlgorithmUnitTests.h
@@ -28,7 +28,14 @@
 namespace U2 {
 
 DECLARE_TEST(MsaConsensusAlgorithmUnitTests, levitskyCheckColumnBase);
+DECLARE_TEST(MsaConsensusAlgorithmUnitTests, levitskyCheckReplace);
+DECLARE_TEST(MsaConsensusAlgorithmUnitTests, levitskyCheckAddRow);
+DECLARE_TEST(MsaConsensusAlgorithmUnitTests, levitskyCheckRemoveColumn);
+
 
 }  // namespace U2
 
 DECLARE_METATYPE(MsaConsensusAlgorithmUnitTests, levitskyCheckColumnBase)
+DECLARE_METATYPE(MsaConsensusAlgorithmUnitTests, levitskyCheckReplace)
+DECLARE_METATYPE(MsaConsensusAlgorithmUnitTests, levitskyCheckAddRow)
+DECLARE_METATYPE(MsaConsensusAlgorithmUnitTests, levitskyCheckRemoveColumn)

--- a/tests/unit_tests/ApiTest/datatype/msa/MsaConsensusAlgorithmUnitTests.xml
+++ b/tests/unit_tests/ApiTest/datatype/msa/MsaConsensusAlgorithmUnitTests.xml
@@ -2,5 +2,8 @@
 
     MsaConsensusAlgorithmUnitTests
     + levitskyCheckColumnBase
+    + levitskyCheckReplace
+    + levitskyCheckAddRow
+    + levitskyCheckRemoveColumn
 
 </unittest>


### PR DESCRIPTION
Это не полноценный PR (как минимум, тестов нет), а только первая версия - хочу обсудить идею и решить, что делать в этой задаче, а что нет.

Решаемая проблема простая - алгоритм Левицкого использует все символы выравнивания для расчета консенсуса, но данные о встречаемости символов не обновляются при редактировании этого выравнивания.

Самый простой способ решения этой проблемы - на любое редактирование делать полный пересчет - выглядит крайне непривлекательным, т.к. пересчитывать все выравнивание (которое может быть очень большим) при редактировании одного символа не слишком-то оптимально.

Соответственно, нужно понимать, что мы редактируем и пересчитывать только то, что с этим связано. К счастью, в данный момент уже есть определенная система, которая отслеживает, что было отредактировано в процессе изменения выравнивания. Однако, она не совсем полноценная и оповещает только о части информации. Например, если был отредактирован один символ, она передаст только номер строки, на которой этот символ находился. Это немного облегчит задачу - нам достаточно будет только пересчитать символы текущей строки - но все же хотелось бы для каждого возможного способа редактирования знать конкретно что, где и как изменилось. Добавить это все за один раз может быть объемной задачей, поэтому я пока что сделал программу минимум, где сделал перерасчет только исходя из того, что уже есть в UGENE. Сейчас хотелось бы понять, что из улучшений лучше сделать сейчас, а что - унести в отдельные задачи. Варианты:

1. Редактирование региона строки (замена, удаление, вставка). Сейчас у нас есть только информация о том, какая строка была отредактированна, а хотелось бы знать, какой именно её участок подвергся изменениям. Эту информацию можно принести с собой в `MaModificationInfo`.
2. Изменение длины выравнивания (удаление столбца). В теории, можно отнести к предыдущему пункту с пометкой "удаление", но `MaModificationInfo` имеет это отедбным флагом. Если мы удаляем столбец, то сейчас мы пересчитываем все выравнивание, т.к. не знаем, какой именно столбец был удален. Лучше всего - приносить с собой информацию об этом, чтобы сам пересчет был максимально быстрым.
3. Добавление/удаление строки. Сейчас мы сначала ищем строку, которую добавили/удалили сравнивая старое и новое выравнивание, что долго - лучше бы информация об этом приходила в `MaModificationInfo`.
4. Изменение алфавита. Если мы просто заменили символ на символ другого алфавита с помощью стандартного редактирования, то это обычная замена и мы идем в пункт 1. Но у нас есть кнопки -->DNA/--->RNA на панели опций, пересчет для которых можно сделать очень быстро (если мы изменили алфавит с ДНК на РНК, то мы просто перекидываем счетчик **Т**на **U**). Сейчас проблематично понять, как именно был изменен алфавит - но эту информацию можно принести с собой в `MaModificationInfo`.

Есть еще один пункт, но он стоит немного особоняком, потому что сложнее всех предыдущих - это изменение выравнивания посредством Undo/Redo. Сейчас UGENE в принципе не умеет понимать, что было изменено при нажатии этих кнопок - если это происходит, он просто подгружает предыдущую версию из базы. Соответственно, мы тоже не можем это отслеживать и при нажатии Undo/Redo можем только сделать полный перерасчет. Разобраться с этой проблемой может быть гораздо труднее.

Есть еще один баг-не баг, не знаю, но требующий улучшения момент (распространяется на все алгоритмы, а не только на этот). Если мы экспортируем последовательность в виде изображения, то мы можем выбрать не всю последовательность для экспорта, а только ее регион. В этом случае логично иметь консенсус, соответствующий экспортируемой последовательности, а не всей (хотя тут спорно, лучше дать пользователю возможность выбрать).

Соответственно - что нравится, что не нравится, что делать сейчас, что унести в другие задачи? Если спросить меня, то я бы вообще все пункты (4 + 1 +1 = 6) раскидал по отдельным задачам.

