### PR TITLE
UGENE-7721: Fix issue with double click behaviour.

### DIFF
--- a/src/corelibs/U2View/src/ov_mca/McaEditor.cpp
+++ b/src/corelibs/U2View/src/ov_mca/McaEditor.cpp
@@ -332,4 +332,20 @@ MaEditorSelectionController* McaEditor::getSelectionController() const {
     return selectionController;
 }
 
+void McaEditor::gotoSelectedRead(const MaEditorSelection& selection){
+    QRect selectionRect = selection.toRect();
+    int viewRowIndex = selectionRect.y();
+
+    int maRowIndex = collapseModel->getMaRowIndexByViewRowIndex(viewRowIndex);
+    CHECK(maRowIndex >= 0 && maRowIndex < maObject->getRowCount(), );
+
+    MsaRow maRow = maObject->getRow(maRowIndex);
+    int posToCenter = maRow->isComplemented() ? maRow->getCoreEnd() - 1 : maRow->getCoreStart();
+    MaEditorSequenceArea* sequenceArea = getLineWidget(0)->getSequenceArea();
+    if (sequenceArea->isPositionCentered(posToCenter)) {
+        posToCenter = maRow->isComplemented() ? maRow->getCoreStart() : maRow->getCoreEnd() - 1;
+    }
+    sequenceArea->centerPos(posToCenter);
+}
+
 }  // namespace U2

--- a/src/corelibs/U2View/src/ov_mca/McaEditor.cpp
+++ b/src/corelibs/U2View/src/ov_mca/McaEditor.cpp
@@ -332,7 +332,10 @@ MaEditorSelectionController* McaEditor::getSelectionController() const {
     return selectionController;
 }
 
-void McaEditor::gotoSelectedRead(const MaEditorSelection& selection){
+void McaEditor::sl_gotoSelectedRead(){
+    MaEditor::sl_gotoSelectedRead();
+    MaEditorSelection selection = getSelection();
+    CHECK(!selection.isEmpty(), );
     QRect selectionRect = selection.toRect();
     int viewRowIndex = selectionRect.y();
 

--- a/src/corelibs/U2View/src/ov_mca/McaEditor.h
+++ b/src/corelibs/U2View/src/ov_mca/McaEditor.h
@@ -113,6 +113,7 @@ protected:
     void addAlignmentMenu(QMenu* menu);
     void addAppearanceMenu(QMenu* menu);
     void addNavigationMenu(QMenu* menu);
+    void gotoSelectedRead(const MaEditorSelection& selection) override;
 };
 
 }  // namespace U2

--- a/src/corelibs/U2View/src/ov_mca/McaEditor.h
+++ b/src/corelibs/U2View/src/ov_mca/McaEditor.h
@@ -113,7 +113,7 @@ protected:
     void addAlignmentMenu(QMenu* menu);
     void addAppearanceMenu(QMenu* menu);
     void addNavigationMenu(QMenu* menu);
-    void gotoSelectedRead(const MaEditorSelection& selection) override;
+    void sl_gotoSelectedRead() override;
 };
 
 }  // namespace U2

--- a/src/corelibs/U2View/src/ov_msa/MaEditor.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditor.cpp
@@ -624,13 +624,6 @@ void MaEditor::sl_onClearActionTriggered() {
     getSelectionController()->clearSelection();
 }
 
-void MaEditor::sl_gotoSelectedRead() {
-    GCOUNTER(cvar, "MAEditor:gotoSelectedRead");
-    MaEditorSelection selection = getSelection();
-    CHECK(!selection.isEmpty(), );
-    gotoSelectedRead(selection);
-}
-
 MaCollapseModel* MaEditor::getCollapseModel() const {
     return collapseModel;
 }

