### PR TITLE
UGENE-7995 turn off dark mode on macOS

### DIFF
--- a/etc/script/mac/dmg/Info.plist
+++ b/etc/script/mac/dmg/Info.plist
@@ -48,6 +48,9 @@
     <key>LSMinimumSystemVersion</key>
     <string>10.13</string>
     
+    <key>NSRequiresAquaSystemAppearance</key>
+    <true/>
+    
     <key>CFBundleDocumentTypes</key>
     <array>
         <!-- Project -->


### PR DESCRIPTION
Описание проблемы пришло от пользователя.

При включении темной темы на macOS стилистика всех запущенных приложений тоже становится темной, т.е., фактически, включается автоматическая темная. Цветовая гамма изменяется очень неплохо для стандартных виджетов, но UGENE состоит далеко не только из них. Пример:
![Screen Shot 2024-01-31 at 11 46 12 AM](https://github.com/ugeneunipro/ugene/assets/26257527/e4650a43-bc56-4df5-969d-b7cb1d2629ba)

Многие иконки плохо видно из-за того, что они нарисованы для отображения на светлом фоне; цвета лога и некоторых кнопок темные на темном фоне, т.к. цвета им задаются вручную; основные окошки SV остались белыми (т.к. они, опять же, рисуются вручную), что создает некрасивый контраст;  много других визуальных проблем, из-за которых UGENE выглядит, откровенно говоря, убого в такой половинчатой раскраске.

Данный фикс оставляет UGENE светлым даже при запущеном темном режиме на macOS. Временное решение до тех пор, пока, однажды, мы не сделаем полноценную темную тему. Релиз [собран](http://ugene-teamcity.unipro.ru:8111/ugene-teamcity/buildConfiguration/ReleaseMacIntelDmg?branch=UGENE-7995&buildTypeTab=overview&mode=builds) и протестирован - работает.

PS. На Windows такой проблемы нет, т.к. темная тема системы не заставляет сторонние приложения тоже становиться темными.

