### PR TITLE
UGENE-8043 update Primer3 (no target sequences) and Primer-BLAST Help page links

### DIFF
--- a/src/plugins/remote_blast/src/SendSelectionDialog.cpp
+++ b/src/plugins/remote_blast/src/SendSelectionDialog.cpp
@@ -143,6 +143,7 @@ SendSelectionDialog::SendSelectionDialog(ADVSequenceObjectContext* _seqCtx, bool
     : QDialog(parent), isAminoSeq(_isAminoSeq), seqCtx(_seqCtx) {
     setupUi(this);
 
+    QString helpPageId;
     if (selectedPrimerPairNames.isEmpty()) {
         U2SequenceObject* dnaso = seqCtx->getSequenceObject();
         CreateAnnotationModel createAnnotationModel;
@@ -155,6 +156,7 @@ SendSelectionDialog::SendSelectionDialog(ADVSequenceObjectContext* _seqCtx, bool
 
         optionsTab->setCurrentIndex(0);
         layoutAnnotations->addWidget(annWgtController->getWidget());
+        helpPageId = "65930710";
     } else {
         auto label = new QLabel(tr("The following primer pairs will be BLASTed:"), this);
         // This listwidget shows grou names of all fit primer pairs
@@ -169,9 +171,9 @@ SendSelectionDialog::SendSelectionDialog(ADVSequenceObjectContext* _seqCtx, bool
         QString tooltip = tr("The maximum number of results received for each primer");
         lblQuantity->setToolTip(tooltip);
         quantitySpinBox->setToolTip(tooltip);
+        helpPageId = "96666281";
     }
-
-    new HelpButton(this, buttonBox, "65930710");
+    new HelpButton(this, buttonBox, helpPageId);
     buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Search"));
     buttonBox->button(QDialogButtonBox::Cancel)->setText(tr("Cancel"));
 

--- a/src/plugins_3rdparty/primer3/src/Primer3Dialog.cpp
+++ b/src/plugins_3rdparty/primer3/src/Primer3Dialog.cpp
@@ -92,7 +92,11 @@ Primer3Dialog::Primer3Dialog(ADVSequenceObjectContext* _context)
           {tr("Probe"), "Probe"},
           {tr("Recombinase Polymerase Amplification"), "Recombinase Polymerase Amplification"}}) {
     setupUi(this);
-    new HelpButton(this, helpButton, "65930919");
+    QString helpPageId = "65930919";
+    if (context == nullptr) {
+        helpPageId = "96666247";
+    }
+    new HelpButton(this, helpButton, helpPageId);
 
     connect(closeButton, &QPushButton::clicked, this, &Primer3Dialog::close);
     connect(pickPrimersButton, &QPushButton::clicked, this, &Primer3Dialog::sl_pickClicked);


### PR DESCRIPTION
Добавлены страницы Help и обновлены ссылки для Primer-BLAST ([UGENE-8043](https://ugene.dev/tracker/browse/UGENE-8043)) и Primer3 (no target sequences) ([UGENE-8042](https://ugene.dev/tracker/browse/UGENE-8042))