--- a/src/corelibs/U2View/src/ov_msa/MaEditor.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditor.cpp
@@ -628,20 +628,7 @@ void MaEditor::sl_gotoSelectedRead() {
     GCOUNTER(cvar, "MAEditor:gotoSelectedRead");
     MaEditorSelection selection = getSelection();
     CHECK(!selection.isEmpty(), );
-
-    QRect selectionRect = selection.toRect();
-    int viewRowIndex = selectionRect.y();
-
-    int maRowIndex = collapseModel->getMaRowIndexByViewRowIndex(viewRowIndex);
-    CHECK(maRowIndex >= 0 && maRowIndex < maObject->getRowCount(), );
-
-    MsaRow maRow = maObject->getRow(maRowIndex);
-    int posToCenter = maRow->isComplemented() ? maRow->getCoreEnd() - 1 : maRow->getCoreStart();
-    MaEditorSequenceArea* sequenceArea = getLineWidget(0)->getSequenceArea();
-    if (sequenceArea->isPositionCentered(posToCenter)) {
-        posToCenter = maRow->isComplemented() ? maRow->getCoreStart() : maRow->getCoreEnd() - 1;
-    }
-    sequenceArea->centerPos(posToCenter);
+    gotoSelectedRead(selection);
 }
 
 MaCollapseModel* MaEditor::getCollapseModel() const {

--- a/src/corelibs/U2View/src/ov_msa/MaEditor.h
+++ b/src/corelibs/U2View/src/ov_msa/MaEditor.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <U2Core/Counter.h>
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Gui/ObjectViewModel.h>
@@ -257,7 +258,9 @@ protected slots:
     virtual void sl_selectionChanged(const MaEditorSelection& ma, const MaEditorSelection& modInfo);
 
     /** Callback for the 'gotoSelectedReadAction' action. See docs for 'gotoSelectedReadAction'. */
-    void sl_gotoSelectedRead();
+    virtual void sl_gotoSelectedRead() {
+        GCOUNTER(cvar, "MAEditor:gotoSelectedRead");
+    };
 
     virtual void sl_multilineViewAction() {
         SAFE_POINT(false, "The function sl_multilineViewAction() must be overridden", );
@@ -286,7 +289,6 @@ protected:
     void setZoomFactor(double newZoomFactor);
 
     virtual void updateActions();
-    virtual void gotoSelectedRead(const MaEditorSelection& selection) = 0;
 
     MsaObject* maObject = nullptr;
 

--- a/src/corelibs/U2View/src/ov_msa/MaEditor.h
+++ b/src/corelibs/U2View/src/ov_msa/MaEditor.h
@@ -286,6 +286,7 @@ protected:
     void setZoomFactor(double newZoomFactor);
 
     virtual void updateActions();
+    virtual void gotoSelectedRead(const MaEditorSelection& selection) = 0;
 
     MsaObject* maObject = nullptr;
 

--- a/src/corelibs/U2View/src/ov_msa/MaEditorNameList.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorNameList.cpp
@@ -281,6 +281,7 @@ void MaEditorNameList::mouseDoubleClickEvent(QMouseEvent* e) {
     if (editor->gotoSelectedReadAction->isEnabled()) {
         editor->gotoSelectedReadAction->trigger();
         e->ignore();
+        isDoubleClicked = true;
         return;
     }
     QWidget::mouseDoubleClickEvent(e);
@@ -569,6 +570,11 @@ void MaEditorNameList::mouseReleaseEvent(QMouseEvent* e) {
             // Drag or click with no modifiers make a new 1-rect selection.
             int y = qMin(mousePressRow, mouseReleaseRow);
             int width = qMax(mousePressRow, mouseReleaseRow) - y + 1;
+            if (isDoubleClicked) { // When you double-click, it means you are clicking on a single point, not an area.
+                y = mousePressRow;
+                width = mousePressRow - y + 1;
+                isDoubleClicked = false;
+            }
             QRect newSelectionRect(0, y, alignmentLen, width);
             setSelection({{newSelectionRect}});
         }

--- a/src/corelibs/U2View/src/ov_msa/MaEditorNameList.h
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorNameList.h
@@ -178,6 +178,7 @@ protected:
     QPoint mousePressPoint;
     bool isDragging = false;
     QRubberBand* rubberBand = nullptr;
+    bool isDoubleClicked = false;
 
 public:
     QAction* editSequenceNameAction = nullptr;

--- a/src/corelibs/U2View/src/ov_msa/MsaEditor.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MsaEditor.cpp
@@ -1012,14 +1012,17 @@ MaEditorWgt* MsaEditor::getLineWidget(int index) const {
     return ui->getLineWidget(index);
 }
 
-void MsaEditor::gotoSelectedRead(const MaEditorSelection& selection){
+void MsaEditor::sl_gotoSelectedRead(){
+    MaEditor::sl_gotoSelectedRead();
+    MaEditorSelection selection = getSelection();
+    CHECK(!selection.isEmpty(), );
     QRect selectionRect = selection.toRect();
     int viewRowIndex = selectionRect.y();
 
     int maRowIndex = collapseModel->getMaRowIndexByViewRowIndex(viewRowIndex);
     CHECK(maRowIndex >= 0 && maRowIndex < maObject->getRowCount(), );
 
-    MsaRow maRow = maObject->getRow(maRowIndex);
+    const MsaRow& maRow = maObject->getRow(maRowIndex);
     if (isMultilineMode()){
         auto widget = getMainWidget();
         int overviewHeight        = widget->getOverviewArea()->height();
@@ -1041,8 +1044,7 @@ void MsaEditor::gotoSelectedRead(const MaEditorSelection& selection){
         int finalScroll = minimalScroll + fineTuningScroll;
         if (finalScroll < availableWidgetHeight / 2) {
             finalScroll = 0;
-        }
-        else {
+        } else {
             finalScroll = finalScroll - availableWidgetHeight / 2;
         }
 

--- a/src/corelibs/U2View/src/ov_msa/MsaEditor.h
+++ b/src/corelibs/U2View/src/ov_msa/MsaEditor.h
@@ -213,6 +213,7 @@ protected:
     void addStatisticsMenu(QMenu* m);
 
     void updateActions() override;
+    void gotoSelectedRead(const MaEditorSelection& selection) override;
 
     void initDragAndDropSupport(MaEditorWgt* wgt);
 

--- a/src/corelibs/U2View/src/ov_msa/MsaEditor.h
+++ b/src/corelibs/U2View/src/ov_msa/MsaEditor.h
@@ -213,7 +213,7 @@ protected:
     void addStatisticsMenu(QMenu* m);
 
     void updateActions() override;
-    void gotoSelectedRead(const MaEditorSelection& selection) override;
+    void sl_gotoSelectedRead() override;
 
     void initDragAndDropSupport(MaEditorWgt* wgt);
 

--- a/src/corelibs/U2View/src/ov_msa/MsaEditorMultilineWgt.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MsaEditorMultilineWgt.cpp
@@ -71,8 +71,6 @@ MsaEditorMultilineWgt::MsaEditorMultilineWgt(MsaEditor* _editor, QWidget* parent
     connect(editor->getCollapseModel(), &MaCollapseModel::si_toggled, this, [this]() {
         this->updateSize();
     });
-
-    connect(editor, &MaEditor::si_cursorPositionChanged, this, &MsaEditorMultilineWgt::sl_cursorPositionChanged);
 }
 
 MsaEditorWgt* MsaEditorMultilineWgt::createChild(MsaEditor* msaEditor,
@@ -113,27 +111,29 @@ void MsaEditorMultilineWgt::addChild(MsaEditorWgt* child) {
 }
 
 void MsaEditorMultilineWgt::createChildren() {
-    int childrenCount = isWrapMode() ? 3 : 1;
+    int childrenCount = 1; //isWrapMode() ? 3 : 1;
+    MsaEditorWgt* child = createChild(editor, overviewArea, statusBar);
+    SAFE_POINT(child != nullptr, "Can't create sequence widget", );
+    addChild(child);
+    // calculate necessary count of children MSAs
+    if (isWrapMode()) {
+        QSize s = child->minimumSizeHint();
+        childrenCount = height() / s.height() + 3;
+        int l = editor->getAlignmentLen();
+        int aw = getSequenceAreaAllBaseWidth();
+        int al = getSequenceAreaAllBaseLen();
 
-    for (int i = 0; i < childrenCount; i++) {
+        // TODO:ichebyki: 0.66 is a heuristic value, need to define more smart
+        int b = width() * 0.66 / (aw / al);
+        if (b * (childrenCount - 1) > l) {
+            childrenCount = l / b + (l % b > 0 ? 1 : 0);
+        }
+    }
+
+    for (int i = 1; i < childrenCount; i++) {
         MsaEditorWgt* child = createChild(editor, overviewArea, statusBar);
         SAFE_POINT(child != nullptr, "Can't create sequence widget", );
         addChild(child);
-
-        // recalculate count
-        if (i == 0 && isWrapMode()) {
-            QSize s = child->minimumSizeHint();
-            childrenCount = height() / s.height() + 3;
-            int l = editor->getAlignmentLen();
-            int aw = getSequenceAreaAllBaseWidth();
-            int al = getSequenceAreaAllBaseLen();
-
-            // TODO:ichebyki: 0.66 is a heuristic value, need to define more smart
-            int b = width() * 0.66 / (aw / al);
-            if (b * (childrenCount - 1) > l) {
-                childrenCount = l / b + (l % b > 0 ? 1 : 0);
-            }
-        }
     }
 
     // TODO:ichebyki
@@ -276,12 +276,6 @@ void MsaEditorMultilineWgt::sl_triggerUseDots(int checkState) {
     for (int i = 0; i < getLineWidgetCount(); i++) {
         MaEditorSequenceArea* sequence = getLineWidget(i)->getSequenceArea();
         sequence->sl_triggerUseDots(checkState);
-    }
-}
-
-void MsaEditorMultilineWgt::sl_cursorPositionChanged(const QPoint& point) {
-    if (multilineMode) {
-        scrollController->scrollToPoint(point);
     }
 }
 

--- a/src/corelibs/U2View/src/ov_msa/MsaEditorMultilineWgt.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MsaEditorMultilineWgt.cpp
@@ -131,7 +131,7 @@ void MsaEditorMultilineWgt::createChildren() {
     }
 
     for (int i = 1; i < childrenCount; i++) {
-        MsaEditorWgt* child = createChild(editor, overviewArea, statusBar);
+        child = createChild(editor, overviewArea, statusBar);
         SAFE_POINT(child != nullptr, "Can't create sequence widget", );
         addChild(child);
     }

--- a/src/corelibs/U2View/src/ov_msa/MsaEditorMultilineWgt.h
+++ b/src/corelibs/U2View/src/ov_msa/MsaEditorMultilineWgt.h
@@ -109,7 +109,6 @@ public slots:
     void sl_changeColorScheme(const QString& id);
     void sl_onPosChangeRequest(int position);
     void sl_triggerUseDots(int checkState);
-    void sl_cursorPositionChanged(const QPoint&);
     void sl_setAllNameAndSequenceAreasSplittersSizes(int pos, int index);
     void sl_goto();
     void sl_toggleSequenceRowOrder(bool isOrderBySequence);

--- a/src/corelibs/U2View/src/ov_msa/MsaMultilineScrollArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MsaMultilineScrollArea.cpp
@@ -88,19 +88,9 @@ void MsaMultilineScrollArea::scrollVert(const MultilineScrollController::Directi
 
     maEditorUi->setUpdatesEnabled(false);
 
-    if (directions.testFlag(MultilineScrollController::SliderMoved)) {
-        moveVSlider(globalVBar->value(),
-                    globalVBar->sliderPosition(),
-                    wheel ? directions : MultilineScrollController::None);
-    } else if (byStep) {
-        moveVSlider(globalVBar->value(),
-                    globalVBar->sliderPosition(),
-                    wheel ? directions : MultilineScrollController::None);
-    } else {
-        moveVSlider(globalVBar->value(),
-                    globalVBar->sliderPosition(),
-                    wheel ? directions : MultilineScrollController::None);
-    }
+    moveVSlider(globalVBar->value(),
+                globalVBar->sliderPosition(),
+                wheel ? directions : MultilineScrollController::None);
     maEditorUi->setUpdatesEnabled(true);
 }
 

--- a/src/corelibs/U2View/src/ov_msa/MsaMultilineScrollArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MsaMultilineScrollArea.cpp
@@ -44,12 +44,12 @@ bool MsaMultilineScrollArea::eventFilter(QObject* obj, QEvent* event) {
             case Qt::Key_Up:
                 if (maEditorUi->moveSelection(key, isShiftPressed, isCtrlPressed))
                     return true;
-                scrollVert(MultilineScrollController::Up, true, true);
+                scrollVert(MultilineScrollController::Up, true);
                 return true;
             case Qt::Key_Down:
                 if (maEditorUi->moveSelection(key, isShiftPressed, isCtrlPressed))
                     return true;
-                scrollVert(MultilineScrollController::Down, true, true);
+                scrollVert(MultilineScrollController::Down, true);
                 return true;
             case Qt::Key_Home:
                 if (maEditorUi->moveSelection(key, isShiftPressed, isCtrlPressed))
@@ -64,12 +64,12 @@ bool MsaMultilineScrollArea::eventFilter(QObject* obj, QEvent* event) {
             case Qt::Key_PageUp:
                 if (maEditorUi->moveSelection(key, isShiftPressed, isCtrlPressed))
                     return true;
-                scrollVert(MultilineScrollController::PageUp, false, true);
+                scrollVert(MultilineScrollController::PageUp, true);
                 return true;
             case Qt::Key_PageDown:
                 if (maEditorUi->moveSelection(key, isShiftPressed, isCtrlPressed))
                     return true;
-                scrollVert(MultilineScrollController::PageDown, false, true);
+                scrollVert(MultilineScrollController::PageDown, true);
                 return true;
         }
     }
@@ -78,7 +78,6 @@ bool MsaMultilineScrollArea::eventFilter(QObject* obj, QEvent* event) {
 }
 
 void MsaMultilineScrollArea::scrollVert(const MultilineScrollController::Directions& directions,
-                                        bool byStep,
                                         bool wheel) {
     GScrollBar* globalVBar = maEditorUi->getScrollController()->getVerticalScrollBar();
     if (globalVBar->minimum() == globalVBar->maximum()) {
@@ -215,11 +214,11 @@ void MsaMultilineScrollArea::wheelEvent(QWheelEvent* event) {
             event->accept();
             return;
         } else if (direction < 0) {
-            scrollVert(MultilineScrollController::Down, true, true);
+            scrollVert(MultilineScrollController::Down, true);
             event->accept();
             return;
         } else if (direction > 0) {
-            scrollVert(MultilineScrollController::Up, true, true);
+            scrollVert(MultilineScrollController::Up, true);
             event->accept();
             return;
         }

--- a/src/corelibs/U2View/src/ov_msa/MsaMultilineScrollArea.h
+++ b/src/corelibs/U2View/src/ov_msa/MsaMultilineScrollArea.h
@@ -18,7 +18,6 @@ public:
     MsaMultilineScrollArea(MsaEditor* maEditor, MsaEditorMultilineWgt* ui);
     // wheel arg signals that this is non scrollbar scrolling
     void scrollVert(const MultilineScrollController::Directions& directions,
-                    bool byStep,
                     bool wheel = false);
     bool eventFilter(QObject* obj, QEvent* event) override;
 


### PR DESCRIPTION
Current behaviour is following:
1. When user first time double-click on the sequence name it tries to scroll to "widget" where the start of the sequence is present and set this sequence row in the middle of the MSA widget.
<img width="796" alt="Screenshot 2024-05-31 at 15 38 56" src="https://github.com/ugeneunipro/ugene/assets/5506989/b697eb7f-3c9e-4cd3-8341-ac487b004319">

2. When user again double-click on the same sequence name it tries to scroll "widget" where the end of the sequence is present and set this sequence in the middle of the MSA widget.
<img width="799" alt="Screenshot 2024-05-31 at 15 39 32" src="https://github.com/ugeneunipro/ugene/assets/5506989/0a13e07c-396a-4bca-80ea-f2512cab6616">
