### PR TITLE
UGENE-7783 The "ACE" format "A name is duplicated" error

### DIFF
--- a/src/corelibs/U2Formats/src/ace/AceFormat.cpp
+++ b/src/corelibs/U2Formats/src/ace/AceFormat.cpp
@@ -214,7 +214,7 @@ static inline void skipBreaks(U2::IOAdapter* io, U2OpStatus& ti, char* buff, qin
     CHECK_EXT(lineOk, ti.setError(ACEFormat::tr("Line is too long")), );
 }
 
-static inline void parseConsensus(U2::IOAdapter* io, U2OpStatus& ti, char* buff, QString& consName, QList<QString>& names, QString& headerLine, QByteArray& consensus) {
+static inline void parseConsensus(U2::IOAdapter* io, U2OpStatus& ti, char* buff, QString& consName, QString& headerLine, QByteArray& consensus) {
     char aceBStartChar = 'B';
     QBitArray aceBStart = TextUtils::createBitMap(aceBStartChar);
     qint64 len = 0;
@@ -222,9 +222,7 @@ static inline void parseConsensus(U2::IOAdapter* io, U2OpStatus& ti, char* buff,
     QString line;
     consName = getName(headerLine);
     CHECK_EXT(!consName.isEmpty(), ti.setError(ACEFormat::tr("There is no AF note")), );
-    CHECK_EXT(!names.contains(consName), ti.setError(ACEFormat::tr("A name is duplicated")), );
 
-    names << consName;
     consensus.clear();
     do {
         len = io->readUntil(buff, DocumentFormat::READ_BUFF_SIZE, aceBStart, IOAdapter::Term_Exclude, &ok);
@@ -407,13 +405,11 @@ void ACEFormat::load(IOAdapter* io, const U2DbiRef& dbiRef, QList<GObject*>& obj
         int count = readsCount(headerLine);
         CHECK_EXT(count != -1, os.setError(ACEFormat::tr("There is no note about reads count")), );
 
-        QList<QString> names;
-
         // consensus
         QByteArray consensus;
         QString consName;
 
-        parseConsensus(io, os, buff, consName, names, headerLine, consensus);
+        parseConsensus(io, os, buff, consName, headerLine, consensus);
         CHECK_OP(os, );
 
         Msa al(consName);
@@ -421,6 +417,7 @@ void ACEFormat::load(IOAdapter* io, const U2DbiRef& dbiRef, QList<GObject*>& obj
 
         // AF
         QList<Assembly::Sequence> reads;
+        QList<QString> names;
         parseAFTag(io, os, buff, count, reads, names);
         CHECK_OP(os, );
 

--- a/src/corelibs/U2Formats/src/ace/AceFormat.h
+++ b/src/corelibs/U2Formats/src/ace/AceFormat.h
@@ -44,14 +44,40 @@ protected:
     Document* loadTextDocument(IOAdapter* io, const U2DbiRef& dbiRef, const QVariantMap& fs, U2OpStatus& os) override;
 
 private:
+    /*
+     * Parses the AF tag of the format. This tag has the following structure:
+     * AF <read name> <C or U> <padded start consensus position>
+     * C or U means complemented or uncomplemented (direct, in UGENE terms).
+     * The <read name> is the true read name.
+     *
+     * \param io the input-ouput adapter instance.
+     * \param ti the state information handler instance.
+     * \param buff buffer, whuch contains text, read from the file.
+     * \param count the number of reads, read from header of the file.
+     * \param reads reads representation.All information, except sequence itself, should be filled in this function.
+     * \param names the list of all reads in the current contig.
+     * This value will be used further to check, that AF and RD tags has comparable reads.
+     **/
     static void parseAFTag(U2::IOAdapter* io, U2OpStatus& ti, char* buff, int count, QList<Assembly::Sequence>& reads, QList<QString>& names);
+    /*
+     * Parses RD and QA tags of the format. These tags have the following structures:
+     * RD <read name> <# of padded bases> <# of whole read info items> <# of read tags>
+     * QA <qual clipping start> <qual clipping end> <align clipping start> <align clipping end>
+     *
+     * \param io the input-ouput adapter instance.
+     * \param ti the state information handler instance.
+     * \param buff buffer, whuch contains text, read from the file.
+     * \param names the list of all reads in the current contig.
+     * \param name name of the considerable read.
+     * \param sequence considerable read's sequence.
+     **/
     static void parseRDandQATag(U2::IOAdapter* io, U2OpStatus& ti, char* buff, QList<QString>& names, QString& name, QByteArray& sequence);
 
     /**
      * Offsets in an ACE file are specified relatively to the reference sequence,
      * so "pos" can be negative.
      */
-    static int getSmallestOffset(const QList<Assembly::Sequence>& reads);
+    static qint64 getSmallestOffset(const QList<Assembly::Sequence>& reads);
 
     void load(IOAdapter* io, const U2DbiRef& dbiRef, QList<GObject*>& objects, const QVariantMap& hints, U2OpStatus& ti);
 

--- a/src/corelibs/U2Formats/src/ace/AceFormat.h
+++ b/src/corelibs/U2Formats/src/ace/AceFormat.h
@@ -55,10 +55,9 @@ private:
      * \param buff buffer, whuch contains text, read from the file.
      * \param count the number of reads, read from header of the file.
      * \param reads reads representation.All information, except sequence itself, should be filled in this function.
-     * \param names the list of all reads in the current contig.
      * This value will be used further to check, that AF and RD tags has comparable reads.
      **/
-    static void parseAFTag(U2::IOAdapter* io, U2OpStatus& ti, char* buff, int count, QList<Assembly::Sequence>& reads, QList<QString>& names);
+    static void parseAFTag(U2::IOAdapter* io, U2OpStatus& ti, char* buff, int count, QList<Assembly::Sequence>& reads);
     /*
      * Parses RD and QA tags of the format. These tags have the following structures:
      * RD <read name> <# of padded bases> <# of whole read info items> <# of read tags>
@@ -67,11 +66,10 @@ private:
      * \param io the input-ouput adapter instance.
      * \param ti the state information handler instance.
      * \param buff buffer, whuch contains text, read from the file.
-     * \param names the list of all reads in the current contig.
      * \param name name of the considerable read.
      * \param sequence considerable read's sequence.
      **/
-    static void parseRDandQATag(U2::IOAdapter* io, U2OpStatus& ti, char* buff, QList<QString>& names, QString& name, QByteArray& sequence);
+    static void parseRDandQATag(U2::IOAdapter* io, U2OpStatus& ti, char* buff, QString& name, QByteArray& sequence);
 
     /**
      * Offsets in an ACE file are specified relatively to the reference sequence,

--- a/src/corelibs/U2Formats/src/ace/AceFormat.h
+++ b/src/corelibs/U2Formats/src/ace/AceFormat.h
@@ -28,6 +28,8 @@
 
 #include "../TextDocumentFormat.h"
 
+#include "AceImportUtils.h"
+
 namespace U2 {
 
 class IOAdapter;
@@ -42,6 +44,15 @@ protected:
     Document* loadTextDocument(IOAdapter* io, const U2DbiRef& dbiRef, const QVariantMap& fs, U2OpStatus& os) override;
 
 private:
+    static void parseAFTag(U2::IOAdapter* io, U2OpStatus& ti, char* buff, int count, QList<Assembly::Sequence>& reads, QList<QString>& names);
+    static void parseRDandQATag(U2::IOAdapter* io, U2OpStatus& ti, char* buff, QList<QString>& names, QString& name, QByteArray& sequence);
+
+    /**
+     * Offsets in an ACE file are specified relatively to the reference sequence,
+     * so "pos" can be negative.
+     */
+    static int getSmallestOffset(const QList<Assembly::Sequence>& reads);
+
     void load(IOAdapter* io, const U2DbiRef& dbiRef, QList<GObject*>& objects, const QVariantMap& hints, U2OpStatus& ti);
 
     static const QString CO;

--- a/src/corelibs/U2Formats/src/ace/AceImportUtils.cpp
+++ b/src/corelibs/U2Formats/src/ace/AceImportUtils.cpp
@@ -484,7 +484,9 @@ void AceReader::parseRdAndQaTag(U2::IOAdapter* io, char* buff, Assembly::Sequenc
     // Magic numbers: RD tag, name, three numbers, sequence data
     CHECK_EXT(6 <= rdSplitted.count(), os->setError(DocumentFormatUtils::tr("Invalid RD part")), );
     SAFE_POINT_EXT(RD == rdSplitted[0], os->setError("Can't find the RD tag"), );
-    read.name = rdSplitted[1];
+
+    QByteArray name = rdSplitted[1];
+    CHECK_EXT(read.name == name, os->setError(DocumentFormatUtils::tr("A name is not match with AF names")), );
 
     for (int chain = 5; chain < rdSplitted.count(); chain++) {
         read.data += rdSplitted[chain];

--- a/src/corelibs/U2Formats/src/ace/AceImportUtils.cpp
+++ b/src/corelibs/U2Formats/src/ace/AceImportUtils.cpp
@@ -181,13 +181,13 @@ Assembly AceReader::getAssembly() {
     readsCount = getReadsCount(headerLine);
     CHECK_OP((*os), result);
 
-    QList<QByteArray> names;
     // consensus, is set as reference in assembly
-    parseConsensus(io, buff, names, headerLine, reference);
+    parseConsensus(io, buff, headerLine, reference);
     CHECK_OP((*os), result);
 
     // read AF tag
     QList<Assembly::Sequence> reads;
+    QList<QByteArray> names;
     parseAfTag(io, buff, readsCount, reads, names);
     CHECK_OP((*os), result);
     CHECK_EXT(readsCount == reads.size(),
@@ -271,7 +271,7 @@ int AceReader::getReadsCount(const QByteArray& cur_line) {
     return readsCount;
 }
 
-void AceReader::parseConsensus(IOAdapter* io, char* buff, QList<QByteArray>& names, QByteArray& headerLine, Assembly::Sequence& consensus) {
+void AceReader::parseConsensus(IOAdapter* io, char* buff, QByteArray& headerLine, Assembly::Sequence& consensus) {
     char aceBStartChar = 'B';
     QBitArray aceBStart = TextUtils::createBitMap(aceBStartChar);
     qint64 len = 0;
@@ -279,9 +279,6 @@ void AceReader::parseConsensus(IOAdapter* io, char* buff, QList<QByteArray>& nam
     QByteArray line;
 
     consensus.name = getName(headerLine);
-    CHECK_EXT(!names.contains(consensus.name), os->setError(DocumentFormatUtils::tr("A name is duplicated")), );
-
-    names << consensus.name;
     consensus.name += "_ref";
 
     do {

--- a/src/corelibs/U2Formats/src/ace/AceImportUtils.cpp
+++ b/src/corelibs/U2Formats/src/ace/AceImportUtils.cpp
@@ -32,6 +32,25 @@
 namespace U2 {
 
 ///////////////////////////////////
+//// Assembly::Sequence
+///////////////////////////////////
+
+Assembly::Sequence::Sequence()
+    : offset(0), isComplemented(false) {
+}
+
+bool Assembly::Sequence::isValid() const {
+    return !name.isEmpty() && offset >= 0;
+}
+
+bool Assembly::Sequence::operator==(const Sequence& second) const {
+    return data == second.data &&
+           name == second.name &&
+           offset == second.offset &&
+           isComplemented == second.isComplemented;
+}
+
+///////////////////////////////////
 //// Assembly
 ///////////////////////////////////
 
@@ -438,7 +457,7 @@ int AceReader::paddedStartCons(const QByteArray& cur_line) {
 int AceReader::getSmallestOffset(const QList<Assembly::Sequence>& reads) {
     int smallestOffset = 0;
     for (const auto& read : qAsConst(reads)) {
-        smallestOffset = qMin(smallestOffset, read.offset - 1);
+        smallestOffset = qMin(smallestOffset, (int)read.offset - 1);
     }
 
     return smallestOffset;

--- a/src/corelibs/U2Formats/src/ace/AceImportUtils.h
+++ b/src/corelibs/U2Formats/src/ace/AceImportUtils.h
@@ -31,24 +31,15 @@ class Assembly {
 public:
     class Sequence {  // it is consensus in the ACE format specification
     public:
-        Sequence()
-            : offset(0), isComplemented(false) {
-        }
+        Sequence();
 
-        bool isValid() const {
-            return !name.isEmpty() && offset >= 0;
-        }
+        bool isValid() const;
 
-        bool operator==(const Sequence& second) {
-            return data == second.data &&
-                   name == second.name &&
-                   offset == second.offset &&
-                   isComplemented == second.isComplemented;
-        }
+        bool operator==(const Sequence& second) const;
 
         QByteArray data;
         QByteArray name;
-        int offset;
+        qint64 offset;
         bool isComplemented;
     };
 

--- a/src/corelibs/U2Formats/src/ace/AceImportUtils.h
+++ b/src/corelibs/U2Formats/src/ace/AceImportUtils.h
@@ -84,13 +84,13 @@ private:
     void parseConsensus(IOAdapter* io, char* buff, QByteArray& headerLine, Assembly::Sequence& consensus);
     QByteArray getName(const QByteArray& line);
     bool checkSeq(const QByteArray& seq);
-    void parseAfTag(IOAdapter* io, char* buff, int count, QList<Assembly::Sequence>& reads, QList<QByteArray>& names);
+    void parseAfTag(IOAdapter* io, char* buff, int count, QList<Assembly::Sequence>& reads);
     int readsPos(const QByteArray& cur_line);
     int prepareLine(QByteArray& line, int pos);
     int readsComplement(const QByteArray& cur_line);
     int paddedStartCons(const QByteArray& cur_line);
     int getSmallestOffset(const QList<Assembly::Sequence>& reads);
-    void parseRdAndQaTag(U2::IOAdapter* io, char* buff, QList<QByteArray>& names, Assembly::Sequence& read);
+    void parseRdAndQaTag(U2::IOAdapter* io, char* buff, Assembly::Sequence& read);
     int getClearRangeStart(const QByteArray& cur_line);
     int getClearRangeEnd(const QByteArray& cur_line);
     void formatSequence(QByteArray& data);

--- a/src/corelibs/U2Formats/src/ace/AceImportUtils.h
+++ b/src/corelibs/U2Formats/src/ace/AceImportUtils.h
@@ -39,6 +39,13 @@ public:
             return !name.isEmpty() && offset >= 0;
         }
 
+        bool operator==(const Sequence& second) {
+            return data == second.data &&
+                   name == second.name &&
+                   offset == second.offset &&
+                   isComplemented == second.isComplemented;
+        }
+
         QByteArray data;
         QByteArray name;
         int offset;
@@ -83,16 +90,16 @@ private:
     int getContigCount(const QByteArray& cur_line);
     int getSubString(QByteArray& line, int pos);
     int getReadsCount(const QByteArray& cur_line);
-    void parseConsensus(IOAdapter* io, char* buff, QSet<QByteArray>& names, QByteArray& headerLine, Assembly::Sequence& consensus);
+    void parseConsensus(IOAdapter* io, char* buff, QList<QByteArray>& names, QByteArray& headerLine, Assembly::Sequence& consensus);
     QByteArray getName(const QByteArray& line);
     bool checkSeq(const QByteArray& seq);
-    void parseAfTag(IOAdapter* io, char* buff, int count, QMap<QByteArray, int>& posMap, QMap<QByteArray, bool>& complMap, QSet<QByteArray>& names);
+    void parseAfTag(IOAdapter* io, char* buff, int count, QList<Assembly::Sequence>& reads, QList<QByteArray>& names);
     int readsPos(const QByteArray& cur_line);
     int prepareLine(QByteArray& line, int pos);
     int readsComplement(const QByteArray& cur_line);
     int paddedStartCons(const QByteArray& cur_line);
-    int getSmallestOffset(const QMap<QByteArray, int>& posMap);
-    void parseRdAndQaTag(U2::IOAdapter* io, char* buff, QSet<QByteArray>& names, Assembly::Sequence& read);
+    int getSmallestOffset(const QList<Assembly::Sequence>& reads);
+    void parseRdAndQaTag(U2::IOAdapter* io, char* buff, QList<QByteArray>& names, Assembly::Sequence& read);
     int getClearRangeStart(const QByteArray& cur_line);
     int getClearRangeEnd(const QByteArray& cur_line);
     void formatSequence(QByteArray& data);

--- a/src/corelibs/U2Formats/src/ace/AceImportUtils.h
+++ b/src/corelibs/U2Formats/src/ace/AceImportUtils.h
@@ -81,7 +81,7 @@ private:
     int getContigCount(const QByteArray& cur_line);
     int getSubString(QByteArray& line, int pos);
     int getReadsCount(const QByteArray& cur_line);
-    void parseConsensus(IOAdapter* io, char* buff, QList<QByteArray>& names, QByteArray& headerLine, Assembly::Sequence& consensus);
+    void parseConsensus(IOAdapter* io, char* buff, QByteArray& headerLine, Assembly::Sequence& consensus);
     QByteArray getName(const QByteArray& line);
     bool checkSeq(const QByteArray& seq);
     void parseAfTag(IOAdapter* io, char* buff, int count, QList<Assembly::Sequence>& reads, QList<QByteArray>& names);

--- a/src/corelibs/U2Formats/transl/russian.ts
+++ b/src/corelibs/U2Formats/transl/russian.ts
@@ -129,22 +129,22 @@
         <translation>Строка слишком длинная</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceFormat.cpp" line="350"/>
+        <location filename="../src/ace/AceFormat.cpp" line="351"/>
         <source>A name is not match with AF names</source>
         <translation>Имя не совпадает с именами AF</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceFormat.cpp" line="389"/>
+        <location filename="../src/ace/AceFormat.cpp" line="382"/>
         <source>First line is not an ace header</source>
         <translation>Первая строка не является заголовком ACE</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceFormat.cpp" line="392"/>
+        <location filename="../src/ace/AceFormat.cpp" line="385"/>
         <source>No contig count tag in the header line</source>
         <translation>Отсутствует тег числа контигов в строке заголовка</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceFormat.cpp" line="405"/>
+        <location filename="../src/ace/AceFormat.cpp" line="398"/>
         <source>Must be CO keyword</source>
         <translation>Ожидается ключевое слово CO</translation>
     </message>
@@ -154,7 +154,7 @@
         <translation>Неожиданный конец файла</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceFormat.cpp" line="415"/>
+        <location filename="../src/ace/AceFormat.cpp" line="408"/>
         <source>There is no note about reads count</source>
         <translation>Отсуствтует информация о числе считываний</translation>
     </message>
@@ -171,7 +171,6 @@
     </message>
     <message>
         <location filename="../src/ace/AceFormat.cpp" line="225"/>
-        <location filename="../src/ace/AceFormat.cpp" line="282"/>
         <source>A name is duplicated</source>
         <translation>Повторные вхождения имени</translation>
     </message>
@@ -228,12 +227,17 @@
         <translation>Некорректные данные в последовательности</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceFormat.cpp" line="463"/>
+        <location filename="../src/ace/AceFormat.cpp" line="442"/>
+        <source>RD line has read &quot;%1&quot;, but it wasn&apos;t presented in AF</source>
+        <translation>Тэг RD содержит прочтение с именем &quot;%1&quot;, которое не было представлено в тэгах AF</translation>
+    </message>
+    <message>
+        <location filename="../src/ace/AceFormat.cpp" line="464"/>
         <source>Alphabet unknown</source>
         <translation>Неизвестный алфавит</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceFormat.cpp" line="489"/>
+        <location filename="../src/ace/AceFormat.cpp" line="490"/>
         <source>File doesn&apos;t contain any msa objects</source>
         <translation>Файл не содержит msa объектов</translation>
     </message>
@@ -266,23 +270,23 @@
         <translation>Узел &quot;name&quot; не найден, вероятно, файл поврежден</translation>
     </message>
     <message>
-        <location filename="../src/ASNFormat.cpp" line="260"/>
-        <location filename="../src/ASNFormat.cpp" line="658"/>
+        <location filename="../src/ASNFormat.cpp" line="261"/>
+        <location filename="../src/ASNFormat.cpp" line="659"/>
         <source>Unknown error occurred</source>
         <translation>Неизвестная ошибка</translation>
     </message>
     <message>
-        <location filename="../src/ASNFormat.cpp" line="644"/>
+        <location filename="../src/ASNFormat.cpp" line="645"/>
         <source>no root element</source>
         <translation>Отсутствует корневой элемент</translation>
     </message>
     <message>
-        <location filename="../src/ASNFormat.cpp" line="650"/>
+        <location filename="../src/ASNFormat.cpp" line="651"/>
         <source>states stack is not empty</source>
         <translation>Стек состояний не пуст</translation>
     </message>
     <message>
-        <location filename="../src/ASNFormat.cpp" line="673"/>
+        <location filename="../src/ASNFormat.cpp" line="674"/>
         <source>First line is too long</source>
         <translation>Первая строка слишком длинная</translation>
     </message>
@@ -876,13 +880,18 @@
         <translation>В файле нет сборок</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceImportUtils.cpp" line="156"/>
+        <location filename="../src/ace/AceImportUtils.cpp" line="154"/>
         <source>There are not enough assemblies</source>
         <translation>Недостаточно сборок</translation>
     </message>
     <message>
+        <location filename="../src/ace/AceImportUtils.cpp" line="175"/>
+        <source>Expected %1 reads, but only %2 AF tags found</source>
+        <translation>Ожидается %1 прочтений, но только %2 тэгов AF было найдено</translation>
+    </message>
+    <message>
         <location filename="../src/ace/AceImportUtils.cpp" line="212"/>
-        <location filename="../src/ace/AceImportUtils.cpp" line="464"/>
+        <location filename="../src/ace/AceImportUtils.cpp" line="463"/>
         <source>Unexpected end of file</source>
         <translation>Неожиданный конец файла</translation>
     </message>
@@ -942,45 +951,40 @@
         <translation>Не указано имя последовательности</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceImportUtils.cpp" line="371"/>
-        <source>A name is duplicated: %1</source>
-        <translation>Повторные вхождения имени: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/ace/AceImportUtils.cpp" line="377"/>
+        <location filename="../src/ace/AceImportUtils.cpp" line="376"/>
         <source>Not all reads were found</source>
         <translation>Не все риды были найдены</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceImportUtils.cpp" line="386"/>
-        <location filename="../src/ace/AceImportUtils.cpp" line="390"/>
-        <location filename="../src/ace/AceImportUtils.cpp" line="422"/>
-        <location filename="../src/ace/AceImportUtils.cpp" line="434"/>
+        <location filename="../src/ace/AceImportUtils.cpp" line="385"/>
+        <location filename="../src/ace/AceImportUtils.cpp" line="389"/>
+        <location filename="../src/ace/AceImportUtils.cpp" line="421"/>
+        <location filename="../src/ace/AceImportUtils.cpp" line="433"/>
         <source>Bad AF note</source>
         <translation>Плохое примечание AF</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceImportUtils.cpp" line="460"/>
+        <location filename="../src/ace/AceImportUtils.cpp" line="459"/>
         <source>There is no read note</source>
         <translation>Отсутствует</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceImportUtils.cpp" line="473"/>
+        <location filename="../src/ace/AceImportUtils.cpp" line="472"/>
         <source>Invalid RD part</source>
         <translation>Неверная часть RD</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceImportUtils.cpp" line="483"/>
+        <location filename="../src/ace/AceImportUtils.cpp" line="482"/>
         <source>QA keyword hasn&apos;t been found</source>
         <translation>Ключевое слово QA не было найдено</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceImportUtils.cpp" line="492"/>
+        <location filename="../src/ace/AceImportUtils.cpp" line="491"/>
         <source>QA error bad range</source>
         <translation>Ошибка QA: плохой регион</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceImportUtils.cpp" line="495"/>
+        <location filename="../src/ace/AceImportUtils.cpp" line="494"/>
         <source>Unexpected symbols in sequence data</source>
         <translation>Неоижданные символы в последовательности</translation>
     </message>
@@ -990,27 +994,27 @@
         <translation>Имя не совпадает с именами AF</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceImportUtils.cpp" line="504"/>
+        <location filename="../src/ace/AceImportUtils.cpp" line="503"/>
         <source>Can&apos;t find clear range start in current line</source>
         <translation>Невозможно найти начало диапазона в текущей строке</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceImportUtils.cpp" line="505"/>
+        <location filename="../src/ace/AceImportUtils.cpp" line="504"/>
         <source>Clear range start is invalid</source>
         <translation>Неверное начало диапазона</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceImportUtils.cpp" line="512"/>
+        <location filename="../src/ace/AceImportUtils.cpp" line="511"/>
         <source>Can&apos;t find clear range end in current line</source>
         <translation>Невозможно найти конец диапазона в текущей строке</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceImportUtils.cpp" line="513"/>
+        <location filename="../src/ace/AceImportUtils.cpp" line="512"/>
         <source>Clear range end is invalid</source>
         <translation>Неверный конец диапазона</translation>
     </message>
     <message>
-        <location filename="../src/ace/AceImportUtils.cpp" line="537"/>
+        <location filename="../src/ace/AceImportUtils.cpp" line="536"/>
         <source>There is no next element</source>
         <translation>Отсутствует следующий элемент</translation>
     </message>

--- a/tests/doc_format/ace/negative/test_0016.xml
+++ b/tests/doc_format/ace/negative/test_0016.xml
@@ -1,7 +1,0 @@
-<multi-test>
-
-    <!-- Test reading file: a name in an RD tag doesn't mutch with a name in an AF tag -->
-
-    <load-broken-document url="ace/ace_test_11_(error).ace" io="local_file" format="ace"/>
-
-</multi-test>

--- a/tests/doc_format/ace/negative/test_0019.xml
+++ b/tests/doc_format/ace/negative/test_0019.xml
@@ -1,7 +1,0 @@
-<multi-test>
-
-    <!-- Test reading file: there is no clear range in an QA tag -->
-
-    <load-broken-document url="ace/ace_test_41_(error).ace" io="local_file" format="ace"/>
-
-</multi-test>

--- a/tests/doc_format/ace/test_0001.xml
+++ b/tests/doc_format/ace/test_0001.xml
@@ -1,0 +1,5 @@
+<multi-test>
+
+    <load-document url="ace/xyz.cap.ace" io="local_file" format="ace"/>
+
+</multi-test>

--- a/tests/doc_format/ace/test_0002.xml
+++ b/tests/doc_format/ace/test_0002.xml
@@ -1,0 +1,5 @@
+<multi-test>
+
+	<import-document url="ace/xyz.cap.ace" io="local_file" format="ace"/>
+
+</multi-test>

--- a/tests/doc_format/ace/test_0003.xml
+++ b/tests/doc_format/ace/test_0003.xml
@@ -1,0 +1,5 @@
+<multi-test>
+
+    <load-document url="ace/ace_test_duplicated_consensus_names.ace" io="local_file" format="ace"/>
+
+</multi-test>


### PR DESCRIPTION
Сделал так, что ACE может спокойно работать, если в нем попались риды с одинаковыми именами (это не помеха ни для редактора множестенного выравнивания, ни для браузера сброк).

Удалил один негативный XML тест, который проверял как раз ошибку при загрузке ACE файла с ридами, имеющими одинаковые имена. Добавил два позитивных.

Обнаружил, что для обоих способов открытия используется разный код, что не очень хорошо, потому что парсят файл они по одному и тому же сценарию, т.е., по факту, дублирование кода. Сделаю в [UGENE-8066](https://ugene.dev/tracker/browse/UGENE-8066)