### PR TITLE
Remove trace log about translation files selection.

### DIFF
--- a/src/ugenecl/src/Main.cpp
+++ b/src/ugenecl/src/Main.cpp
@@ -248,7 +248,6 @@ int main(int argc, char** argv) {
     // Set translations if needed: use value in the settings or cmd-line parameter override.
     // The default case 'en' does not need any files: the values for this locale are hardcoded in the code.
     QTranslator translator;
-    QStringList failedToLoadTranslatorFiles;  // List of translators file names tried but failed to load/not found.
     QStringList translationFileList = {
         "transl_" + cmdLineRegistry->getParameterValue(CMDLineCoreOptions::TRANSLATION),
         userAppSettings->getTranslationFile(),
@@ -263,7 +262,6 @@ int main(int argc, char** argv) {
         if (translationFile == "transl_en" || translator.load(translationFile, AppContext::getWorkingDirectoryPath())) {
             break;
         }
-        failedToLoadTranslatorFiles << translationFile;
     }
     if (!translator.isEmpty()) {
         QCoreApplication::installTranslator(&translator);
@@ -274,10 +272,6 @@ int main(int argc, char** argv) {
     ConsoleLogDriver logs;
     Q_UNUSED(logs);
     coreLog.details(AppContextImpl::tr("UGENE initialization started"));
-    for (const QString& fileName : failedToLoadTranslatorFiles) {
-        coreLog.trace(QObject::tr("Translation file not found: %1").arg(fileName));
-    }
-
     auto resTrack = new ResourceTracker();
     appContext->setResourceTracker(resTrack);
 

--- a/src/ugeneui/src/Main.cpp
+++ b/src/ugeneui/src/Main.cpp
@@ -502,15 +502,11 @@ int main(int argc, char** argv) {
     // Set translations if needed: use value in the settings or environment variables to override.
     // The default case 'en' does not need any files: the values for this locale are hardcoded in the code.
     QTranslator translator;
-    QStringList failedToLoadTranslatorFiles;  // List of translators file names tried but failed to load/not found.
 
     // The file specified by user has the highest priority in the translations lookup order.
     QStringList envList = QProcess::systemEnvironment();
     QString envTranslationFile = findKey(envList, "UGENE_TRANSLATION_FILE");
     if (envTranslationFile.isEmpty() || !translator.load(envTranslationFile)) {
-        if (!envTranslationFile.isEmpty()) {
-            failedToLoadTranslatorFiles << envTranslationFile;
-        }
         QStringList translationFileList = {
             "transl_" + findKey(envList, "UGENE_TRANSLATION"),
             userAppSettings->getTranslationFile(),
@@ -525,7 +521,6 @@ int main(int argc, char** argv) {
             if (translationFile == "transl_en" || translator.load(translationFile, AppContext::getWorkingDirectoryPath())) {
                 break;
             }
-            failedToLoadTranslatorFiles << translationFile;
         }
     }
     if (!translator.isEmpty()) {
@@ -542,9 +537,6 @@ int main(int argc, char** argv) {
     LogCache::setAppGlobalInstance(&logsCache);
     app.installEventFilter(new UserActionsWriter());
     coreLog.details(UserAppsSettings::tr("UGENE initialization started"));
-    for (const QString& fileName : failedToLoadTranslatorFiles) {
-        coreLog.trace(QObject::tr("Translation file not found: %1").arg(fileName));
-    }
 
     int ugeneArch = getUgeneBinaryArch();
     QString ugeneArchCounterSuffix = ugeneArch == UGENE_ARCH_X86_64   ? "Ugene 64-bit"

--- a/src/ugeneui/transl/russian.ts
+++ b/src/ugeneui/transl/russian.ts
@@ -438,11 +438,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/Main.cpp" line="546"/>
-        <source>Translation file not found: %1</source>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="../src/Main.cpp" line="845"/>
         <source>UGENE started</source>
         <translation>UGENE готов к работе</translation>

--- a/src/ugeneui/transl/turkish.ts
+++ b/src/ugeneui/transl/turkish.ts
@@ -450,11 +450,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/Main.cpp" line="532"/>
-        <source>Translation file not found: %1</source>
-        <translation>Çeviri dosyası bulunamadı: %1</translation>
-    </message>
-    <message>
         <location filename="../src/Main.cpp" line="846"/>
         <source>UGENE started</source>
         <translation>UGENE başladı</translation>


### PR DESCRIPTION
Reason: this debug log was used during development and debugging and is not needed today - messages like this look misleading in the log.