### PR TITLE
UGENE-8034 Split Plasmid features annotations to separate groups

### DIFF
--- a/src/plugins/annotator/src/AnnotatorTests.h
+++ b/src/plugins/annotator/src/AnnotatorTests.h
@@ -69,6 +69,7 @@ private:
     // How many unique features was found
     // Two features with the same name couns as one
     int expectedUniqueFeaturesFound = -1;
+    QStringList expectedAnnotationGroupNames;
     CustomPatternAnnotationTask* searchTask = nullptr;;
     AnnotationTableObject* ao = nullptr;
 };

--- a/src/plugins/annotator/src/CustomPatternAnnotationTask.h
+++ b/src/plugins/annotator/src/CustomPatternAnnotationTask.h
@@ -91,19 +91,19 @@ public:
 
     struct PatternInfo {
         QString name;
-        bool forwardStrand;
-        PatternInfo()
-            : forwardStrand(true) {
-        }
-        PatternInfo(const QString& nm, bool isForward)
-            : name(nm), forwardStrand(isForward) {
+        QString type;
+        bool forwardStrand = true;
+
+        PatternInfo() = default;
+        PatternInfo(const QString& _nm, const QString& _type, bool isForward)
+            : name(_nm), type(_type), forwardStrand(isForward) {
         }
     };
 
 private:
     QSharedPointer<SArrayIndex> index;
+    QMap<QString, QList<SharedAnnotationData>> groupAnnotationsMap;
     QMap<Task*, PatternInfo> taskFeatureNames;
-    QList<SharedAnnotationData> annotations;
     U2SequenceObject dnaObj;
     QPointer<AnnotationTableObject> annotationTableObject;
     QByteArray sequence;

--- a/tests/annotator/custom_auto_annotation/test_0006.xml
+++ b/tests/annotator/custom_auto_annotation/test_0006.xml
@@ -1,0 +1,4 @@
+<multi-test>
+    <load-document index="doc" url="annotator/seq_with_all_features.fa" io="local_file" format="fasta"/>
+    <custom-auto-annotation-search doc="doc" seq="clipboard_3" result="plasmid_annotations" circular="false" expected_results="Promoter,Terminator,Regulatory sequence,Replication origin,Selectable marker,Reporter gene,Two-hybrid gene,Localization sequence,Affinity tag,Gene,Primer,Miscellaneous"/>
+</multi-test>


### PR DESCRIPTION
Разбил фичи по группам в зависимости от типа фичи (всего 12 типов -> 12 групп). Так же, аннотациям, соответствующим некоторым типам фич, можно задать соответствующий тип аннотации (Promoter, Terminator, Regulatory sequence, Replication origin, Gene и Primer). Фичи, не имеющие специального типа, остаются misc_feature.