### PR TITLE
UGENE-7483 [Sequence] Numerical overflow in Region Selection

### DIFF
--- a/src/corelibs/U2Gui/src/util/GenbankLocationValidator.cpp
+++ b/src/corelibs/U2Gui/src/util/GenbankLocationValidator.cpp
@@ -36,7 +36,7 @@
 
 namespace U2 {
 
-GenbankLocationValidator::GenbankLocationValidator(QPushButton* _okButton, int length, bool _isCircular, QLineEdit* _le)
+GenbankLocationValidator::GenbankLocationValidator(QPushButton* _okButton, qint64 length, bool _isCircular, QLineEdit* _le)
     : QValidator(),
       okButton(_okButton),
       isCircular(_isCircular),

--- a/src/corelibs/U2Gui/src/util/GenbankLocationValidator.h
+++ b/src/corelibs/U2Gui/src/util/GenbankLocationValidator.h
@@ -30,7 +30,7 @@ namespace U2 {
 
 class GenbankLocationValidator : public QValidator {
 public:
-    GenbankLocationValidator(QPushButton* okButton, int length, bool isCircular, QLineEdit* le);
+    GenbankLocationValidator(QPushButton* okButton, qint64 length, bool isCircular, QLineEdit* le);
     ~GenbankLocationValidator();
 
     State validate(QString& str, int& ii) const override;
@@ -40,7 +40,7 @@ private:
 
     QPushButton* okButton;
     bool isCircular;
-    int seqLen;
+    qint64 seqLen = 0;
     QLineEdit* le;
 };
 

--- a/src/corelibs/U2Gui/src/util/RangeSelector.cpp
+++ b/src/corelibs/U2Gui/src/util/RangeSelector.cpp
@@ -106,7 +106,7 @@ void RangeSelector::init() {
     setLayout(l);
 }
 
-RangeSelector::RangeSelector(QDialog* dialog, int rangeStart, int rangeEnd, int len, bool autoClose)
+RangeSelector::RangeSelector(QDialog* dialog, qint64 rangeStart, qint64 rangeEnd, qint64 len, bool autoClose)
     : QWidget(dialog), rangeStart(rangeStart), rangeEnd(rangeEnd), len(len), startEdit(nullptr), endEdit(nullptr),
       minButton(nullptr), maxButton(nullptr), rangeLabel(nullptr), dialog(dialog), autoClose(autoClose) {
     init();
@@ -150,11 +150,11 @@ void RangeSelector::sl_onReturnPressed() {
 
 void RangeSelector::exec() {
     bool ok = false;
-    int v1 = startEdit->text().toInt(&ok);
+    qint64 v1 = startEdit->text().toLongLong(&ok);
     if (!ok || v1 < 1 || v1 > len) {
         return;
     }
-    int v2 = endEdit->text().toInt(&ok);
+    qint64 v2 = endEdit->text().toLongLong(&ok);
     if (!ok || v2 < v1 || v2 > len) {
         return;
     }
@@ -176,21 +176,21 @@ void RangeSelector::sl_onMaxButtonClicked(bool checked) {
     endEdit->setText(QString::number(len));
 }
 
-int RangeSelector::getStart() const {
+qint64 RangeSelector::getStart() const {
     bool ok = false;
-    int v = startEdit->text().toInt(&ok);
+    qint64 v = startEdit->text().toLongLong(&ok);
     assert(ok);
     return v;
 }
 
-int RangeSelector::getEnd() const {
+qint64 RangeSelector::getEnd() const {
     bool ok = false;
-    int v = endEdit->text().toInt(&ok);
+    qint64 v = endEdit->text().toLongLong(&ok);
     assert(ok);
     return v;
 }
 
-MultipleRangeSelector::MultipleRangeSelector(QWidget* _parent, const QVector<U2Region>& _regions, int _seqLen, bool _isCircular)
+MultipleRangeSelector::MultipleRangeSelector(QWidget* _parent, const QVector<U2Region>& _regions, qint64 _seqLen, bool _isCircular)
     : QDialog(_parent), seqLen(_seqLen), selectedRanges(_regions), isCircular(_isCircular) {
     ui = new Ui_RangeSelectionDialog;
     ui->setupUi(this);
@@ -251,11 +251,11 @@ MultipleRangeSelector::~MultipleRangeSelector() {
 void MultipleRangeSelector::accept() {
     if (ui->singleButton->isChecked()) {
         bool ok = false;
-        int v1 = ui->startEdit->text().toInt(&ok);
+        qint64 v1 = ui->startEdit->text().toLongLong(&ok);
         if (!ok || v1 < 1 || v1 > seqLen) {
             return;
         }
-        int v2 = ui->endEdit->text().toInt(&ok);
+        qint64 v2 = ui->endEdit->text().toLongLong(&ok);
         if (!ok || (v2 < v1 && !isCircular) || v2 > seqLen) {
             return;
         }
@@ -275,8 +275,8 @@ void MultipleRangeSelector::accept() {
 }
 
 void MultipleRangeSelector::sl_textEdited(const QString&) {
-    int min = ui->startEdit->text().toInt();
-    int max = ui->endEdit->text().toInt();
+    qint64 min = ui->startEdit->text().toLongLong();
+    qint64 max = ui->endEdit->text().toLongLong();
     QPalette p = normalPalette;
     if (min > max && !isCircular) {
         p.setColor(QPalette::Base, QColor(255, 200, 200));
@@ -307,10 +307,10 @@ QVector<U2Region> MultipleRangeSelector::getSelectedRegions() {
 
     if (ui->singleButton->isChecked()) {
         bool ok = false;
-        int st = ui->startEdit->text().toInt(&ok);
+        qint64 st = ui->startEdit->text().toLongLong(&ok);
         CHECK(ok, currentRegions);
 
-        int en = ui->endEdit->text().toInt(&ok);
+        qint64 en = ui->endEdit->text().toLongLong(&ok);
         CHECK(ok, currentRegions);
 
         if (isCircular && st > en) {

--- a/src/corelibs/U2Gui/src/util/RangeSelector.h
+++ b/src/corelibs/U2Gui/src/util/RangeSelector.h
@@ -36,15 +36,15 @@ namespace U2 {
 class U2GUI_EXPORT RangeSelector : public QWidget {
     Q_OBJECT
 public:
-    RangeSelector(QDialog* dialog, int rangeStart, int rangeEnd, int len, bool autoClose);
+    RangeSelector(QDialog* dialog, qint64 rangeStart, qint64 rangeEnd, qint64 len, bool autoClose);
 
-    int getStart() const;
+    qint64 getStart() const;
 
-    int getEnd() const;
+    qint64 getEnd() const;
 
 signals:
 
-    void si_rangeChanged(int startPos, int endPos);
+    void si_rangeChanged(qint64 startPos, qint64 endPos);
 
 private slots:
 
@@ -61,9 +61,9 @@ private:
 
     void exec();
 
-    int rangeStart;
-    int rangeEnd;
-    int len;
+    qint64 rangeStart = 0;
+    qint64 rangeEnd = 0;
+    qint64 len = 0;
 
     QLineEdit* startEdit;
     QLineEdit* endEdit;
@@ -79,7 +79,7 @@ private:
 class U2GUI_EXPORT MultipleRangeSelector : public QDialog {
     Q_OBJECT
 public:
-    MultipleRangeSelector(QWidget* parent, const QVector<U2Region>& _regions, int _seqLen, bool isCircular);
+    MultipleRangeSelector(QWidget* parent, const QVector<U2Region>& _regions, qint64 _seqLen, bool isCircular);
 
     ~MultipleRangeSelector();
 
@@ -88,7 +88,7 @@ public:
     QVector<U2Region> getSelectedRegions();
 
 private:
-    int seqLen;
+    qint64 seqLen = 0;
     QVector<U2Region> selectedRanges;
     bool isCircular;
     QPalette normalPalette;

--- a/src/corelibs/U2View/src/ov_sequence/GSequenceLineView.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/GSequenceLineView.cpp
@@ -684,7 +684,7 @@ qint64 GSequenceLineViewRenderArea::coordToPos(const QPoint& coord) const {
     int x = qBound(0, coord.x(), width());
     const U2Region& visibleRange = view->getVisibleRange();
     double scale = getCurrentScale();
-    qint64 pos = qFloor((double)visibleRange.startPos + x / scale);
+    qint64 pos = std::floor((double)visibleRange.startPos + x / scale);
     return qBound(visibleRange.startPos, pos, visibleRange.endPos());
 }
 


### PR DESCRIPTION
Селекторы региона использовали исключительно `int`, из-за чего возникали проблемы на последовательностях длиной больше чем 2^31. Так же `qFloor` кастует результат к `int`, из-за чего на длинных последовательностях были проблемы с выделением.

Затрудняюсь с тестом, тут все гуишное и завязано на очень больших данных (2Гб+).