### PR TITLE
UGENE-7787 [Pcr, wd] Improve logging when using too small primers

### DIFF
--- a/src/plugins/CoreTests/src/CMDLineTests.cpp
+++ b/src/plugins/CoreTests/src/CMDLineTests.cpp
@@ -98,6 +98,10 @@ void GTest_RunCMDLine::setArgs(const QDomElement& el) {
             expectedMessage = node.nodeValue();
             continue;
         }
+        if (nodeName == "message2") {
+            expectedMessage2 = node.nodeValue();
+            continue;
+        }
         if (nodeName == "nomessage") {
             unexpectedMessage = node.nodeValue();
             continue;
@@ -212,6 +216,12 @@ Task::ReportResult GTest_RunCMDLine::report() {
     if (!expectedMessage.isEmpty()) {
         cmdLog.error(output);
         if (!output.contains(expectedMessage, Qt::CaseSensitive)) {
+            stateInfo.setError(QString("Expected message not found in output"));
+        }
+    }
+    if (!expectedMessage2.isEmpty()) {
+        cmdLog.error(output);
+        if (!output.contains(expectedMessage2, Qt::CaseSensitive)) {
             stateInfo.setError(QString("Expected message not found in output"));
         }
     }

--- a/src/plugins/CoreTests/src/CMDLineTests.h
+++ b/src/plugins/CoreTests/src/CMDLineTests.h
@@ -49,6 +49,7 @@ private:
 
 private:
     QString expectedMessage;
+    QString expectedMessage2;
     QString unexpectedMessage;
     QStringList args;
     QProcess* proc = nullptr;

--- a/src/plugins/pcr/src/InSilicoPcrWorker.cpp
+++ b/src/plugins/pcr/src/InSilicoPcrWorker.cpp
@@ -212,6 +212,7 @@ void InSilicoPcrWorker::onPrepared(Task* task, U2OpStatus& os) {
     CHECK_OP(os, );
 
     auto TmCalculator = AppContext::getTmCalculatorRegistry()->createTmCalculator(getValue<QVariantMap>(InSilicoPcrWorkerFactory::TEMPERATURE_SETTINGS_ID));
+    QList<QPair<Primer, Primer>> primersToExclude;
     for (const auto& primerPair : qAsConst(primers)) {
         bool isCriticalError = false;
         QString message = PrimerStatistics::checkPcrPrimersPair(primerPair.first.sequence.toLocal8Bit(),
@@ -221,7 +222,10 @@ void InSilicoPcrWorker::onPrepared(Task* task, U2OpStatus& os) {
         CHECK_CONTINUE(isCriticalError);
 
         coreLog.error(message);
-        primers.removeOne(primerPair);
+        primersToExclude << primerPair;
+    }
+    for (const auto& primerToExclude : qAsConst(primersToExclude)) {
+        primers.removeOne(primerToExclude);
     }
     if (primers.isEmpty()) {
         os.setError(tr("All primer pairs have been filtered, see log for details."));

--- a/src/plugins/pcr/src/InSilicoPcrWorker.cpp
+++ b/src/plugins/pcr/src/InSilicoPcrWorker.cpp
@@ -54,6 +54,7 @@ namespace U2 {
 namespace LocalWorkflow {
 
 const QString InSilicoPcrWorkerFactory::ACTOR_ID = "in-silico-pcr";
+const QString InSilicoPcrWorkerFactory::TEMPERATURE_SETTINGS_ID = "temperature-settings";
 namespace {
 const QString OUT_PORT_ID = "out";
 const QString PRIMERS_ATTR_ID = "primers-url";
@@ -63,7 +64,6 @@ const QString PERFECT_ATTR_ID = "perfect-match";
 const QString MAX_PRODUCT_ATTR_ID = "max-product";
 const QString USE_AMBIGUOUS_BASES_ID = "use-ambiguous-bases";
 const QString EXTRACT_ANNOTATIONS_ATTR_ID = "extract-annotations";
-const QString TEMPERATURE_SETTINGS_ID = "temperature-settings";
 
 const char* PAIR_NUMBER_PROP_ID = "pair-number";
 }  // namespace
@@ -209,36 +209,41 @@ void InSilicoPcrWorker::onPrepared(Task* task, U2OpStatus& os) {
     CHECK_EXT(0 == objects.size() % 2, os.setError(tr("There is the odd number of primers in the file: ") + loadTask->getURLString()), );
 
     fetchPrimers(objects, os);
+    CHECK_OP(os, );
+
+    auto TmCalculator = AppContext::getTmCalculatorRegistry()->createTmCalculator(getValue<QVariantMap>(InSilicoPcrWorkerFactory::TEMPERATURE_SETTINGS_ID));
+    for (const auto& primerPair : qAsConst(primers)) {
+        bool isCriticalError = false;
+        QString message = PrimerStatistics::checkPcrPrimersPair(primerPair.first.sequence.toLocal8Bit(),
+                                                                primerPair.second.sequence.toLocal8Bit(),
+                                                                TmCalculator,
+                                                                isCriticalError);
+        CHECK_CONTINUE(isCriticalError);
+
+        coreLog.error(message);
+        primers.removeOne(primerPair);
+    }
+    if (primers.isEmpty()) {
+        os.setError(tr("All primer pairs have been filtered, see log for details."));
+    }
 }
 
 void InSilicoPcrWorker::fetchPrimers(const QList<GObject*>& objects, U2OpStatus& os) {
     for (int i = 0; i < objects.size() / 2; i++) {
-        bool skipped = false;
-
-        Primer forward = createPrimer(objects[2 * i], skipped, os);
+        Primer forward = createPrimer(objects[2 * i], os);
         CHECK_OP(os, );
 
-        Primer reverse = createPrimer(objects[2 * i + 1], skipped, os);
+        Primer reverse = createPrimer(objects[2 * i + 1], os);
         CHECK_OP(os, );
-
-        if (skipped) {
-            continue;
-        }
 
         primers << QPair<Primer, Primer>(forward, reverse);
     }
 }
 
-Primer InSilicoPcrWorker::createPrimer(GObject* object, bool& skipped, U2OpStatus& os) {
+Primer InSilicoPcrWorker::createPrimer(GObject* object, U2OpStatus& os) {
     Primer result;
     auto primerSeq = qobject_cast<U2SequenceObject*>(object);
     CHECK_EXT(primerSeq != nullptr, os.setError(L10N::nullPointerError("Primer sequence")), result);
-
-    if (primerSeq->getSequenceLength() > Primer::MAX_LEN) {
-        skipped = true;
-        coreLog.details(tr("Primer sequence is too long: %1. The pair is skipped").arg(primerSeq->getSequenceName()));
-        return result;
-    }
 
     result.name = primerSeq->getSequenceName();
     result.sequence = primerSeq->getWholeSequenceData(os);
@@ -324,7 +329,7 @@ int InSilicoPcrWorker::createMetadata(int sequenceLength, const U2Region& produc
 Task* InSilicoPcrWorker::onInputEnded() {
     CHECK(!reported, nullptr);
     reported = true;
-    QVariantMap tmAlgorithmSettings = getValue<QVariantMap>(TEMPERATURE_SETTINGS_ID);
+    QVariantMap tmAlgorithmSettings = getValue<QVariantMap>(InSilicoPcrWorkerFactory::TEMPERATURE_SETTINGS_ID);
     if (tmAlgorithmSettings.isEmpty()) {
         tmAlgorithmSettings = AppContext::getTmCalculatorRegistry()->getDefaultTmCalculatorFactory()->createDefaultSettings();
     }
@@ -371,7 +376,7 @@ Task* InSilicoPcrWorker::createTask(const Message& message, U2OpStatus& os) {
         pcrSettings->useAmbiguousBases = getValue<bool>(USE_AMBIGUOUS_BASES_ID);
         pcrSettings->perfectMatch = getValue<int>(PERFECT_ATTR_ID);
         pcrSettings->sequenceName = seq->getSequenceName();
-        QVariantMap tmAlgorithmSettings = getValue<QVariantMap>(TEMPERATURE_SETTINGS_ID);
+        QVariantMap tmAlgorithmSettings = getValue<QVariantMap>(InSilicoPcrWorkerFactory::TEMPERATURE_SETTINGS_ID);
         TmCalculatorRegistry* tmRegistry = AppContext::getTmCalculatorRegistry();
         pcrSettings->temperatureCalculator = tmRegistry->createTmCalculator(tmAlgorithmSettings);
         CHECK(pcrSettings->temperatureCalculator != nullptr,
@@ -382,7 +387,7 @@ Task* InSilicoPcrWorker::createTask(const Message& message, U2OpStatus& os) {
         tasks << pcrTask;
     }
     sequences << seqId;
-    CHECK(!tasks.isEmpty(), new FailTask(tr("Primers specified in \"%1\" are too long.").arg(QFileInfo(getValue<QString>(PRIMERS_ATTR_ID)).fileName())));
+    SAFE_POINT(!tasks.isEmpty(), "Tasks shouldn't be empty", new FailTask("Tasks shouldn't be empty"));
 
     return new MultiTask(tr("Multiple In Silico PCR"), tasks);
 }

--- a/src/plugins/pcr/src/InSilicoPcrWorker.h
+++ b/src/plugins/pcr/src/InSilicoPcrWorker.h
@@ -46,6 +46,7 @@ public:
     Worker* createWorker(Actor* a);
 
     static const QString ACTOR_ID;
+    static const QString TEMPERATURE_SETTINGS_ID;
     static void init();
 };
 
@@ -94,7 +95,7 @@ protected:
 
 private:
     void fetchPrimers(const QList<GObject*>& objects, U2OpStatus& os);
-    Primer createPrimer(GObject* object, bool& skipped, U2OpStatus& os);
+    Primer createPrimer(GObject* object, U2OpStatus& os);
     int createMetadata(int sequenceLength, const U2Region& productRegion, int pairNumber);
     QByteArray createReport() const;
     QVariant fetchSequence(Document* doc);

--- a/src/plugins/pcr/transl/russian.ts
+++ b/src/plugins/pcr/transl/russian.ts
@@ -619,27 +619,27 @@
 <context>
     <name>U2::LocalWorkflow::InSilicoPcrReportTask</name>
     <message>
-        <location filename="../src/InSilicoPcrWorker.cpp" line="398"/>
+        <location filename="../src/InSilicoPcrWorker.cpp" line="409"/>
         <source>Generate In Silico PCR report</source>
         <translation>Generate In Silico PCR report</translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrWorker.cpp" line="431"/>
+        <location filename="../src/InSilicoPcrWorker.cpp" line="442"/>
         <source>Sequence name</source>
         <translation>Имя последовательности</translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrWorker.cpp" line="447"/>
+        <location filename="../src/InSilicoPcrWorker.cpp" line="458"/>
         <source>Products count table</source>
         <translation>Таблица продуктов</translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrWorker.cpp" line="456"/>
+        <location filename="../src/InSilicoPcrWorker.cpp" line="467"/>
         <source>An error &apos;%1&apos; has occurred during processing file with primers &apos;%2&apos;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrWorker.cpp" line="463"/>
+        <location filename="../src/InSilicoPcrWorker.cpp" line="474"/>
         <source>Primer pair details</source>
         <translation>Информация о парах праймеров</translation>
     </message>
@@ -792,42 +792,37 @@
         <translation>There is the odd number of primers in the file: </translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrWorker.cpp" line="239"/>
-        <source>Primer sequence is too long: %1. The pair is skipped</source>
-        <translation>Primer sequence is too long: %1. The pair is skipped</translation>
+        <location filename="../src/InSilicoPcrWorker.cpp" line="227"/>
+        <source>All primer pairs have been filtered, see log for details.</source>
+        <translation>Все пары праймеров были отфильтрованы, детали вычисления смотрите в логе.</translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrWorker.cpp" line="296"/>
+        <location filename="../src/InSilicoPcrWorker.cpp" line="307"/>
         <source>Wrong sequence objects count</source>
         <translation>Wrong sequence objects count</translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrWorker.cpp" line="306"/>
+        <location filename="../src/InSilicoPcrWorker.cpp" line="317"/>
         <source>Wrong annotations objects count</source>
         <translation>Wrong annotations objects count</translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrWorker.cpp" line="340"/>
+        <location filename="../src/InSilicoPcrWorker.cpp" line="351"/>
         <source>The input file &quot;%1&quot; doesn&apos;t contain a valid sequence.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrWorker.cpp" line="344"/>
+        <location filename="../src/InSilicoPcrWorker.cpp" line="355"/>
         <source>The sequence is too long: </source>
         <translation>The sequence is too long: </translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrWorker.cpp" line="378"/>
+        <location filename="../src/InSilicoPcrWorker.cpp" line="389"/>
         <source>Failed to find TM algorithm with id &apos;%1&apos;.</source>
         <translation>Не удалось найти алгоритм расчета температуры плавления с ID %1.</translation>
     </message>
     <message>
-        <location filename="../src/InSilicoPcrWorker.cpp" line="385"/>
-        <source>Primers specified in &quot;%1&quot; are too long.</source>
-        <translation>Праймеры указанные в &quot;%1&quot; слишком длинные.</translation>
-    </message>
-    <message>
-        <location filename="../src/InSilicoPcrWorker.cpp" line="387"/>
+        <location filename="../src/InSilicoPcrWorker.cpp" line="398"/>
         <source>Multiple In Silico PCR</source>
         <translation>Multiple In Silico PCR</translation>
     </message>

--- a/tests/cmdline/common/pcr/test_0005.xml
+++ b/tests/cmdline/common/pcr/test_0005.xml
@@ -8,7 +8,7 @@
             in="!common_data_dir!fasta/pcr_test.fa"
             primers="!common_data_dir!cmdline/pcr/primers_long1.fa"
             working-dir="pcr_0005"
-            message="Primer sequence is too long"
+            message="The forward primer length should be between 15 and 200 bp. Unable to calculate primer statistics."
     />
 
     <check-temp-file url="pcr_0005/pcr_test_pIB2-SEC13_1_fr_3-3396.gb" exists="1"/>

--- a/tests/cmdline/common/pcr/test_0006.xml
+++ b/tests/cmdline/common/pcr/test_0006.xml
@@ -8,7 +8,7 @@
             in="!common_data_dir!fasta/pcr_test.fa"
             primers="!common_data_dir!cmdline/pcr/primers_long2.fa"
             working-dir="pcr_0006"
-            message="Primer sequence is too long"
+            message="The reverse primer length should be between 15 and 200 bp. Unable to calculate primer statistics."
     />
 
     <check-temp-file url="pcr_0006/pcr_test_pIB2-SEC13_1_fr_3-3396.gb" exists="1"/>

--- a/tests/cmdline/common/pcr/test_0009.xml
+++ b/tests/cmdline/common/pcr/test_0009.xml
@@ -1,13 +1,13 @@
 <multi-test>
 
-    <remove-temp-dir url="pcr_0008"/>
-    <create-temp-dir url="pcr_0008"/>
+    <remove-temp-dir url="pcr_0009"/>
+    <create-temp-dir url="pcr_0009"/>
 
     <run-cmdline
             task="!common_data_dir!cmdline/pcr/pcr.uwl"
             in="!common_data_dir!genbank/CVU55762.gb"
-            primers="!common_data_dir!cmdline/pcr/long_primers.fa"
-            working-dir="pcr_0008"
+            primers="!common_data_dir!cmdline/pcr/TooSmallPrimers.txt"
+            working-dir="pcr_0009"
             message="The forward primer length should be between 15 and 200 bp. Unable to calculate primer statistics."
             message2="All primer pairs have been filtered, see log for details."
     />

--- a/tests/regression/7216/test_0001.xml
+++ b/tests/regression/7216/test_0001.xml
@@ -5,7 +5,7 @@ task="!common_data_dir!cmdline/pcr/pcr.uwl"
 in="!common_data_dir!fasta/pcr_test.fa"
 primers="!common_data_dir!primer3/not_for_production_2.lib"
 out="!tmp_data_dir!7216_out.gb"
-message="An error 'Unexpected symbol: Y' has occurred during processing file with primers"
+message="The reverse primer contains a character from the Extended DNA alphabet. Unable to calculate primer statistics."
 />
 
 </multi-test>


### PR DESCRIPTION
У проблемы слишком длинный/короткий праймер в WD было как-то очень много не связанных друг с другом обработчиков, я их все удалил и оставил один со стандартным сообщением, которое мы используем в GUI интерфейсе на вкладке OP в SV