### PR TITLE
Replace QList with QVector as MSA rows collection

### DIFF
--- a/src/corelibs/U2Core/src/datatype/msa/MultipleAlignment.cpp
+++ b/src/corelibs/U2Core/src/datatype/msa/MultipleAlignment.cpp
@@ -58,7 +58,7 @@ const MultipleAlignmentData* MultipleAlignment::operator->() const {
 MultipleAlignmentData::MultipleAlignmentData(const MultipleAlignmentDataType& _type,
                                              const QString& name,
                                              const DNAAlphabet* _alphabet,
-                                             const QList<MultipleAlignmentRow>& _rows)
+                                             const QVector<MultipleAlignmentRow>& _rows)
     : type(_type), alphabet(_alphabet), rows(_rows) {
     MaStateCheck check(this);
     Q_UNUSED(check);
@@ -191,17 +191,14 @@ void MultipleAlignmentData::sortRows(MultipleAlignment::SortType type, MultipleA
 }
 
 MultipleAlignmentRow MultipleAlignmentData::getRow(int rowIndex) {
-    int rowsCount = rows.count();
-    SAFE_POINT(0 != rowsCount, "No rows", getEmptyRow());
-    SAFE_POINT(rowIndex >= 0 && (rowIndex < rowsCount), "Internal error: unexpected row index was passed to MAlignmnet::getRow", getEmptyRow());
+    int rowCount = rows.count();
+    SAFE_POINT(rowIndex >= 0 && rowIndex < rowCount, "Internal error: unexpected row index was passed to MAlignment::getRow", getEmptyRow());
     return rows[rowIndex];
 }
 
 const MultipleAlignmentRow& MultipleAlignmentData::getRow(int rowIndex) const {
-    static MultipleAlignmentRow emptyRow = getEmptyRow();
-    int rowsCount = rows.count();
-    SAFE_POINT(rowsCount != 0, "No rows", emptyRow);
-    SAFE_POINT(rowIndex >= 0 && rowIndex < rowsCount, "Internal error: unexpected row index was passed to MAlignment::getRow", emptyRow);
+    int rowCount = rows.count();
+    SAFE_POINT(rowIndex >= 0 && rowIndex < rowCount, "Internal error: unexpected row index was passed to MAlignment::getRow", getEmptyRow());
     return rows[rowIndex];
 }
 
@@ -215,7 +212,7 @@ const MultipleAlignmentRow& MultipleAlignmentData::getRow(const QString& name) c
     SAFE_POINT(false, "Internal error: row name passed to MAlignmnet::getRow function not exists", emptyRow);
 }
 
