### PR TITLE
UGENE-7843 Improve "Construct molecule" and "Edit molecule fragment" dialogs

### DIFF
--- a/src/libs_3rdparty/QSpec/src/primitives/GTListWidget.cpp
+++ b/src/libs_3rdparty/QSpec/src/primitives/GTListWidget.cpp
@@ -29,8 +29,8 @@ namespace HI {
 
 #define GT_CLASS_NAME "GTListWidget"
 
-void GTListWidget::click(QListWidget* listWidget, const QString& text, Qt::MouseButton button, int foundItemsNum) {
-    QList<QListWidgetItem*> list = listWidget->findItems(text, Qt::MatchExactly);
+void GTListWidget::click(QListWidget* listWidget, const QString& text, Qt::MouseButton button, int foundItemsNum, const GTGlobals::FindOptions& options) {
+    QList<QListWidgetItem*> list = listWidget->findItems(text, options.matchPolicy);
     GT_CHECK(0 <= foundItemsNum && foundItemsNum < list.size(), QString("item %1 not found").arg(text));
 
     QListWidgetItem* item = list.at(foundItemsNum);

--- a/src/libs_3rdparty/QSpec/src/primitives/GTListWidget.h
+++ b/src/libs_3rdparty/QSpec/src/primitives/GTListWidget.h
@@ -28,7 +28,7 @@ namespace HI {
 
 class HI_EXPORT GTListWidget {
 public:
-    static void click(QListWidget* listWidget, const QString& text, Qt::MouseButton button = Qt::LeftButton, int foundItemsNum = 0);
+    static void click(QListWidget* listWidget, const QString& text, Qt::MouseButton button = Qt::LeftButton, int foundItemsNum = 0, const GTGlobals::FindOptions& options = {});
     static bool isItemChecked(QListWidget* listWidget, const QString& text);
     static void checkItem(QListWidget* listWidget, const QString& text, bool newState);
     static void checkAllItems(QListWidget* listWidget, bool newState);

--- a/src/plugins/GUITestBase/src/GUITestBasePlugin.cpp
+++ b/src/plugins/GUITestBase/src/GUITestBasePlugin.cpp
@@ -3420,6 +3420,8 @@ void GUITestBasePlugin::registerTests(UGUITestBase* guiTestBase) {
     // common_scenarios/cloning
     /////////////////////////////////////////////////////////////////////////
     REGISTER_TEST(GUITest_common_scenarios_cloning::test_0011);
+    REGISTER_TEST(GUITest_common_scenarios_cloning::test_0012);
+    REGISTER_TEST(GUITest_common_scenarios_cloning::test_0013);
 
     /////////////////////////////////////////////////////////////////////////
     // common_scenarios/options_panel/sequence_view

--- a/src/plugins/GUITestBase/src/runnables/ugene/plugins/enzymes/ConstructMoleculeDialogFiller.cpp
+++ b/src/plugins/GUITestBase/src/runnables/ugene/plugins/enzymes/ConstructMoleculeDialogFiller.cpp
@@ -20,6 +20,8 @@
  */
 
 #include "ConstructMoleculeDialogFiller.h"
+#include <primitives/GTCheckBox.h>
+#include <primitives/GTListWidget.h>
 #include <primitives/GTTreeWidget.h>
 #include <primitives/GTWidget.h>
 
@@ -44,11 +46,26 @@ void ConstructMoleculeDialogFiller::commonScenario() {
 
     foreach (const Action& action, actions) {
         switch (action.first) {
+            case AddFragment:
+                addFragment(action.second);
+                break;
             case AddAllFragments:
                 addAllFragments();
                 break;
+            case SelectAddedFragment:
+                selectFragment(action.second);
+                break;
             case InvertAddedFragment:
                 invertAddedFragment(action.second);
+                break;
+            case CheckMakeCircular:
+                checkMakeCircular(action.second);
+                break;
+            case ClickAdjustLeft:
+                clickAdjustLeft();
+                break;
+            case ClickAdjustRight:
+                clickAdjustRight();
                 break;
             case ClickCancel:
                 clickCancel();
@@ -62,18 +79,55 @@ void ConstructMoleculeDialogFiller::commonScenario() {
     }
 }
 
+void ConstructMoleculeDialogFiller::addFragment(const QVariant& actionData) {
+    GT_CHECK(actionData.canConvert<QString>(), "Can't get a fragment name's part from the action data");
+
+    auto fragmentListWidget = GTWidget::findListWidget("fragmentListWidget", dialog);
+    GTGlobals::FindOptions options;
+    options.matchPolicy = Qt::MatchContains;
+    GTListWidget::click(fragmentListWidget, actionData.toString(), Qt::LeftButton, 0, options);
+    GTWidget::click(GTWidget::findPushButton("takeButton", dialog));
+}
+
 void ConstructMoleculeDialogFiller::addAllFragments() {
     GTWidget::click(GTWidget::findWidget("takeAllButton", dialog));
     GTGlobals::sleep();
 }
 
+void ConstructMoleculeDialogFiller::selectFragment(const QVariant& actionData) {
+    GT_CHECK(actionData.canConvert<QString>(), "Can't get a fragment name's part from the action data");
+    GTGlobals::FindOptions options;
+    options.matchPolicy = Qt::MatchContains;
+    QTreeWidgetItem* item = GTTreeWidget::findItem(GTWidget::findTreeWidget("molConstructWidget", dialog), actionData.toString(), nullptr, 1, options);
+    GTTreeWidget::click(item, 1);
+}
+
 void ConstructMoleculeDialogFiller::invertAddedFragment(const QVariant& actionData) {
     GT_CHECK(actionData.canConvert<QString>(), "Can't get a fragment name's part from the action data");
+
     GTGlobals::FindOptions options;
     options.matchPolicy = Qt::MatchContains;
     QTreeWidgetItem* item = GTTreeWidget::findItem(GTWidget::findTreeWidget("molConstructWidget", dialog), actionData.toString(), nullptr, 1, options);
     bool isCheck = item->data(3, Qt::CheckStateRole).toInt() == Qt::Unchecked;
     GTTreeWidget::checkItem(item, 3, GTGlobals::UseMouse, isCheck, false);  // Do not validate the result. The item is replaced on toggle.
+}
+
+void ConstructMoleculeDialogFiller::checkMakeCircular(const QVariant& actionData) {
+    bool check = true;
+    if (!actionData.isValid()) {
+        GT_CHECK(actionData.canConvert<bool>(), "Can't convert to bool");
+        check = actionData.toBool();
+    }
+
+    GTCheckBox::setChecked("makeCircularBox", check);
+}
+
+void ConstructMoleculeDialogFiller::clickAdjustLeft() {
+    GTWidget::click(GTWidget::findToolButton("tbAdjustLeft", dialog));
+}
+
+void ConstructMoleculeDialogFiller::clickAdjustRight() {
+    GTWidget::click(GTWidget::findToolButton("tbAdjustRight", dialog));
 }
 
 void ConstructMoleculeDialogFiller::clickCancel() {

--- a/src/plugins/GUITestBase/src/runnables/ugene/plugins/enzymes/ConstructMoleculeDialogFiller.h
+++ b/src/plugins/GUITestBase/src/runnables/ugene/plugins/enzymes/ConstructMoleculeDialogFiller.h
@@ -29,8 +29,13 @@ using namespace HI;
 class ConstructMoleculeDialogFiller : public Filler {
 public:
     enum ActionType {  // an appropriate action data
+        AddFragment,  // QString with a part of the fragment name, if several fragments match this part, the first one will be selected
         AddAllFragments,  // ignored
+        SelectAddedFragment,  // QString with a part of the fragment name, if several fragments match this part, the first one will be selected
         InvertAddedFragment,  // QString with a part of the fragment name, if several fragments match this part, the first one will be inverted
+        CheckMakeCircular,  // Check state, true if ignored
+        ClickAdjustLeft,  // ignored
+        ClickAdjustRight,  // ignored
         ClickCancel,  // ignored
         ClickOk
     };
@@ -42,8 +47,13 @@ public:
     void commonScenario();
 
 private:
+    void addFragment(const QVariant& actionData);
     void addAllFragments();
+    void selectFragment(const QVariant& actionData);
     void invertAddedFragment(const QVariant& actionData);
+    void checkMakeCircular(const QVariant& actionData);
+    void clickAdjustLeft();
+    void clickAdjustRight();
     void clickCancel();
     void clickOk();
 

--- a/src/plugins/GUITestBase/src/runnables/ugene/plugins/enzymes/EditFragmentDialogFiller.cpp
+++ b/src/plugins/GUITestBase/src/runnables/ugene/plugins/enzymes/EditFragmentDialogFiller.cpp
@@ -21,6 +21,7 @@
 
 #include "EditFragmentDialogFiller.h"
 #include <primitives/GTCheckBox.h>
+#include <primitives/GTComboBox.h>
 #include <primitives/GTGroupBox.h>
 #include <primitives/GTLineEdit.h>
 #include <primitives/GTRadioButton.h>
@@ -42,9 +43,8 @@ void EditFragmentDialogFiller::commonScenario() {
 
     // GUITest_regression_scenarios_test_0574
     if (parameters.checkRComplText) {
-        GTRadioButton::click(GTWidget::findRadioButton("rStickyButton", dialog));
-        auto rCustomOverhangBox = GTWidget::findGroupBox("rCustomOverhangBox", dialog);
-        GTGroupBox::setChecked(rCustomOverhangBox, true);
+        auto cbRightEndType = GTWidget::findComboBox("cbRightEndType", dialog);
+        GTComboBox::selectItemByText(cbRightEndType, "Sticky");
         GTRadioButton::click(GTWidget::findRadioButton("rComplRadioButton", dialog));
         GT_CHECK(GTLineEdit::getText("rComplOverhangEdit", dialog) == parameters.rComplText, "Wrong rComplTextEdit text");
         GTUtilsDialog::clickButtonBox(dialog, QDialogButtonBox::Cancel);
@@ -52,11 +52,8 @@ void EditFragmentDialogFiller::commonScenario() {
     }
 
     if (parameters.lSticky) {
-        auto lStickyButton = GTWidget::findRadioButton("lStickyButton", dialog);
-        GTRadioButton::click(lStickyButton);
-
-        auto lCustomOverhangBox = GTWidget::findGroupBox("lCustomOverhangBox", dialog);
-        GTGroupBox::setChecked(lCustomOverhangBox, parameters.lCustom);
+        auto cbLeftEndType = GTWidget::findComboBox("cbLeftEndType", dialog);
+        GTComboBox::selectItemByText(cbLeftEndType, "Sticky");
 
         if (parameters.lCustom) {
             if (parameters.lDirect) {
@@ -72,16 +69,13 @@ void EditFragmentDialogFiller::commonScenario() {
             }
         }
     } else {
-        auto lBluntButton = GTWidget::findRadioButton("lBluntButton", dialog);
-        GTRadioButton::click(lBluntButton);
+        auto cbLeftEndType = GTWidget::findComboBox("cbLeftEndType", dialog);
+        GTComboBox::selectItemByText(cbLeftEndType, "Blunt");
     }
 
     if (parameters.rSticky) {
-        auto rStickyButton = GTWidget::findRadioButton("rStickyButton", dialog);
-        GTRadioButton::click(rStickyButton);
-
-        auto rCustomOverhangBox = GTWidget::findGroupBox("rCustomOverhangBox", dialog);
-        GTGroupBox::setChecked(rCustomOverhangBox, parameters.rCustom);
+        auto cbRightEndType = GTWidget::findComboBox("cbRightEndType", dialog);
+        GTComboBox::selectItemByText(cbRightEndType, "Sticky");
 
         if (parameters.rCustom) {
             if (parameters.rDirect) {
@@ -97,8 +91,8 @@ void EditFragmentDialogFiller::commonScenario() {
             }
         }
     } else {
-        auto rBluntButton = GTWidget::findRadioButton("rBluntButton", dialog);
-        GTRadioButton::click(rBluntButton);
+        auto cbRightEndType = GTWidget::findComboBox("cbRightEndType", dialog);
+        GTComboBox::selectItemByText(cbRightEndType, "Blunt");
     }
 
     GTUtilsDialog::clickButtonBox(dialog, QDialogButtonBox::Ok);

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/cloning/GTTestsCloning.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/cloning/GTTestsCloning.cpp
@@ -28,9 +28,13 @@
 #include <U2Gui/ToolsMenu.h>
 
 #include "GTUtilsAnnotationsTreeView.h"
+#include "GTUtilsSequenceView.h"
 #include "GTUtilsTaskTreeView.h"
+#include "GTUtilsNotifications.h"
 #include "primitives/GTMenu.h"
+#include "runnables/ugene/plugins/enzymes/ConstructMoleculeDialogFiller.h"
 #include "runnables/ugene/plugins/enzymes/DigestSequenceDialogFiller.h"
+#include "runnables/ugene/plugins/enzymes/EditFragmentDialogFiller.h"
 #include "runnables/ugene/plugins/enzymes/FindEnzymesDialogFiller.h"
 #include "utils/GTUtilsDialog.h"
 
@@ -87,6 +91,64 @@ GUI_TEST_CLASS_DEFINITION(test_0011) {
     GTUtilsAnnotationsTreeView::findItem("right_end_term", fr2);
     GTUtilsAnnotationsTreeView::findItem("right_end_type", fr2);
 }
+
+GUI_TEST_CLASS_DEFINITION(test_0012) {
+    // Open _common_data/cloning/murine_fragments.gb
+    // Click "Tools" -> "Cloning" -> "Construct molecule..."
+    // Click on the "Fragment 1"
+    // Expected: fragment right end is red and does not fit to the left end of the fragment below
+    // Click "Adjust right end"
+    // Expected: fragment right end has been chaned and now fits to the corresponding left end of the fragment below
+    // Click on the "Fragment 2"
+    // Expected: fragment left end is red and does not fit to the right end of the fragment above
+    // Click "Adjust left end"
+    // Expected: fragment left end has been chaned and now fits to the corresponding right end of the fragment above
+    // Click "OK"
+    // The new product has been created, no error notifications
+    GTFileDialog::openFile(testDir + "_common_data/cloning/", "murine_fragments.gb");
+    GTUtilsSequenceView::checkSequenceViewWindowIsActive();
+
+    QList<ConstructMoleculeDialogFiller::Action> actions;
+    actions << ConstructMoleculeDialogFiller::Action(ConstructMoleculeDialogFiller::AddAllFragments, "");
+    actions << ConstructMoleculeDialogFiller::Action(ConstructMoleculeDialogFiller::SelectAddedFragment, "Fragment 1");
+    actions << ConstructMoleculeDialogFiller::Action(ConstructMoleculeDialogFiller::ClickAdjustRight, "");
+    actions << ConstructMoleculeDialogFiller::Action(ConstructMoleculeDialogFiller::SelectAddedFragment, "Fragment 2");
+    actions << ConstructMoleculeDialogFiller::Action(ConstructMoleculeDialogFiller::ClickAdjustLeft, "");
+    actions << ConstructMoleculeDialogFiller::Action(ConstructMoleculeDialogFiller::ClickOk, "");
+    GTUtilsDialog::waitForDialog(new ConstructMoleculeDialogFiller(actions));
+    GTMenu::clickMainMenuItem({"Tools", "Cloning", "Construct molecule..."});
+    GTUtilsTaskTreeView::waitTaskFinished();
+    GTUtilsNotifications::checkNoVisibleNotifications();
+}
+
+GUI_TEST_CLASS_DEFINITION(test_0013) {
+    // Open _common_data/cloning/murine_fragments.gb
+    // Click "Tools" -> "Cloning" -> "Construct molecule..."
+    // Click on the "Fragment 3"
+    // Click on the "Fragment 1"
+    // Check "Make circular"
+    // Select "Fragment 3"
+    // Expected: Fragment 3 left end is red and does not fit to the right end of the Fragment 1
+    // Click "Adjust left end"
+    // Expected: Fragment 3 left end has been chaned and now fits to the corresponding right end of the Fragment 1
+    // Click "OK"
+    // The new product has been created, no error notifications
+    GTFileDialog::openFile(testDir + "_common_data/cloning/", "murine_fragments.gb");
+    GTUtilsSequenceView::checkSequenceViewWindowIsActive();
+
+    QList<ConstructMoleculeDialogFiller::Action> actions;
+    actions << ConstructMoleculeDialogFiller::Action(ConstructMoleculeDialogFiller::AddFragment, "Fragment 3");
+    actions << ConstructMoleculeDialogFiller::Action(ConstructMoleculeDialogFiller::AddFragment, "Fragment 1");
+    actions << ConstructMoleculeDialogFiller::Action(ConstructMoleculeDialogFiller::CheckMakeCircular, "");
+    actions << ConstructMoleculeDialogFiller::Action(ConstructMoleculeDialogFiller::SelectAddedFragment, "Fragment 3");
+    actions << ConstructMoleculeDialogFiller::Action(ConstructMoleculeDialogFiller::ClickAdjustLeft, "");
+    actions << ConstructMoleculeDialogFiller::Action(ConstructMoleculeDialogFiller::ClickOk, "");
+    GTUtilsDialog::waitForDialog(new ConstructMoleculeDialogFiller(actions));
+    GTMenu::clickMainMenuItem({"Tools", "Cloning", "Construct molecule..."});
+    GTUtilsTaskTreeView::waitTaskFinished();
+    GTUtilsNotifications::checkNoVisibleNotifications();
+}
+
 
 }  // namespace GUITest_common_scenarios_cloning
 

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/cloning/GTTestsCloning.h
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/cloning/GTTestsCloning.h
@@ -30,6 +30,8 @@ namespace GUITest_common_scenarios_cloning {
 #define GUI_TEST_SUITE "GUITest_common_scenarios_cloning"
 
 GUI_TEST_CLASS_DECLARATION(test_0011)
+GUI_TEST_CLASS_DECLARATION(test_0012)
+GUI_TEST_CLASS_DECLARATION(test_0013)
 
 #undef GUI_TEST_SUITE
 }  // namespace GUITest_common_scenarios_cloning

--- a/src/plugins/enzymes/src/ConstructMoleculeDialog.cpp
+++ b/src/plugins/enzymes/src/ConstructMoleculeDialog.cpp
@@ -384,7 +384,7 @@ void ConstructMoleculeDialog::sl_adjustLeftEnd() {
     if (itemAbove == nullptr) {
         SAFE_POINT(makeCircularBox->isChecked(), "Should be circular", );
 
-        auto downItem = molConstructWidget->itemBelow(selectedItem);
+        auto downItem = selectedItem;
         while (molConstructWidget->itemBelow(downItem) != nullptr) {
             downItem = molConstructWidget->itemBelow(downItem);
         }
@@ -419,7 +419,7 @@ void ConstructMoleculeDialog::sl_adjustRightEnd() {
     if (itemBelow == nullptr) {
         SAFE_POINT(makeCircularBox->isChecked(), "Should be circular", );
 
-        auto topItem = molConstructWidget->itemAbove(selectedItem);
+        auto topItem = selectedItem;
         while (molConstructWidget->itemAbove(topItem) != nullptr) {
             topItem = molConstructWidget->itemAbove(topItem);
         }

--- a/src/plugins/enzymes/src/ConstructMoleculeDialog.cpp
+++ b/src/plugins/enzymes/src/ConstructMoleculeDialog.cpp
@@ -288,6 +288,17 @@ void ConstructMoleculeDialog::initSaveController() {
     saveController = new SaveDocumentController(config, formats, this);
 }
 
+const QString ConstructMoleculeDialog::createEndSign(const DNAFragmentTerm& term) {
+    QString result;
+    if (term.type == OVERHANG_TYPE_STICKY) {
+        result = QString("%1 (%2)").arg(QString(term.overhang)).arg(term.isDirect ? tr("Fwd") : tr("Rev"));
+    } else {
+        result = tr("Blunt");
+    }
+
+    return result;
+}
+
 void ConstructMoleculeDialog::sl_makeCircularBoxClicked() {
     update();
 }
@@ -359,6 +370,9 @@ void ConstructMoleculeDialog::sl_onItemClicked(QTreeWidgetItem* item, int column
     tbAdjustRight->setEnabled(adjustRightIsActive);
 }
 
+static constexpr int LEFT_END_COLUMN = 0;
+static constexpr int RIGHT_END_COLUMN = 2;
+
 void ConstructMoleculeDialog::sl_adjustLeftEnd() {
     auto selectedItem = molConstructWidget->currentItem();
     SAFE_POINT_NN(selectedItem, );
@@ -389,9 +403,9 @@ void ConstructMoleculeDialog::sl_adjustLeftEnd() {
     fragment.setLeftTermType(overhang.isEmpty() ? OVERHANG_TYPE_BLUNT : OVERHANG_TYPE_STICKY);
     fragment.setLeftOverhangStrand(!rightTerm.isDirect);
 
-    tbAdjustLeft->setEnabled(false);
-    tbAdjustRight->setEnabled(false);
-    update();
+    selectedItem->setText(LEFT_END_COLUMN, createEndSign(fragment.getLeftTerminus()));
+    selectedItem->setTextColor(LEFT_END_COLUMN, Qt::green);
+    itemAbove->setTextColor(RIGHT_END_COLUMN, Qt::green);
 }
 
 void ConstructMoleculeDialog::sl_adjustRightEnd() {
@@ -427,9 +441,9 @@ void ConstructMoleculeDialog::sl_adjustRightEnd() {
     fragment.setRightTermType(overhang.isEmpty() ? OVERHANG_TYPE_BLUNT : OVERHANG_TYPE_STICKY);
     fragment.setRightOverhangStrand(!leftTerm.isDirect);
 
-    tbAdjustLeft->setEnabled(false);
-    tbAdjustRight->setEnabled(false);
-    update();
+    selectedItem->setText(RIGHT_END_COLUMN, createEndSign(fragment.getRightTerminus()));
+    selectedItem->setTextColor(RIGHT_END_COLUMN, Qt::green);
+    itemBelow->setTextColor(LEFT_END_COLUMN, Qt::green);
 }
 
 void ConstructMoleculeDialog::sl_onAddFromProjectButtonClicked() {

--- a/src/plugins/enzymes/src/ConstructMoleculeDialog.cpp
+++ b/src/plugins/enzymes/src/ConstructMoleculeDialog.cpp
@@ -333,11 +333,14 @@ bool ConstructMoleculeDialog::eventFilter(QObject* obj, QEvent* event) {
         case QEvent::FocusOut:
             molConstructWidget->clearSelection();
             break;
-        case QEvent::KeyPress:
+        case QEvent::KeyPress: {
             QKeyEvent* ke = (QKeyEvent*)event;
             if (ke->key() == Qt::Key_Delete) {
                 sl_onRemoveButtonClicked();
             }
+        }
+        default:
+            break;
         }
     }
 
@@ -353,21 +356,26 @@ void ConstructMoleculeDialog::sl_onItemClicked(QTreeWidgetItem* item, int column
         int idx = molConstructWidget->indexOfTopLevelItem(item);
         DNAFragment& fragment = fragments[selected[idx]];
         if (item->checkState(column) == Qt::Checked) {
+            CHECK(!fragment.isInverted(), );
+
             fragment.setInverted(true);
         } else {
+            CHECK(fragment.isInverted(), );
+
             fragment.setInverted(false);
         }
         update();
-    }
-    if (molConstructWidget->itemAbove(item) == nullptr) {
-        adjustLeftIsActive = makeCircularBox->isChecked();
-    }
-    if (molConstructWidget->itemBelow(item) == nullptr) {
-        adjustRightIsActive = makeCircularBox->isChecked();
-    }
+    } else {
+        if (molConstructWidget->itemAbove(item) == nullptr) {
+            adjustLeftIsActive = makeCircularBox->isChecked();
+        }
+        if (molConstructWidget->itemBelow(item) == nullptr) {
+            adjustRightIsActive = makeCircularBox->isChecked();
+        }
 
-    tbAdjustLeft->setEnabled(adjustLeftIsActive);
-    tbAdjustRight->setEnabled(adjustRightIsActive);
+        tbAdjustLeft->setEnabled(adjustLeftIsActive);
+        tbAdjustRight->setEnabled(adjustRightIsActive);
+    }
 }
 
 static constexpr int LEFT_END_COLUMN = 0;

--- a/src/plugins/enzymes/src/ConstructMoleculeDialog.cpp
+++ b/src/plugins/enzymes/src/ConstructMoleculeDialog.cpp
@@ -334,8 +334,6 @@ bool ConstructMoleculeDialog::eventFilter(QObject* obj, QEvent* event) {
 }
 
 void ConstructMoleculeDialog::sl_onItemClicked(QTreeWidgetItem* item, int column) {
-    static constexpr int FIVE_END_COLUMN = 0;
-    static constexpr int THREE_END_COLUMN = 2;
     static constexpr int INVERTED_COLUMN = 3;
 
     bool adjustLeftIsActive = true;

--- a/src/plugins/enzymes/src/ConstructMoleculeDialog.h
+++ b/src/plugins/enzymes/src/ConstructMoleculeDialog.h
@@ -59,6 +59,8 @@ private:
     void update();
     void initSaveController();
 
+    static const QString createEndSign(const DNAFragmentTerm& term);
+
     QList<DNAFragment> fragments;
     QList<int> selected;
     SaveDocumentController* saveController;

--- a/src/plugins/enzymes/src/ConstructMoleculeDialog.h
+++ b/src/plugins/enzymes/src/ConstructMoleculeDialog.h
@@ -49,6 +49,8 @@ private slots:
     void sl_forceBluntBoxClicked();
     void sl_onEditFragmentButtonClicked();
     void sl_onItemClicked(QTreeWidgetItem* item, int column);
+    void sl_adjustLeftEnd();
+    void sl_adjustRightEnd();
 
 protected:
     bool eventFilter(QObject* obj, QEvent* event);

--- a/src/plugins/enzymes/src/ConstructMoleculeDialog.ui
+++ b/src/plugins/enzymes/src/ConstructMoleculeDialog.ui
@@ -193,6 +193,26 @@
           </widget>
          </item>
          <item>
+          <widget class="QToolButton" name="tbAdjustLeft">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Adjust left end</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="tbAdjustRight">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Adjust right end</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QToolButton" name="clearButton">
            <property name="toolTip">
             <string>Clear molecule contents</string>

--- a/src/plugins/enzymes/src/ConstructMoleculeDialog.ui
+++ b/src/plugins/enzymes/src/ConstructMoleculeDialog.ui
@@ -187,6 +187,9 @@
          </item>
          <item>
           <widget class="QToolButton" name="editFragmentButton">
+           <property name="toolTip">
+            <string>Open the &quot;Edit Molecule Fragment&quot; dialog</string>
+           </property>
            <property name="text">
             <string>Edit</string>
            </property>
@@ -197,8 +200,11 @@
            <property name="enabled">
             <bool>false</bool>
            </property>
+           <property name="toolTip">
+            <string>Automatically edit selected fragment's 5' end and fit it to the 3' end of the fragment above</string>
+           </property>
            <property name="text">
-            <string>Adjust left end</string>
+            <string>Adjust 5' end</string>
            </property>
           </widget>
          </item>
@@ -207,8 +213,11 @@
            <property name="enabled">
             <bool>false</bool>
            </property>
+           <property name="toolTip">
+            <string>Automatically edit selected fragment's 3' end and fit it to the 5' end of the fragment below</string>
+           </property>
            <property name="text">
-            <string>Adjust right end</string>
+            <string>Adjust 3' end</string>
            </property>
           </widget>
          </item>

--- a/src/plugins/enzymes/src/EditFragmentDialog.h
+++ b/src/plugins/enzymes/src/EditFragmentDialog.h
@@ -36,6 +36,11 @@ public:
     void accept() override;
 
 private:
+    enum class OverhangType {
+        Blunt,
+        Sticky
+    };
+
     DNAFragment& dnaFragment;
     DNATranslation* transl;
     QString seq, trseq;
@@ -43,6 +48,8 @@ private:
     void resetLeftOverhang();
     void resetRightOverhang();
     bool isValidOverhang(const QString& text);
+
+    QMap<QString, OverhangType> comboBoxItems;
 private slots:
     void sl_updatePreview();
     void sl_onLeftResetClicked();

--- a/src/plugins/enzymes/src/EditFragmentDialog.ui
+++ b/src/plugins/enzymes/src/EditFragmentDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>488</width>
-    <height>567</height>
+    <height>565</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -19,7 +19,7 @@
   <property name="windowTitle">
    <string>Edit Molecule Fragment</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_7">
+  <layout class="QVBoxLayout" name="verticalLayout_5">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -27,45 +27,24 @@
        <property name="title">
         <string>Left End</string>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_5">
+       <layout class="QVBoxLayout" name="verticalLayout_4">
         <item>
-         <widget class="QGroupBox" name="groupBox_2">
-          <property name="title">
-           <string>Type</string>
-          </property>
-          <property name="checkable">
-           <bool>false</bool>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout">
-           <item>
-            <widget class="QRadioButton" name="lStickyButton">
-             <property name="text">
-              <string>Overhang</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QRadioButton" name="lBluntButton">
-             <property name="text">
-              <string>Blunt</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
+         <layout class="QFormLayout" name="formLayout_3">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Type</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="cbLeftEndType"/>
+          </item>
+         </layout>
         </item>
         <item>
-         <widget class="QGroupBox" name="lCustomOverhangBox">
-          <property name="title">
-           <string>Custom overhang</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <property name="checked">
+         <widget class="QWidget" name="lStickyWidget" native="true">
+          <property name="enabled">
            <bool>false</bool>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -97,6 +76,9 @@
              </item>
              <item row="1" column="1">
               <widget class="QLineEdit" name="lComplOverhangEdit">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
                <property name="maxLength">
                 <number>15</number>
                </property>
@@ -122,45 +104,27 @@
        <property name="title">
         <string>Right End</string>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_6">
+       <layout class="QVBoxLayout" name="verticalLayout_3">
         <item>
-         <widget class="QGroupBox" name="groupBox_4">
-          <property name="title">
-           <string>Type</string>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_4">
-           <item>
-            <widget class="QRadioButton" name="rStickyButton">
-             <property name="text">
-              <string>Overhang</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QRadioButton" name="rBluntButton">
-             <property name="text">
-              <string>Blunt</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Type</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="cbRightEndType"/>
+          </item>
+         </layout>
         </item>
         <item>
-         <widget class="QGroupBox" name="rCustomOverhangBox">
-          <property name="title">
-           <string>Custom overhang</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <property name="checked">
+         <widget class="QWidget" name="rStickyWidget" native="true">
+          <property name="enabled">
            <bool>false</bool>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout_3">
+          <layout class="QVBoxLayout" name="verticalLayout">
            <item>
             <layout class="QGridLayout" name="gridLayout_2">
              <item row="0" column="0">
@@ -304,34 +268,130 @@
    </hints>
   </connection>
   <connection>
-   <sender>lBluntButton</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>lCustomOverhangBox</receiver>
+   <sender>lDirectRadioButton</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>lComplOverhangEdit</receiver>
    <slot>setDisabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>125</x>
-     <y>90</y>
+     <x>53</x>
+     <y>103</y>
     </hint>
     <hint type="destinationlabel">
-     <x>125</x>
-     <y>160</y>
+     <x>151</x>
+     <y>131</y>
     </hint>
    </hints>
   </connection>
   <connection>
-   <sender>rBluntButton</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>rCustomOverhangBox</receiver>
+   <sender>lComplRadioButton</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>lDirectOverhangEdit</receiver>
    <slot>setDisabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>362</x>
-     <y>90</y>
+     <x>53</x>
+     <y>131</y>
     </hint>
     <hint type="destinationlabel">
-     <x>362</x>
-     <y>173</y>
+     <x>151</x>
+     <y>103</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>lComplRadioButton</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>lComplOverhangEdit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>53</x>
+     <y>131</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>151</x>
+     <y>131</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>lDirectRadioButton</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>lDirectOverhangEdit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>53</x>
+     <y>103</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>151</x>
+     <y>103</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>rComplRadioButton</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>rDirectOverhangEdit</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>290</x>
+     <y>131</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>388</x>
+     <y>103</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>rDirectRadioButton</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>rComplOverhangEdit</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>290</x>
+     <y>103</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>388</x>
+     <y>114</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>rComplRadioButton</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>rComplOverhangEdit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>290</x>
+     <y>131</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>388</x>
+     <y>131</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>rDirectRadioButton</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>rDirectOverhangEdit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>290</x>
+     <y>103</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>388</x>
+     <y>86</y>
     </hint>
    </hints>
   </connection>

--- a/src/plugins/enzymes/transl/russian.ts
+++ b/src/plugins/enzymes/transl/russian.ts
@@ -104,32 +104,42 @@
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="198"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="201"/>
+        <source>Adjust left end</source>
+        <translation>Подогнать левый конец</translation>
+    </message>
+    <message>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="211"/>
+        <source>Adjust right end</source>
+        <translation>Подогнать правый конец</translation>
+    </message>
+    <message>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="218"/>
         <source>Clear molecule contents</source>
         <translation>Убрать все фрагменты</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="201"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="221"/>
         <source>Clear All</source>
         <translation>Очистить все</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="223"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="243"/>
         <source>Annotate fragments in new molecule</source>
         <translation>Аннотировать фрагменты в новой молекуле</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="242"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="262"/>
         <source>Force &quot;blunt&quot; and omit all overhangs</source>
         <translation>Не учитывать липкие концы и исключить их</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="258"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="278"/>
         <source>Make circular</source>
         <translation>Сделать круговой</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="236"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="256"/>
         <source>Setting this option checked will result in ignoring overhangs while constructing new molecule.</source>
         <translation>Включение опции позволяет не учитывать липкие концы фрагментов при создании новой молекулы.</translation>
     </message>
@@ -144,32 +154,32 @@
         <translation>Редактировать</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="255"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="275"/>
         <source>Circulirize result molecule</source>
         <translation>Сделать создаваемую молекулу круговой</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="266"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="286"/>
         <source>Output</source>
         <translation>Выходные параметры</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="274"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="294"/>
         <source>Path to file:</source>
         <translation>Путь к файлу:</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="284"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="304"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="296"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="316"/>
         <source>Open view for new molecule</source>
         <translation>Загрузить созданную молекулу</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="309"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="329"/>
         <source>Save immediately</source>
         <translation>Сохранить сразу</translation>
     </message>
@@ -327,56 +337,50 @@
         <translation>Левый конец</translation>
     </message>
     <message>
-        <location filename="../src/EditFragmentDialog.ui" line="43"/>
-        <location filename="../src/EditFragmentDialog.ui" line="135"/>
         <source>Overhang</source>
-        <translation>Выступ</translation>
+        <translation type="vanished">Выступ</translation>
     </message>
     <message>
-        <location filename="../src/EditFragmentDialog.ui" line="63"/>
-        <location filename="../src/EditFragmentDialog.ui" line="155"/>
         <source>Custom overhang</source>
-        <translation>Задать выступ</translation>
+        <translation type="vanished">Задать выступ</translation>
     </message>
     <message>
-        <location filename="../src/EditFragmentDialog.ui" line="77"/>
-        <location filename="../src/EditFragmentDialog.ui" line="169"/>
+        <location filename="../src/EditFragmentDialog.ui" line="56"/>
+        <location filename="../src/EditFragmentDialog.ui" line="133"/>
         <source>5&apos;-3&apos;</source>
         <translation>5&apos;-3&apos;</translation>
     </message>
     <message>
-        <location filename="../src/EditFragmentDialog.ui" line="94"/>
-        <location filename="../src/EditFragmentDialog.ui" line="186"/>
+        <location filename="../src/EditFragmentDialog.ui" line="73"/>
+        <location filename="../src/EditFragmentDialog.ui" line="150"/>
         <source>3&apos;-5&apos;</source>
         <translation>3&apos;-5&apos;</translation>
     </message>
     <message>
-        <location filename="../src/EditFragmentDialog.ui" line="123"/>
+        <location filename="../src/EditFragmentDialog.ui" line="105"/>
         <source>Right End</source>
         <translation>Правый конец</translation>
     </message>
     <message>
-        <location filename="../src/EditFragmentDialog.ui" line="34"/>
-        <location filename="../src/EditFragmentDialog.ui" line="129"/>
+        <location filename="../src/EditFragmentDialog.ui" line="36"/>
+        <location filename="../src/EditFragmentDialog.ui" line="113"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../src/EditFragmentDialog.ui" line="220"/>
+        <location filename="../src/EditFragmentDialog.ui" line="184"/>
         <source>Preview:</source>
         <translation>Предварительный просмотр:</translation>
     </message>
     <message>
-        <location filename="../src/EditFragmentDialog.ui" line="110"/>
-        <location filename="../src/EditFragmentDialog.ui" line="205"/>
+        <location filename="../src/EditFragmentDialog.ui" line="92"/>
+        <location filename="../src/EditFragmentDialog.ui" line="169"/>
         <source>Reset</source>
         <translation>Сбросить</translation>
     </message>
     <message>
-        <location filename="../src/EditFragmentDialog.ui" line="53"/>
-        <location filename="../src/EditFragmentDialog.ui" line="145"/>
         <source>Blunt</source>
-        <translation>Срез</translation>
+        <translation type="vanished">Срез</translation>
     </message>
 </context>
 <context>
@@ -719,71 +723,74 @@
 <context>
     <name>U2::ConstructMoleculeDialog</name>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.cpp" line="97"/>
+        <location filename="../src/ConstructMoleculeDialog.cpp" line="104"/>
         <source>No fragments are selected!
  Please construct molecule from available fragments.</source>
         <translation>Выберите фрагменты, составляющие новую молекулу.</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.cpp" line="276"/>
+        <location filename="../src/ConstructMoleculeDialog.cpp" line="283"/>
         <source>Set new molecule file name</source>
         <translation>Задайте имя файла</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.cpp" line="62"/>
+        <location filename="../src/ConstructMoleculeDialog.cpp" line="66"/>
         <source>core length</source>
         <translation>длина ядра</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.cpp" line="203"/>
         <location filename="../src/ConstructMoleculeDialog.cpp" line="210"/>
+        <location filename="../src/ConstructMoleculeDialog.cpp" line="217"/>
+        <location filename="../src/ConstructMoleculeDialog.cpp" line="296"/>
         <source>Blunt</source>
         <translation>&quot;Срез&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.cpp" line="201"/>
         <location filename="../src/ConstructMoleculeDialog.cpp" line="208"/>
+        <location filename="../src/ConstructMoleculeDialog.cpp" line="215"/>
+        <location filename="../src/ConstructMoleculeDialog.cpp" line="294"/>
         <source>Fwd</source>
         <translation>Прям</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.cpp" line="58"/>
+        <location filename="../src/ConstructMoleculeDialog.cpp" line="62"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.cpp" line="59"/>
+        <location filename="../src/ConstructMoleculeDialog.cpp" line="63"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.cpp" line="201"/>
         <location filename="../src/ConstructMoleculeDialog.cpp" line="208"/>
+        <location filename="../src/ConstructMoleculeDialog.cpp" line="215"/>
+        <location filename="../src/ConstructMoleculeDialog.cpp" line="294"/>
         <source>Rev</source>
         <translation>Обр</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.cpp" line="205"/>
+        <location filename="../src/ConstructMoleculeDialog.cpp" line="212"/>
         <source>Left end</source>
         <translation>Левый конец</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.cpp" line="212"/>
+        <location filename="../src/ConstructMoleculeDialog.cpp" line="219"/>
         <source>Right end</source>
         <translation>Правый конец</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.cpp" line="214"/>
+        <location filename="../src/ConstructMoleculeDialog.cpp" line="221"/>
         <source>yes</source>
         <translation>да</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.cpp" line="214"/>
+        <location filename="../src/ConstructMoleculeDialog.cpp" line="221"/>
         <source>no</source>
         <translation>нет</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.cpp" line="215"/>
+        <location filename="../src/ConstructMoleculeDialog.cpp" line="222"/>
         <source>Make fragment reverse complement</source>
         <translation>Сделать фрагмент обратно-комплементарным</translation>
     </message>
@@ -920,52 +927,62 @@ Choose another region.</translation>
 <context>
     <name>U2::EditFragmentDialog</name>
     <message>
-        <location filename="../src/EditFragmentDialog.cpp" line="46"/>
+        <location filename="../src/EditFragmentDialog.cpp" line="45"/>
+        <source>Blunt</source>
+        <translation>Прямой</translation>
+    </message>
+    <message>
+        <location filename="../src/EditFragmentDialog.cpp" line="45"/>
+        <source>Sticky</source>
+        <translation>Липкий</translation>
+    </message>
+    <message>
+        <location filename="../src/EditFragmentDialog.cpp" line="48"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/EditFragmentDialog.cpp" line="47"/>
+        <location filename="../src/EditFragmentDialog.cpp" line="49"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/EditFragmentDialog.cpp" line="127"/>
+        <location filename="../src/EditFragmentDialog.cpp" line="154"/>
         <source>Left overhang is empty. Please enter the overhang or set blunt left end.</source>
         <translation>Левый выступ не задан. Задайте выступ или уставновите срез.</translation>
     </message>
     <message>
-        <location filename="../src/EditFragmentDialog.cpp" line="131"/>
+        <location filename="../src/EditFragmentDialog.cpp" line="158"/>
         <source>Invalid left overhang: unsupported alphabet!</source>
         <translation>Недопустимое левый конец: неподдерживаемый алфавит!</translation>
     </message>
     <message>
-        <location filename="../src/EditFragmentDialog.cpp" line="150"/>
+        <location filename="../src/EditFragmentDialog.cpp" line="177"/>
         <source>Right overhang is empty. Please enter the overhang or set blunt right end.</source>
         <translation>Правый выступ не задан. Задайте выступ или уставновите срез.</translation>
     </message>
     <message>
-        <location filename="../src/EditFragmentDialog.cpp" line="154"/>
+        <location filename="../src/EditFragmentDialog.cpp" line="181"/>
         <source>Invalid right overhang: unsupported alphabet!</source>
         <translation>Недопустимое правый конец: неподдерживаемый алфавит!</translation>
     </message>
     <message>
-        <location filename="../src/EditFragmentDialog.cpp" line="173"/>
+        <location filename="../src/EditFragmentDialog.cpp" line="200"/>
         <source> (INVERTED)</source>
         <translation> (ИНВЕРТИРОВАН)</translation>
     </message>
     <message>
-        <location filename="../src/EditFragmentDialog.cpp" line="175"/>
+        <location filename="../src/EditFragmentDialog.cpp" line="202"/>
         <source>Fragment of %1%2&lt;br&gt;</source>
         <translation>Фрагмент %1%2&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../src/EditFragmentDialog.cpp" line="189"/>
+        <location filename="../src/EditFragmentDialog.cpp" line="216"/>
         <source>&lt;tr&gt; &lt;td align=&quot;center&quot;&gt; 5&apos; &lt;/td&gt;&lt;td&gt;&lt;/td&gt; &lt;td align=&quot;center&quot;&gt; 3&apos; &lt;/td&gt; &lt;/tr&gt;</source>
         <translation>&lt;tr&gt; &lt;td align=&quot;center&quot;&gt; 5&apos; &lt;/td&gt;&lt;td&gt;&lt;/td&gt; &lt;td align=&quot;center&quot;&gt; 3&apos; &lt;/td&gt; &lt;/tr&gt;</translation>
     </message>
     <message>
-        <location filename="../src/EditFragmentDialog.cpp" line="193"/>
+        <location filename="../src/EditFragmentDialog.cpp" line="220"/>
         <source>&lt;tr&gt; &lt;td align=&quot;center&quot;&gt; 3&apos; &lt;/td&gt;&lt;td&gt;&lt;/td&gt; &lt;td align=&quot;center&quot;&gt; 5&apos; &lt;/td&gt; &lt;/tr&gt;</source>
         <translation>&lt;tr&gt; &lt;td align=&quot;center&quot;&gt; 3&apos; &lt;/td&gt;&lt;td&gt;&lt;/td&gt; &lt;td align=&quot;center&quot;&gt; 5&apos; &lt;/td&gt; &lt;/tr&gt;</translation>
     </message>
@@ -1398,7 +1415,7 @@ To start ligation create a project or open an existing.</source>
 <context>
     <name>U2::InsertEnzymeWidget</name>
     <message numerus="yes">
-        <location filename="../src/insert/InsertEnzymeWidget.cpp" line="71"/>
+        <location filename="../src/insert/InsertEnzymeWidget.cpp" line="78"/>
         <source>%n enzyme(s)</source>
         <translation>
             <numerusform>%n сайт</numerusform>

--- a/src/plugins/enzymes/transl/russian.ts
+++ b/src/plugins/enzymes/transl/russian.ts
@@ -104,42 +104,32 @@
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="201"/>
-        <source>Adjust left end</source>
-        <translation>Подогнать левый конец</translation>
-    </message>
-    <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="211"/>
-        <source>Adjust right end</source>
-        <translation>Подогнать правый конец</translation>
-    </message>
-    <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="218"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="227"/>
         <source>Clear molecule contents</source>
         <translation>Убрать все фрагменты</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="221"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="230"/>
         <source>Clear All</source>
         <translation>Очистить все</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="243"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="252"/>
         <source>Annotate fragments in new molecule</source>
         <translation>Аннотировать фрагменты в новой молекуле</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="262"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="271"/>
         <source>Force &quot;blunt&quot; and omit all overhangs</source>
         <translation>Не учитывать липкие концы и исключить их</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="278"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="287"/>
         <source>Make circular</source>
         <translation>Сделать круговой</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="256"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="265"/>
         <source>Setting this option checked will result in ignoring overhangs while constructing new molecule.</source>
         <translation>Включение опции позволяет не учитывать липкие концы фрагментов при создании новой молекулы.</translation>
     </message>
@@ -150,36 +140,61 @@
     </message>
     <message>
         <location filename="../src/ConstructMoleculeDialog.ui" line="191"/>
+        <source>Open the &quot;Edit Molecule Fragment&quot; dialog</source>
+        <translation>Откройте диалоговое окно &quot;Редактировать фрагмент&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="194"/>
         <source>Edit</source>
         <translation>Редактировать</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="275"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="204"/>
+        <source>Automatically edit selected fragment&apos;s 5&apos; end and fit it to the 3&apos; end of the fragment above</source>
+        <translation>Автоматически отредактировать 5&apos; конец выделенного фрагмента таким образом, чтобы он подходил к 3&apos; концу фрагмента выше</translation>
+    </message>
+    <message>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="207"/>
+        <source>Adjust 5&apos; end</source>
+        <translation>Подогнать 5&apos; конец</translation>
+    </message>
+    <message>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="217"/>
+        <source>Automatically edit selected fragment&apos;s 3&apos; end and fit it to the 5&apos; end of the fragment below</source>
+        <translation>Автоматически отредактировать 3&apos; конец выделенного фрагмента таким образом, чтобы он подходил к 5&apos; концу фрагмента ниже</translation>
+    </message>
+    <message>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="220"/>
+        <source>Adjust 3&apos; end</source>
+        <translation>Подогнать 3&apos; конец</translation>
+    </message>
+    <message>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="284"/>
         <source>Circulirize result molecule</source>
         <translation>Сделать создаваемую молекулу круговой</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="286"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="295"/>
         <source>Output</source>
         <translation>Выходные параметры</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="294"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="303"/>
         <source>Path to file:</source>
         <translation>Путь к файлу:</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="304"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="313"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="316"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="325"/>
         <source>Open view for new molecule</source>
         <translation>Загрузить созданную молекулу</translation>
     </message>
     <message>
-        <location filename="../src/ConstructMoleculeDialog.ui" line="329"/>
+        <location filename="../src/ConstructMoleculeDialog.ui" line="338"/>
         <source>Save immediately</source>
         <translation>Сохранить сразу</translation>
     </message>
@@ -337,14 +352,6 @@
         <translation>Левый конец</translation>
     </message>
     <message>
-        <source>Overhang</source>
-        <translation type="vanished">Выступ</translation>
-    </message>
-    <message>
-        <source>Custom overhang</source>
-        <translation type="vanished">Задать выступ</translation>
-    </message>
-    <message>
         <location filename="../src/EditFragmentDialog.ui" line="56"/>
         <location filename="../src/EditFragmentDialog.ui" line="133"/>
         <source>5&apos;-3&apos;</source>
@@ -377,10 +384,6 @@
         <location filename="../src/EditFragmentDialog.ui" line="169"/>
         <source>Reset</source>
         <translation>Сбросить</translation>
-    </message>
-    <message>
-        <source>Blunt</source>
-        <translation type="vanished">Срез</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Сделал прям по пунктам, что написано в задаче. Добавил пару тестов на кнопку "Adjust 5'/3' end". На диалог редактирования концов не стал добавлять тест, т.к. подправил `GUITest_regression_scenarios_test_0574`, а он один в один проверяет все, что нужно