### PR TITLE
Add counters for scripting features

### DIFF
--- a/src/corelibs/U2Designer/src/DelegateEditors.cpp
+++ b/src/corelibs/U2Designer/src/DelegateEditors.cpp
@@ -24,6 +24,7 @@
 #include <QApplication>
 
 #include <U2Core/AppContext.h>
+#include <U2Core/Counter.h>
 #include <U2Core/DocumentModel.h>
 #include <U2Core/L10n.h>
 #include <U2Core/QObjectScopedPointer.h>
@@ -649,6 +650,7 @@ void ScriptSelectionWidget::sl_comboCurrentIndexChanged(int itemId) {
             return;
         }
         case USER_SCRIPT_ITEM_ID: {
+            GCOUNTER(cvar, "Script. Run Edit script of the element dialog for parameter");
             AttributeScript attrScript = combobox->property(SCRIPT_PROPERTY.toLatin1().constData()).value<AttributeScript>();
             QObjectScopedPointer<ScriptEditorDialog> dlg = new ScriptEditorDialog(QApplication::activeWindow(), AttributeScriptDelegate::createScriptHeader(attrScript));
             dlg->setScriptText(attrScript.getScriptText());
@@ -658,7 +660,11 @@ void ScriptSelectionWidget::sl_comboCurrentIndexChanged(int itemId) {
             if (rc != QDialog::Accepted) {
                 combobox->setItemData(USER_SCRIPT_ITEM_ID, qVariantFromValue<AttributeScript>(attrScript), ConfigurationEditor::ItemValueRole);
             } else {
-                attrScript.setScriptText(dlg->getScriptText());
+                auto scriptText = dlg->getScriptText();
+                if (!scriptText.isEmpty()) {
+                    GCOUNTER(cvar1, "Script. Done Edit script of the element dialog for parameter with new script");
+                }
+                attrScript.setScriptText(scriptText);
                 combobox->setItemData(USER_SCRIPT_ITEM_ID, qVariantFromValue<AttributeScript>(attrScript), ConfigurationEditor::ItemValueRole);
             }
 

--- a/src/plugins/workflow_designer/src/BreakpointManagerView.cpp
+++ b/src/plugins/workflow_designer/src/BreakpointManagerView.cpp
@@ -30,6 +30,7 @@
 #include <QTreeWidget>
 #include <QVBoxLayout>
 
+#include <U2Core/Counter.h>
 #include <U2Core/QObjectScopedPointer.h>
 #include <U2Core/U2SafePoints.h>
 
@@ -260,8 +261,10 @@ void BreakpointManagerView::sl_newBreakpoint() {
                     processItem->toggleBreakpoint();
                 }
                 if (processItem->isBreakpointInserted()) {
+                    GCOUNTER(cvar, "Script. Breakpoint has been inserted");
                     debugInfo->addBreakpointToActor(processItem->getProcess()->getId());
                 } else {
+                    GCOUNTER(cvar, "Script. Breakpoint has been removed");
                     debugInfo->removeBreakpointFromActor(processItem->getProcess()->getId());
                 }
             }

--- a/src/plugins/workflow_designer/src/WorkflowEditor.cpp
+++ b/src/plugins/workflow_designer/src/WorkflowEditor.cpp
@@ -253,6 +253,12 @@ void WorkflowEditor::handleDataChanged(const QModelIndex& topLeft, const QModelI
 }
 
 void WorkflowEditor::changeScriptMode(bool _mode) {
+    if (_mode) {
+        GCOUNTER(cvar, "Script. Scripting mode enabled");
+    } else {
+        GCOUNTER(cvar, "Script. Scripting mode disabled");
+    }
+
     if (table->currentIndex().column() == 2) {
         table->clearSelection();
         table->setCurrentIndex(QModelIndex());

--- a/src/plugins/workflow_designer/src/WorkflowViewController.cpp
+++ b/src/plugins/workflow_designer/src/WorkflowViewController.cpp
@@ -799,11 +799,13 @@ void WorkflowView::sl_findPrototype() {
 }
 
 void WorkflowView::sl_createScript() {
+    GCOUNTER(cvar, "Script. Run Create Element with Script dialog");
     QObjectScopedPointer<CreateScriptElementDialog> dlg = new CreateScriptElementDialog(this);
     dlg->exec();
     CHECK(!dlg.isNull(), );
 
     if (dlg->result() == QDialog::Accepted) {
+        GCOUNTER(cvar1, "Script. A new Element with Script created");
         QList<DataTypePtr> input = dlg->getInput();
         QList<DataTypePtr> output = dlg->getOutput();
         QList<Attribute*> attrs = dlg->getAttributes();
@@ -895,12 +897,17 @@ void WorkflowView::sl_editScript() {
         Actor* scriptActor = selectedActors.first();
         AttributeScript* script = scriptActor->getScript();
         if (script != nullptr) {
+            GCOUNTER(cvar, "Script. Run Edit script of the element dialog for element");
             QObjectScopedPointer<ScriptEditorDialog> scriptDlg = new ScriptEditorDialog(this, AttributeScriptDelegate::createScriptHeader(*script), script->getScriptText());
             scriptDlg->exec();
             CHECK(!scriptDlg.isNull(), );
 
             if (scriptDlg->result() == QDialog::Accepted) {
-                script->setScriptText(scriptDlg->getScriptText());
+                auto scriptText = scriptDlg->getScriptText();
+                if (!scriptText.isEmpty()) {
+                    GCOUNTER(cvar1, "Script. Done Edit script of the element dialog for element with new script");
+                }
+                script->setScriptText(scriptText);
                 scriptActor->setScript(script);
             }
         }
@@ -962,6 +969,9 @@ void WorkflowView::addProcess(Actor* proc, const QPointF& pos) {
     uiLog.trace(addedProto->getDisplayName() + " added");
     if (WorkflowEnv::getExternalCfgRegistry()->getConfigById(addedProto->getId()) != nullptr) {
         GCOUNTER(cvar, "Element with external tool is added to the scene");
+    }
+    if (WorkflowEnv::getProtoRegistry()->getProto(LocalWorkflow::ScriptWorkerFactory::ACTOR_ID + addedProto->getDisplayName())) {
+        GCOUNTER(cvar, "Script. Add Element with Script to the scene");
     }
 
     update();
@@ -1394,6 +1404,7 @@ void WorkflowView::localHostLaunch() {
 
     if (WorkflowSettings::isDebuggerEnabled()) {
         GCounter::increment(meta.name, "Worklow started with enabled debugger");
+        GCOUNTER(cvar, "Script. Worklow started with enabled debugger");
     }
 
     foreach (const Actor* actor, schema->getProcesses()) {

--- a/src/plugins/workflow_designer/src/library/ScriptWorker.cpp
+++ b/src/plugins/workflow_designer/src/library/ScriptWorker.cpp
@@ -24,6 +24,7 @@
 #include <QScriptEngineDebugger>
 
 #include <U2Core/AppContext.h>
+#include <U2Core/Counter.h>
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/DNATranslation.h>
 #include <U2Core/FailTask.h>
@@ -57,6 +58,7 @@ static const QString OUT_PORT_ID("out");
 
 ScriptWorkerTask::ScriptWorkerTask(WorkflowScriptEngine* _engine, AttributeScript* _script)
     : Task(tr("Script worker task"), AppContext::isGUIMode() ? TaskFlag_RunInMainThread : TaskFlag_None), engine(_engine), script(_script) {
+    GCOUNTER(cvar, "Script. Script worker task");
     WorkflowScriptLibrary::initEngine(engine);
 }
 


### PR DESCRIPTION
Я добавил побольше счетчиков на все функции, которые тем или иным образом связаны с модулем Qt Script, т.к. очень интересуюсь степенью его использования. Хотелось бы иметь их в ближайшем релизе. Названия всех счетчиков начинается со "Script", чтобы в таблице статистики они были сконцентрированы в одном месте, т.к. они там идут в алфавитном порядке. Я добавил счетчики таким образом, чтобы было ясно, на каком этапе у пользователей происходит затык. Например, чтобы счедать скриптовый параметр у элемента нужно сначала включить Scripting mode, затем открыть соответствующее диалоговое окно, затем напистать скрипт и запустить расчет. По значению счетчика на каждом этапе можно будет увидеть общую статистику по поводу того, на каком этапе какой процент людей отсеялся 