-const QList<MultipleAlignmentRow>& MultipleAlignmentData::getRows() const {
+const QVector<MultipleAlignmentRow>& MultipleAlignmentData::getRows() const {
     return rows;
 }
 
@@ -247,8 +244,11 @@ MultipleAlignmentRow MultipleAlignmentData::getRowByRowId(qint64 rowId, U2OpStat
     return emptyRow;
 }
 
-char MultipleAlignmentData::charAt(int rowNumber, qint64 position) const {
-    return getRow(rowNumber)->charAt(position);
+char MultipleAlignmentData::charAt(int rowIndex, qint64 position) const {
+    int rowCount = rows.count();
+    return rowIndex >= 0 && rowIndex < rowCount
+               ? rows[rowIndex]->charAt(position)  // Hotspot: 20% Faster this way than getRow().
+               : getRow(rowIndex)->charAt(position);
 }
 
 bool MultipleAlignmentData::isGap(int rowNumber, qint64 pos) const {
@@ -348,11 +348,11 @@ void MultipleAlignmentData::moveRowsBlock(int startRow, int numRows, int delta) 
                    .arg(numRows)
                    .arg(delta), );
 
-    QList<MultipleAlignmentRow> toMove;
+    QVector<MultipleAlignmentRow> toMove;
     int fromRow = delta > 0 ? startRow + numRows : startRow + delta;
 
     while (i < k) {
-        const MultipleAlignmentRow row = rows.takeAt(fromRow);
+        MultipleAlignmentRow row = rows.takeAt(fromRow);
         toMove.append(row);
         i++;
     }
@@ -360,8 +360,7 @@ void MultipleAlignmentData::moveRowsBlock(int startRow, int numRows, int delta) 
     int toRow = delta > 0 ? startRow : startRow + numRows - k;
 
     while (toMove.count() > 0) {
-        int n = toMove.count();
-        const MultipleAlignmentRow row = toMove.takeAt(n - 1);
+        MultipleAlignmentRow row = toMove.takeLast();
         rows.insert(toRow, row);
     }
 }
@@ -404,7 +403,7 @@ bool MultipleAlignmentData::sortRowsByList(const QStringList& rowsOrder) {
         CHECK(rowsOrder.contains(rowName), false);
     }
 
-    QList<MultipleAlignmentRow> sortedRows;
+    QVector<MultipleAlignmentRow> sortedRows;
     foreach (const QString& rowName, rowsOrder) {
         int rowIndex = rowNames.indexOf(rowName);
         if (rowIndex >= 0) {

--- a/src/corelibs/U2Core/src/datatype/msa/MultipleAlignment.h
+++ b/src/corelibs/U2Core/src/datatype/msa/MultipleAlignment.h
@@ -92,7 +92,7 @@ protected:
     MultipleAlignmentData(const MultipleAlignmentDataType& type,
                           const QString& name = QString(),
                           const DNAAlphabet* alphabet = nullptr,
-                          const QList<MultipleAlignmentRow>& rows = QList<MultipleAlignmentRow>());
+                          const QVector<MultipleAlignmentRow>& rows = {});
 
 public:
     virtual ~MultipleAlignmentData() = default;
@@ -147,7 +147,7 @@ public:
     const MultipleAlignmentRow& getRow(const QString& name) const;
 
     /** Returns all rows in the alignment */
-    const QList<MultipleAlignmentRow>& getRows() const;
+    const QVector<MultipleAlignmentRow>& getRows() const;
 
     /** Returns IDs of the alignment rows in the database */
     QList<qint64> getRowsIds() const;
@@ -226,7 +226,7 @@ protected:
     const DNAAlphabet* alphabet = nullptr;
 
     /** Alignment rows (each row = sequence + gap model) */
-    QList<MultipleAlignmentRow> rows;
+    QVector<MultipleAlignmentRow> rows;
 
     /** The length of the longest row in the alignment */
     qint64 length = 0;

--- a/src/corelibs/U2Core/src/datatype/msa/MultipleAlignmentRow.h
+++ b/src/corelibs/U2Core/src/datatype/msa/MultipleAlignmentRow.h
@@ -47,6 +47,7 @@ protected:
     MultipleAlignmentRow(MultipleAlignmentRowData* maRowData);
 
 public:
+    MultipleAlignmentRow() = default;
     virtual ~MultipleAlignmentRow() = default;
 
     MultipleAlignmentRowData* data() const;

--- a/src/corelibs/U2Core/src/datatype/msa/MultipleChromatogramAlignment.cpp
+++ b/src/corelibs/U2Core/src/datatype/msa/MultipleChromatogramAlignment.cpp
@@ -79,8 +79,8 @@ QSharedPointer<MultipleChromatogramAlignmentData> MultipleChromatogramAlignment:
 
 namespace {
 
-QList<MultipleAlignmentRow> convertToMaRows(const QList<MultipleChromatogramAlignmentRow>& mcaRows) {
-    QList<MultipleAlignmentRow> maRows;
+QVector<MultipleAlignmentRow> convertToMaRows(const QList<MultipleChromatogramAlignmentRow>& mcaRows) {
+    QVector<MultipleAlignmentRow> maRows;
     foreach (const MultipleChromatogramAlignmentRow& mcaRow, mcaRows) {
         maRows << mcaRow;
     }

--- a/src/corelibs/U2Core/src/datatype/msa/MultipleSequenceAlignment.cpp
+++ b/src/corelibs/U2Core/src/datatype/msa/MultipleSequenceAlignment.cpp
@@ -76,8 +76,8 @@ QSharedPointer<MultipleSequenceAlignmentData> MultipleSequenceAlignment::getMsaD
 
 namespace {
 
-static QList<MultipleAlignmentRow> convertToMaRows(const QList<MultipleSequenceAlignmentRow>& msaRows) {
-    QList<MultipleAlignmentRow> maRows;
+static QVector<MultipleAlignmentRow> convertToMaRows(const QList<MultipleSequenceAlignmentRow>& msaRows) {
+    QVector<MultipleAlignmentRow> maRows;
     foreach (const MultipleSequenceAlignmentRow& msaRow, msaRows) {
         maRows << msaRow;
     }

--- a/src/corelibs/U2Core/src/gobjects/MultipleAlignmentObject.cpp
+++ b/src/corelibs/U2Core/src/gobjects/MultipleAlignmentObject.cpp
@@ -190,7 +190,7 @@ qint64 MultipleAlignmentObject::getRowCount() const {
     return getMultipleAlignment()->getRowCount();
 }
 
-const QList<MultipleAlignmentRow>& MultipleAlignmentObject::getRows() const {
+const QVector<MultipleAlignmentRow>& MultipleAlignmentObject::getRows() const {
     return getMultipleAlignment()->getRows();
 }
 
@@ -576,10 +576,10 @@ void MultipleAlignmentObject::removeRegion(int startPos, int startRow, int nBase
 
     QList<qint64> modifiedRowIds;
     const MultipleAlignment& ma = getMultipleAlignment();
-    const QList<MultipleAlignmentRow>& maRows = ma->getRows();
+    const QVector<MultipleAlignmentRow>& maRows = ma->getRows();
     SAFE_POINT(nRows > 0 && startRow >= 0 && startRow + nRows <= maRows.size() && startPos + nBases <= ma->getLength(), "Invalid parameters", );
-    QList<MultipleAlignmentRow>::ConstIterator it = maRows.begin() + startRow;
-    QList<MultipleAlignmentRow>::ConstIterator end = it + nRows;
+    QVector<MultipleAlignmentRow>::ConstIterator it = maRows.begin() + startRow;
+    QVector<MultipleAlignmentRow>::ConstIterator end = it + nRows;
     for (; it != end; it++) {
         modifiedRowIds << (*it)->getRowId();
     }
@@ -809,7 +809,7 @@ int MultipleAlignmentObject::getMaxWidthOfGapRegion(U2OpStatus& os, const QList<
 
 QList<qint64> MultipleAlignmentObject::convertMaRowIndexesToMaRowIds(const QList<int>& maRowIndexes, bool excludeErrors) {
     QList<qint64> ids;
-    const QList<MultipleAlignmentRow>& rows = getMultipleAlignment()->getRows();
+    const QVector<MultipleAlignmentRow>& rows = getMultipleAlignment()->getRows();
     for (int i = 0; i < maRowIndexes.length(); i++) {
         int index = maRowIndexes[i];
         bool isValid = index >= 0 && index <= rows.size() - 1;
@@ -824,7 +824,7 @@ QList<qint64> MultipleAlignmentObject::convertMaRowIndexesToMaRowIds(const QList
 
 QList<int> MultipleAlignmentObject::convertMaRowIdsToMaRowIndexes(const QList<qint64>& maRowIds, bool excludeErrors) {
     QList<int> indexes;
-    const QList<MultipleAlignmentRow>& rows = getMultipleAlignment()->getRows();
+    const QVector<MultipleAlignmentRow>& rows = getMultipleAlignment()->getRows();
     for (int i = 0; i < maRowIds.length(); i++) {
         int rowId = maRowIds[i];
         int index = -1;

--- a/src/corelibs/U2Core/src/gobjects/MultipleAlignmentObject.h
+++ b/src/corelibs/U2Core/src/gobjects/MultipleAlignmentObject.h
@@ -65,7 +65,7 @@ public:
     const DNAAlphabet* getAlphabet() const;
     qint64 getLength() const;
     qint64 getRowCount() const;
-    const QList<MultipleAlignmentRow>& getRows() const;
+    const QVector<MultipleAlignmentRow>& getRows() const;
     const MultipleAlignmentRow getRow(int row) const;
     int getRowPosById(qint64 rowId) const;
     virtual char charAt(int seqNum, qint64 position) const = 0;

--- a/src/corelibs/U2Core/src/util/MSAUtils.cpp
+++ b/src/corelibs/U2Core/src/util/MSAUtils.cpp
@@ -523,7 +523,7 @@ bool MSAUtils::restoreOriginalRowProperties(MultipleSequenceAlignment& resultMa,
     return true;
 }
 
-QList<U2Region> MSAUtils::getColumnsWithGaps(const QList<QVector<U2MsaGap>>& maGapModel, const QList<MultipleAlignmentRow>& rows, int alignmentLength, int requiredGapsCount) {
+QList<U2Region> MSAUtils::getColumnsWithGaps(const QList<QVector<U2MsaGap>>& maGapModel, const QVector<MultipleAlignmentRow>& rows, int alignmentLength, int requiredGapsCount) {
     const int rowsCount = rows.size();
     if (requiredGapsCount == -1) {
         requiredGapsCount = rowsCount;

--- a/src/corelibs/U2Core/src/util/MSAUtils.h
+++ b/src/corelibs/U2Core/src/util/MSAUtils.h
@@ -122,7 +122,7 @@ public:
     /**
      * Returns list of columns with desired quantity of gaps.
      */
-    static QList<U2Region> getColumnsWithGaps(const QList<QVector<U2MsaGap>>& maGapModel, const QList<MultipleAlignmentRow>& rows, int alignmentLength, int requiredGapsCount = -1);
+    static QList<U2Region> getColumnsWithGaps(const QList<QVector<U2MsaGap>>& maGapModel, const QVector<MultipleAlignmentRow>& rows, int alignmentLength, int requiredGapsCount = -1);
     static void removeColumnsWithGaps(MultipleSequenceAlignment& msa, int requiredGapsCount = -1);
 
     /**

--- a/src/corelibs/U2Formats/src/StockholmFormat.cpp
+++ b/src/corelibs/U2Formats/src/StockholmFormat.cpp
@@ -304,7 +304,7 @@ static bool isEndOfMsaBlock(IOAdapterReader& reader, U2OpStatus& os) {
 
 /** Returns true if there is a row in the 'msa' with the given name. */
 static bool hasRowWithName(const MultipleSequenceAlignment& msa, const QString& name) {
-    const QList<MultipleAlignmentRow>& rows = msa->getRows();
+    const QVector<MultipleAlignmentRow>& rows = msa->getRows();
     return std::any_of(rows.begin(), rows.end(), [name](auto& row) { return row->getName() == name; });
 }
 
@@ -465,7 +465,7 @@ static void load(IOAdapterReader& reader, const U2DbiRef& dbiRef, QList<GObject*
 
 /** Returns maximum row name length in the msa. */
 static int getMaxNameLen(const MultipleSequenceAlignment& msa) {
-    const QList<MultipleAlignmentRow>& rows = msa->getRows();
+    const QVector<MultipleAlignmentRow>& rows = msa->getRows();
     CHECK(rows.isEmpty(), 0);
     auto it = std::max_element(rows.begin(), rows.end(), [](auto& r1, auto& r2) { return r1->getName().length() < r2->getName().length(); });
     return (*it)->getName().length();
@@ -487,7 +487,7 @@ static void save(IOAdapterWriter& writer, const MultipleSequenceAlignment& msa, 
     int maxNameLength = getMaxNameLen(msa);
     int remainingSequenceLength = msa->getLength();
     MultipleSequenceAlignmentWalker walker(msa);
-    const QList<MultipleAlignmentRow>& rows = msa->getRows();
+    const QVector<MultipleAlignmentRow>& rows = msa->getRows();
     while (remainingSequenceLength > 0) {
         // Write a block.
         int blockLength = qMin(remainingSequenceLength, WRITE_BLOCK_LENGTH);

--- a/src/corelibs/U2View/src/ov_msa/MSAEditor.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MSAEditor.cpp
@@ -883,7 +883,7 @@ void MSAEditor::sl_sortGroupsBySize() {
 
 // TODO: move this function into MSA?
 /* Groups rows by similarity. Two rows are considered equal if their sequences are equal with ignoring of gaps. */
-static QList<QList<int>> groupRowsBySimilarity(const QList<MultipleAlignmentRow>& msaRows) {
+static QList<QList<int>> groupRowsBySimilarity(const QVector<MultipleAlignmentRow>& msaRows) {
     QList<QList<int>> rowGroups;
     QSet<int> mappedRows;  // contains indexes of the already processed rows.
     for (int i = 0; i < msaRows.size(); i++) {

--- a/src/corelibs/U2View/src/ov_msa/exclude_list/MsaExcludeList.cpp
+++ b/src/corelibs/U2View/src/ov_msa/exclude_list/MsaExcludeList.cpp
@@ -492,7 +492,7 @@ void MsaExcludeListWidget::handleUndoRedoInMsaEditor(const MultipleAlignment& ma
     const UndoRedoStep& undoRedoContext = isRedo ? trackedRedoMsaVersions.value(version) : trackedUndoMsaVersions.value(version);
     bool isAddToExcludeList = (isRedo && undoRedoContext.isMoveFromMsaToExcludeList) || (!isRedo && !undoRedoContext.isMoveFromMsaToExcludeList);
     if (isAddToExcludeList) {  // Add rows removed from MSA to Exclude list
-        QList<MultipleAlignmentRow> msaRows;
+        QVector<MultipleAlignmentRow> msaRows;
         QSet<qint64> msaRowIdsAfter = msaObject->getRowIds().toSet();
         for (int i = 0; i < maBefore->getRowCount(); i++) {
             const MultipleAlignmentRow& row = maBefore->getRow(i);

--- a/src/plugins_3rdparty/sitecon/src/SiteconAlgorithm.cpp
+++ b/src/plugins_3rdparty/sitecon/src/SiteconAlgorithm.cpp
@@ -78,7 +78,7 @@ QVector<PositionStats> SiteconAlgorithm::calculateDispersionAndAverage(const Mul
             average /= N;
 
             qreal dispersion = 0;  // dispersion in a column
-            const QList<MultipleAlignmentRow>& msaRows = ma->getRows();
+            const QVector<MultipleAlignmentRow>& msaRows = ma->getRows();
             for (int j = 0; j < msaRows.size(); j++) {  // collect di-position stat for all sequence in alignment
                 CHECK(!ts.isCoR(), {});
                 const MultipleSequenceAlignmentRow& row = msaRows[j];


### PR DESCRIPTION
First part of refactoring of MSA and MCA rows.
This change is also needed for migration to Qt6 (QList is replaced with QVector)
