### PR TITLE
UGENE-8067 UGENE can't open GTF that it wrote itself

### DIFF
--- a/src/corelibs/U2Formats/src/GTFFormat.cpp
+++ b/src/corelibs/U2Formats/src/GTFFormat.cpp
@@ -559,15 +559,16 @@ void GTFFormat::storeDocument(Document* doc, IOAdapter* io, U2OpStatus& os) {
                 QString transcriptIdAttributeStr;
                 QString otherAttributesStr;
                 for (const U2Qualifier& qualifier : qAsConst(annotQualifiers)) {
+                    auto qualValue = QString(qualifier.value).replace('\n', " ");
                     if (qualifier.name == SOURCE_QUALIFIER_NAME) {
-                        lineFields[GTF_SOURCE_INDEX] = qualifier.value;
+                        lineFields[GTF_SOURCE_INDEX] = qualValue;
                     } else if (qualifier.name == SCORE_QUALIFIER_NAME) {
-                        lineFields[GTF_SCORE_INDEX] = qualifier.value;
+                        lineFields[GTF_SCORE_INDEX] = qualValue;
                     } else if (qualifier.name == FRAME_QUALIFIER_NAME) {
-                        lineFields[GTF_FRAME_INDEX] = qualifier.value;
+                        lineFields[GTF_FRAME_INDEX] = qualValue;
                     } else {
                         // All other qualifiers are saved as attributes
-                        QString attrStr = qualifier.name + " \"" + qualifier.value + "\";";
+                        QString attrStr = qualifier.name + " \"" + qualValue + "\";";
                         if (qualifier.name == GENE_ID_QUALIFIER_NAME) {
                             geneIdAttributeStr = attrStr;
                         } else {

--- a/src/corelibs/U2Formats/src/GenbankPlainTextFormat.cpp
+++ b/src/corelibs/U2Formats/src/GenbankPlainTextFormat.cpp
@@ -207,7 +207,7 @@ bool GenbankPlainTextFormat::readEntry(ParserState* st, U2SequenceImporter& seqI
                 commentSection.append(st->value());
             }
             if (!commentSection.isEmpty()) {
-                st->entry->tags[DNAInfo::COMMENT] = st->entry->tags[DNAInfo::COMMENT].toStringList() << commentSection.join("\n");
+                st->entry->tags[DNAInfo::COMMENT] = st->entry->tags[DNAInfo::COMMENT].toStringList() << commentSection.join(" ");
             }
             hasLine = true;
             continue;

--- a/tests/cmdline/common/annotations/export_annotations_03.xml
+++ b/tests/cmdline/common/annotations/export_annotations_03.xml
@@ -1,0 +1,10 @@
+<multi-test>
+    <run-cmdline
+            task="!common_data_dir!cmdline/annotations/export.uwl"
+            in="!common_data_dir!genbank/murine_cut.gb"
+            format="GTF"
+            out="!tmp_data_dir!export_annotations_03.gbk"/>
+
+    <load-document index="doc2" url="export_annotations_03.gbk" io="local_file" format="GTF" dir="temp"/>
+
+</multi-test>

--- a/tests/cmdline/common/annotations/export_annotations_03.xml
+++ b/tests/cmdline/common/annotations/export_annotations_03.xml
@@ -3,8 +3,8 @@
             task="!common_data_dir!cmdline/annotations/export.uwl"
             in="!common_data_dir!genbank/murine_cut.gb"
             format="GTF"
-            out="!tmp_data_dir!export_annotations_03.gbk"/>
+            out="!tmp_data_dir!export_annotations_03.gtf"/>
 
-    <load-document index="doc2" url="export_annotations_03.gbk" io="local_file" format="GTF" dir="temp"/>
+    <load-document index="doc2" url="export_annotations_03.gtf" io="local_file" format="GTF" dir="temp"/>
 
 </multi-test>


### PR DESCRIPTION
В генбанк формате коммент может писаться в несколько строк, если длинный. По каким причинам перенос строки сохранили при парсинге не очень ясно, заменил на пробел