### PR TITLE
UGENE-7991 remove Advanced button

### DIFF
--- a/src/corelibs/U2View/src/util_smith_waterman/SmithWatermanDialogBase.ui
+++ b/src/corelibs/U2View/src/util_smith_waterman/SmithWatermanDialogBase.ui
@@ -72,11 +72,11 @@
          <property name="tabChangesFocus">
           <bool>true</bool>
          </property>
-         <property name="tabStopWidth">
-          <number>0</number>
-         </property>
          <property name="acceptRichText">
           <bool>false</bool>
+         </property>
+         <property name="tabStopWidth" stdset="0">
+          <number>0</number>
          </property>
         </widget>
        </item>
@@ -226,7 +226,7 @@
              <string>Algorithm version</string>
             </property>
             <layout class="QGridLayout" name="gridLayout_3">
-             <item row="0" column="0" colspan="2">
+             <item row="0" column="0" colspan="3">
               <widget class="QComboBox" name="comboRealization">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -262,20 +262,17 @@
               </spacer>
              </item>
              <item row="1" column="1">
-              <widget class="QPushButton" name="bttnAdvanced">
-               <property name="enabled">
-                <bool>false</bool>
+              <spacer name="verticalSpacer_3">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
                </property>
-               <property name="maximumSize">
+               <property name="sizeHint" stdset="0">
                 <size>
-                 <width>75</width>
-                 <height>23</height>
+                 <width>20</width>
+                 <height>40</height>
                 </size>
                </property>
-               <property name="text">
-                <string>Advanced..</string>
-               </property>
-              </widget>
+              </spacer>
              </item>
             </layout>
            </widget>
@@ -782,7 +779,6 @@
   <tabstop>radioDirect</tabstop>
   <tabstop>radioComplement</tabstop>
   <tabstop>comboRealization</tabstop>
-  <tabstop>bttnAdvanced</tabstop>
   <tabstop>comboMatrix</tabstop>
   <tabstop>bttnViewMatrix</tabstop>
   <tabstop>spinGapOpen</tabstop>


### PR DESCRIPTION
Удалил кнопку "Advanced"  в диалоге поиска Смита-Ватермана - вероятно, она была нужна то ли для OpenCL, то ли для CUDA, но ни один из текущих алгоритмов поиска не имеет никаких дополнительных настроек, поэтому ее существование только вводит в заблуждение.