### PR TITLE
Fix windows tests

### DIFF
--- a/src/libs_3rdparty/QSpec/src/drivers/GTMouseDriver.cpp
+++ b/src/libs_3rdparty/QSpec/src/drivers/GTMouseDriver.cpp
@@ -81,8 +81,13 @@ bool GTMouseDriver::selectArea(const QPoint& start, const QPoint& end) {
 bool GTMouseDriver::doubleClick() {
     DRIVER_CHECK(press(Qt::LeftButton), "Left button could not be pressed on first click");
     DRIVER_CHECK(release(Qt::LeftButton), "Left button could not be released on first click");
+
     // Use an interval below "doubleClickInterval" between clicks because we want it to be a "double-click".
-    GTGlobals::sleep(QApplication::doubleClickInterval() / 2);
+    auto interval = QApplication::doubleClickInterval() / 2;
+#ifdef Q_OS_WIN
+    interval -= interval / 20;  // -5%
+#endif
+    GTGlobals::sleep(interval);
 
     DRIVER_CHECK(press(Qt::LeftButton), "Left button could not be pressed on second click");
     DRIVER_CHECK(release(Qt::LeftButton), "Left button could not be released on second click");

--- a/src/libs_3rdparty/QSpec/src/drivers/GTMouseDriver.cpp
+++ b/src/libs_3rdparty/QSpec/src/drivers/GTMouseDriver.cpp
@@ -81,13 +81,8 @@ bool GTMouseDriver::selectArea(const QPoint& start, const QPoint& end) {
 bool GTMouseDriver::doubleClick() {
     DRIVER_CHECK(press(Qt::LeftButton), "Left button could not be pressed on first click");
     DRIVER_CHECK(release(Qt::LeftButton), "Left button could not be released on first click");
-
     // Use an interval below "doubleClickInterval" between clicks because we want it to be a "double-click".
-    auto interval = QApplication::doubleClickInterval() / 2;
-#ifdef Q_OS_WIN
-    interval -= interval / 20;  // -5%
-#endif
-    GTGlobals::sleep(interval);
+    GTGlobals::sleep(QApplication::doubleClickInterval() / 2);
 
     DRIVER_CHECK(press(Qt::LeftButton), "Left button could not be pressed on second click");
     DRIVER_CHECK(release(Qt::LeftButton), "Left button could not be released on second click");

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_3001_4000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_3001_4000.cpp
@@ -850,6 +850,8 @@ GUI_TEST_CLASS_DEFINITION(test_3216_2) {
     GTUtilsAnnotationsTreeView::selectItemsByName({"CDS"});
     QString actualValue = GTUtilsAnnotationsTreeView::getQualifierValue("test_3216_2", "CDS");
     CHECK_SET_ERR(actualValue == expectedValue, QString("The qualifier value is incorrect: expect '%1', got '%2'").arg(expectedValue).arg(actualValue));
+
+    GTUtilsProject::closeProject(true);
 }
 
 GUI_TEST_CLASS_DEFINITION(test_3216_3) {


### PR DESCRIPTION
В #1645 упали 2 виндовых теста:

- common_scenarios_sanger_test_0005_4
- regression_scenarios_test_3216_2

Ни один из них к предложенным в том пр правкам отношения не имеет.