### PR TITLE
Fix failed tests

### DIFF
--- a/src/corelibs/U2Core/src/globals/NetworkConfiguration.h
+++ b/src/corelibs/U2Core/src/globals/NetworkConfiguration.h
@@ -34,6 +34,10 @@
 namespace U2 {
 typedef QNetworkProxy::ProxyType Proxy_t;
 
+namespace U2HttpHeaders {
+const QString userAgent = "UGENE";
+}
+
 class U2CORE_EXPORT ProxyConfig {
 public:
     ProxyConfig()

--- a/src/corelibs/U2Core/src/io/HttpFileAdapter.cpp
+++ b/src/corelibs/U2Core/src/io/HttpFileAdapter.cpp
@@ -109,15 +109,18 @@ bool HttpFileAdapter::open(const QUrl& url, const QNetworkProxy& p) {
             postData = splittedStrings.at(1).toLatin1();
             QNetworkRequest netRequest(headerString);
             netRequest.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
+            netRequest.setHeader(QNetworkRequest::UserAgentHeader, U2HttpHeaders::userAgent);
             reply = netManager->post(netRequest, postData);
         } else {
             QNetworkRequest netRequest(url);
+            netRequest.setHeader(QNetworkRequest::UserAgentHeader, U2HttpHeaders::userAgent);
             reply = netManager->post(netRequest, "");
         }
     } else {
         QString urlString = url.toString();
         urlString = urlString.replace(RemoteRequestConfig::HTTP_BODY_SEPARATOR, "&");
         QNetworkRequest netRequest(urlString);
+        netRequest.setHeader(QNetworkRequest::UserAgentHeader, U2HttpHeaders::userAgent);
         reply = netManager->get(netRequest);
     }
     coreLog.details(tr("GET %1").arg(reply->url().toString()));

--- a/src/corelibs/U2Core/src/tasks/LoadRemoteDocumentTask.cpp
+++ b/src/corelibs/U2Core/src/tasks/LoadRemoteDocumentTask.cpp
@@ -83,6 +83,11 @@ const QMap<QString, QString> RemoteDBRegistry::PAGE_LINKS = { {ENSEMBL, ENSEMBL_
                                                               {SWISS_PROT, UNIPROTKB_PAGE_ID},
                                                               {UNIPROTKB_SWISS_PROT, UNIPROTKB_PAGE_ID},
                                                               {UNIPROTKB_TREMBL, UNIPROTKB_PAGE_ID} };
+static QNetworkRequest constructRequest(const QUrl& requestUrl) {
+    QNetworkRequest req(requestUrl);
+    req.setHeader(QNetworkRequest::UserAgentHeader, "UGENE");
+    return req;
+}
 
 ////////////////////////////////////////////////////////////////////////////
 // BaseLoadRemoteDocumentTask
@@ -465,7 +470,7 @@ void LoadDataFromEntrezTask::run() {
 }
 
 void LoadDataFromEntrezTask::runRequest(const QUrl& requestUrl) {
-    downloadReply = networkManager->get(QNetworkRequest(requestUrl));
+    downloadReply = networkManager->get(constructRequest(requestUrl));
     connect(downloadReply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(sl_onError()));
     connect(downloadReply, SIGNAL(uploadProgress(qint64, qint64)), this, SLOT(sl_uploadProgress(qint64, qint64)));
 
@@ -564,7 +569,7 @@ void EntrezQueryTask::sl_replyFinished(QNetworkReply* reply) {
 
 void EntrezQueryTask::runRequest(const QUrl& requestUrl) {
     ioLog.trace(QString("Sending request: %1").arg(query));
-    queryReply = networkManager->get(QNetworkRequest(requestUrl));
+    queryReply = networkManager->get(constructRequest(requestUrl));
     connect(queryReply, &QNetworkReply::errorOccurred, this, &EntrezQueryTask::sl_onError);
 }
 

--- a/src/corelibs/U2Core/src/tasks/LoadRemoteDocumentTask.cpp
+++ b/src/corelibs/U2Core/src/tasks/LoadRemoteDocumentTask.cpp
@@ -465,7 +465,9 @@ void LoadDataFromEntrezTask::run() {
 }
 
 void LoadDataFromEntrezTask::runRequest(const QUrl& requestUrl) {
-    downloadReply = networkManager->get(QNetworkRequest(requestUrl));
+    QNetworkRequest req(requestUrl);
+    req.setHeader(QNetworkRequest::UserAgentHeader, U2HttpHeaders::userAgent);
+    downloadReply = networkManager->get(req);
     connect(downloadReply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(sl_onError()));
     connect(downloadReply, SIGNAL(uploadProgress(qint64, qint64)), this, SLOT(sl_uploadProgress(qint64, qint64)));
 
@@ -564,7 +566,9 @@ void EntrezQueryTask::sl_replyFinished(QNetworkReply* reply) {
 
 void EntrezQueryTask::runRequest(const QUrl& requestUrl) {
     ioLog.trace(QString("Sending request: %1").arg(query));
-    queryReply = networkManager->get(QNetworkRequest(requestUrl));
+    QNetworkRequest req(requestUrl);
+    req.setHeader(QNetworkRequest::UserAgentHeader, U2HttpHeaders::userAgent);
+    queryReply = networkManager->get(req);
     connect(queryReply, &QNetworkReply::errorOccurred, this, &EntrezQueryTask::sl_onError);
 }
 

--- a/src/corelibs/U2Core/src/tasks/LoadRemoteDocumentTask.cpp
+++ b/src/corelibs/U2Core/src/tasks/LoadRemoteDocumentTask.cpp
@@ -83,11 +83,6 @@ const QMap<QString, QString> RemoteDBRegistry::PAGE_LINKS = { {ENSEMBL, ENSEMBL_
                                                               {SWISS_PROT, UNIPROTKB_PAGE_ID},
                                                               {UNIPROTKB_SWISS_PROT, UNIPROTKB_PAGE_ID},
                                                               {UNIPROTKB_TREMBL, UNIPROTKB_PAGE_ID} };
-static QNetworkRequest constructRequest(const QUrl& requestUrl) {
-    QNetworkRequest req(requestUrl);
-    req.setHeader(QNetworkRequest::UserAgentHeader, "UGENE");
-    return req;
-}
 
 ////////////////////////////////////////////////////////////////////////////
 // BaseLoadRemoteDocumentTask
@@ -470,7 +465,7 @@ void LoadDataFromEntrezTask::run() {
 }
 
 void LoadDataFromEntrezTask::runRequest(const QUrl& requestUrl) {
-    downloadReply = networkManager->get(constructRequest(requestUrl));
+    downloadReply = networkManager->get(QNetworkRequest(requestUrl));
     connect(downloadReply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(sl_onError()));
     connect(downloadReply, SIGNAL(uploadProgress(qint64, qint64)), this, SLOT(sl_uploadProgress(qint64, qint64)));
 
@@ -569,7 +564,7 @@ void EntrezQueryTask::sl_replyFinished(QNetworkReply* reply) {
 
 void EntrezQueryTask::runRequest(const QUrl& requestUrl) {
     ioLog.trace(QString("Sending request: %1").arg(query));
-    queryReply = networkManager->get(constructRequest(requestUrl));
+    queryReply = networkManager->get(QNetworkRequest(requestUrl));
     connect(queryReply, &QNetworkReply::errorOccurred, this, &EntrezQueryTask::sl_onError);
 }
 


### PR DESCRIPTION
На всех системах и в гуи, и в хмл тестировании появились падения. Все связаны с ncbi. Они стали слать следующий ответ на любые запросы (код 302):
```html
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="https://misuse.ncbi.nlm.nih.gov/error/abuse.shtml?db=nucleotide&amp;id=NC_001363&amp;retmode=text&amp;rettype=gbwithparts&amp;tool=UGENE">here</a>.</p>
</body></html>
```
По [редирект-ссылке](https://misuse.ncbi.nlm.nih.gov/error/abuse.shtml?db=nucleotide&amp;id=NC_001363&amp;retmode=text&amp;rettype=gbwithparts&amp;tool=UGENE) говорит, что мой IP -- абьюзер.

2 нюанса:

1. UGENE не обрабатывает такие ситуации: задачи завершаются успешно, только отсутствует выходной файл. С точки зрения пользователя неясно, что происходит. В задаче поиска возникает ассёрт в дебажной сборке, на релиз не влияет.
Можно завести задачу: обрабатывать запросы с редиректом корректно+давать пользователю внятную ошибку как есть, если в ответе отсутствует запрашиваемая последовательность.
2. От IP эта штука вообще не зависит :) И это надолго сбило с толку. Впн и запуск из домашней сети -- ничего не помогает, скачивание не работает.

Как всегда, пр пока что драфт, пока тесты не пройдут. Также отмечу, что [поле](https://github.com/ugeneunipro/ugene/blob/b160206e0f7565dc79c0818220f6220356628841/src/corelibs/U2Core/src/tasks/LoadRemoteDocumentTask.h#L220) не нужно.