### PR TITLE
UGENE-7953 [Crash] PDB parser, second model with 2 chains

### DIFF
--- a/src/corelibs/U2Formats/src/PDBFormat.cpp
+++ b/src/corelibs/U2Formats/src/PDBFormat.cpp
@@ -416,7 +416,6 @@ void PDBFormat::PDBParser::parseAtom(BioStruct3D& biostruct, U2OpStatus&, QList<
     int modelId = currentModelIndex + 1;
     biostruct.modelMap[modelId].insert(id, a);
 
-    // If atom is in chain
     if (!isHetero || seqResContains(chainIdentifier, residueIndex.toInt(), residueAcronym)) {
         // Process residue
         if (!biostruct.moleculeMap.contains(chainIndex)) {

--- a/src/corelibs/U2Formats/src/PDBFormat.cpp
+++ b/src/corelibs/U2Formats/src/PDBFormat.cpp
@@ -391,10 +391,37 @@ void PDBFormat::PDBParser::parseAtom(BioStruct3D& biostruct, U2OpStatus&, QList<
     char chainIdentifier = currentPDBLine.at(21).toLatin1();
 
     ResidueIndex residueIndex(resId, insCode);
+    bool atomIsInChain = !isHetero || seqResContains(chainIdentifier, residueIndex.toInt(), residueAcronym);
+
     QByteArray elementName = currentPDBLine.mid(76, 2).toLatin1().trimmed();
+
     QByteArray element = elementName.isEmpty() ? atomName.mid(0, 1) : elementName;
     int atomicNumber = PDBFormat::getElementNumberByName(element);
+
     int chainIndex = chainIndexMap.contains(chainIdentifier) ? chainIndexMap.value(chainIdentifier) : currentChainIndex;
+    
+    if (atomIsInChain && !biostruct.moleculeMap.contains(chainIndex)) {
+        createMolecule(chainIdentifier, biostruct, chainIndex);
+    }
+
+    if (currentModelIndex == 0 && atomIsInChain) {
+        // Process residue
+        SharedMolecule& mol = biostruct.moleculeMap[chainIndex];
+
+        if (currentResidueIndex != residueIndex) {
+            SharedResidue residue(new ResidueData);
+            residue->name = residueName;
+            residue->acronym = residueAcronym;
+            if (residue->acronym == 'X') {
+                ioLog.details(tr("PDB warning: unknown residue name: %1").arg(residue->name.constData()));
+            }
+            residue->chainIndex = chainIndex;
+            currentResidueIndex = residueIndex;
+            residueOrder++;
+            residueIndex.setOrder(residueOrder);
+            mol->residueMap.insert(residueIndex, residue);
+        }
+    }
 
     // Process atom
     double x, y, z;
@@ -416,26 +443,8 @@ void PDBFormat::PDBParser::parseAtom(BioStruct3D& biostruct, U2OpStatus&, QList<
     int modelId = currentModelIndex + 1;
     biostruct.modelMap[modelId].insert(id, a);
 
-    if (!isHetero || seqResContains(chainIdentifier, residueIndex.toInt(), residueAcronym)) {
-        // Process residue
-        if (!biostruct.moleculeMap.contains(chainIndex)) {
-            createMolecule(chainIdentifier, biostruct, chainIndex);
-        }
+    if (atomIsInChain) {
         SharedMolecule& mol = biostruct.moleculeMap[chainIndex];
-        if (currentResidueIndex != residueIndex) {
-            SharedResidue residue(new ResidueData);
-            residue->name = residueName;
-            residue->acronym = residueAcronym;
-            if (residue->acronym == 'X') {
-                ioLog.details(tr("PDB warning: unknown residue name: %1").arg(residue->name.constData()));
-            }
-            residue->chainIndex = chainIndex;
-            currentResidueIndex = residueIndex;
-            residueOrder++;
-            residueIndex.setOrder(residueOrder);
-            mol->residueMap.insert(residueIndex, residue);
-        }
-        // Add molecule to 3D view
         Molecule3DModel& model3D = mol->models[modelId];
         model3D.atoms.append(a);
         sequenceIds.append(id);

--- a/tests/doc_format/pdb/test_0014.xml
+++ b/tests/doc_format/pdb/test_0014.xml
@@ -1,0 +1,5 @@
+<multi-test>
+
+    <load-document index="doc" url="pdb/multi_model_with_ter.pdb" io="local_file" format="pdb"/>
+
+</multi-test>


### PR DESCRIPTION
https://www.wwpdb.org/documentation/file-format-content/format33/sect9.html#TER
Проверил проблемный файл в других программах отображения молекул.
Согласно описанию формата ограничение что тег TER может находиться в середине цепочки атомов только первой модели было неверно.
Убрал это ограничение и скомпоновал код по удобней.
Проверил что отрисовка PDB файлов из samples и _common_data остались прежними.