### PR TITLE
UGENE-8098 SAFE_POINT after closing ugene on a loaded computer

### DIFF
--- a/src/corelibs/U2Private/src/ServiceRegistryImpl.cpp
+++ b/src/corelibs/U2Private/src/ServiceRegistryImpl.cpp
@@ -242,7 +242,7 @@ void EnableServiceTask::prepare() {
 
 Task::ReportResult EnableServiceTask::report() {
     sr->activeServiceTasks.removeAll(this);
-    if (stateInfo.hasError() || s->isEnabled()) {
+    if (stateInfo.isCoR() || s->isEnabled()) {
         return ReportResult_Finished;
     }
     bool success = !propagateSubtaskError();

--- a/src/plugins/dotplot/src/DotPlotDialog.cpp
+++ b/src/plugins/dotplot/src/DotPlotDialog.cpp
@@ -316,7 +316,7 @@ void DotPlotDialog::sl_loadSequenceButton() {
     LastUsedDirHelper lod("DotPlot file");
     lod.url = U2FileDialog::getOpenFileName(this, tr("Open file"), lod.dir, filter);
     if (!lod.url.isEmpty()) {
-        auto tasks = new Task("Adding document to the project", TaskFlag_NoRun);
+        auto tasks = new Task("Adding document to the project", TaskFlags_NR_FOSCOE | TaskFlag_SuppressErrorNotification);
 
         if (!AppContext::getProject()) {
             tasks->addSubTask(AppContext::getProjectLoader()->createNewProjectTask());

--- a/src/ugeneui/src/project_support/ProjectLoaderImpl.cpp
+++ b/src/ugeneui/src/project_support/ProjectLoaderImpl.cpp
@@ -1041,6 +1041,8 @@ AddDocumentsToProjectTask::~AddDocumentsToProjectTask() {
 }
 
 QList<Task*> AddDocumentsToProjectTask::onSubTaskFinished(Task* t) {
+    CHECK_OP(stateInfo, {});
+
     QList<Task*> res;
     if (!loadTasksAdded) {
         res = prepareLoadTasks();


### PR DESCRIPTION
Проблема связана с тем, что при попытке закрыть UGENE отменяются все текущие таски, но сами эти таски, зачастую, не проверяют свой `stateInfo` на предмет того, отменены они или нет, и, соответственно, продолжают исполняться даже в случае, если им уже выставлен флаг отмены. С другой же стороны, `TaskScheduler` имеет свои правила работы с отмененными тасками и не запускает их сабтаски. Из-за этого происходит ситуация, когда определенной родительской таске нужна какая-то информация, которую ей должна предоставить её сабтаска, а эта сабтаска не была запущена, т.к. у неё был выставлен флаг отмены. В итоге, родительская таска продолжает работать как если бы у нее была эта информация, в какой-то момент натыкается на `nullptr` в `SAFE_POINT`'е и падает.

Конкретно в данном случае: есть таска `EnableServiceTask`, в какой-то момент она должна запустить сабтаску `ProjectServiceEnableTask`. Эта сабтаска должна задать указатель на проект в `AppContext` (см. [тут](https://github.com/ugeneunipro/ugene/blob/2580e2fca6f5be28cb899082724d1fb4ad25c124/src/ugeneui/src/project_support/ProjectServiceImpl.cpp#L139)). Соответственно, из-за того, что мы закрываем UGENE пускается shutdown, который выставляет всем таскам отмену. `ProjectServiceEnableTask` (дочерняя) не исполняется, проект в контекст не ставится, но `EnableServiceTask` (родительская) про это не знает и продолжает исполняться. Соответственно, в паре мест срабатывает `SAFE_POINT`.

Баг воспроизводится стабильно, для этого нужно открыть файл (я воспроизводил на файле, указанном в сценарии задачи, но, думаю, тут не важно, на каком файле пробовать) и очень быстро нажать на крестик UGENE (до того, как в `AppContext` будет задан проект). Можно поставить breakpoint в `AppContextImpl::setProject(...)`, чтобы точно знать, успел или нет.

Тестов нет, т.к. тестовая система не может с достаточной скоростью закрыть UGENE.