### PR TITLE
UGENE-8132 Incorrect visualisation of joint CDS annotation

### DIFF
--- a/src/corelibs/U2View/src/ov_sequence/view_rendering/SequenceViewAnnotatedRenderer.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/view_rendering/SequenceViewAnnotatedRenderer.cpp
@@ -147,7 +147,7 @@ void SequenceViewAnnotatedRenderer::drawAnnotation(QPainter& p, const QSize& can
     for (int ri = 0, ln = location.size(); ri < ln; ri++) {
         const U2Region& r = location.at(ri);
         if (r.intersects(visibleRange)) {
-            const QRect annotationRect = getAnnotationRect(r, canvasSize, visibleRange, selected, a, as);
+            const QRect annotationRect = getAnnotationRect(ri, canvasSize, visibleRange, selected, a, as);
             CHECK_CONTINUE(!annotationRect.isEmpty());
 
             QPainterPath rectPath;
@@ -258,11 +258,12 @@ int SequenceViewAnnotatedRenderer::getCutPosition(const U2Region& r, const QStri
     return cutPosition;
 }
 
-QRect SequenceViewAnnotatedRenderer::getAnnotationRect(const U2Region& reg, const QSize& canvasSize, const U2Region& visibleRange, bool selected, Annotation* a, const AnnotationSettings* as) const {
+QRect SequenceViewAnnotatedRenderer::getAnnotationRect(int regionIndex, const QSize& canvasSize, const U2Region& visibleRange, bool selected, Annotation* a, const AnnotationSettings* as) const {
     QRect res;
-    const U2Region y = getAnnotationYRange(a, 0, as, canvasSize.height());
+    const U2Region y = getAnnotationYRange(a, regionIndex, as, canvasSize.height());
     CHECK(y.startPos >= 0, res);
 
+    const auto& reg = a->getRegions().at(regionIndex);
     if (reg.intersects(visibleRange)) {
         const U2Region x = getAnnotationXRange(reg, visibleRange, canvasSize, selected);
         CHECK(!x.isEmpty(), res);
@@ -351,13 +352,13 @@ void SequenceViewAnnotatedRenderer::drawCutSite(QPainter& p, const QSize& canvas
         // draw direct cut
         auto cutPosDirect = getCutPosition(regionPair.first, qualifierValue, isDirectStrand, true);
         if (cutPosDirect != INCORRECT_CUT_POSITION) {
-            auto annRect = getAnnotationRect(regionPair.first, canvasSize, visibleRange, selected, a, as);
+            auto annRect = getAnnotationRect(0, canvasSize, visibleRange, selected, a, as);
             drawCutSite(p, aData, cutPosDirect, annRect, as->color, canvasSize, visibleRange, true);
         }
         // draw complement cut
         auto cutPosComplement = getCutPosition(regionPair.second, qualifierValue, isDirectStrand, false);
         if (cutPosComplement != INCORRECT_CUT_POSITION) {
-            auto annRect = getAnnotationRect(regionPair.second, canvasSize, visibleRange, selected, a, as);
+            auto annRect = getAnnotationRect(1, canvasSize, visibleRange, selected, a, as);
             drawCutSite(p, aData, cutPosComplement, annRect, as->color, canvasSize, visibleRange, false);
         }
     } else if (location.size() == 1) {
@@ -366,14 +367,14 @@ void SequenceViewAnnotatedRenderer::drawCutSite(QPainter& p, const QSize& canvas
         // draw direct cut
         auto cutPosDirect = getCutPosition(reg, qualifierValue, isDirectStrand, true);
         if (cutPosDirect != INCORRECT_CUT_POSITION) {
-            annRect = getAnnotationRect(reg, canvasSize, visibleRange, selected, a, as);
+            annRect = getAnnotationRect(0, canvasSize, visibleRange, selected, a, as);
             drawCutSite(p, aData, cutPosDirect, annRect, as->color, canvasSize, visibleRange, true);
         }
         // draw complement cut
         auto cutPosComplement = getCutPosition(reg, qualifierValue, isDirectStrand, false);
         if (cutPosComplement != INCORRECT_CUT_POSITION) {
             if (annRect.isEmpty()) {
-                annRect = getAnnotationRect(reg, canvasSize, visibleRange, selected, a, as);
+                annRect = getAnnotationRect(0, canvasSize, visibleRange, selected, a, as);
             }
             drawCutSite(p, aData, cutPosComplement, annRect, as->color, canvasSize, visibleRange, false);
         }

--- a/src/corelibs/U2View/src/ov_sequence/view_rendering/SequenceViewAnnotatedRenderer.h
+++ b/src/corelibs/U2View/src/ov_sequence/view_rendering/SequenceViewAnnotatedRenderer.h
@@ -136,7 +136,7 @@ protected:
     /**
      * Calculates position of annotation rect on visible part of details view.
      *
-     * \param reg Annotation region.
+     * \param regionIndex Index of the annotation region.
      * \param canvasSize Size of the whole details view part, where all annotations are drawn.
      * \param visibleRange Sequence visible range.
      * \param selected True if annotation is selected, false otherwise.
@@ -144,7 +144,7 @@ protected:
      * \param as AnnotationSettings object.
      * \return Returns rect, which contains posistions of annotation on details view.
      */
-    QRect getAnnotationRect(const U2Region& reg, const QSize& canvasSize, const U2Region& visibleRange, bool selected, Annotation* a, const AnnotationSettings* as) const;
+    QRect getAnnotationRect(int regionIndex, const QSize& canvasSize, const U2Region& visibleRange, bool selected, Annotation* a, const AnnotationSettings* as) const;
 
     void drawAnnotationConnections(QPainter& p, Annotation* a, const AnnotationSettings* as, const AnnotationDisplaySettings& drawSettings, const QSize& canvasSize, const U2Region& visibleRange);
 


### PR DESCRIPTION
Проблема возникала из-за того, что в место расчета координат прямоугольника аннотации по оси Y всегда передавался индекс аннотации 0, а не реальный индекс текущей аннотации.

Теста нет, т.к. это чисто визуальная проблема, которую не потестируешь автоматическим тестированием. Несмотря на то, что аннотация отображалась не на своей трансляции, все взаимодействия с ней (выделение и т.д.) все равно отрабатывали только при щелчке на трансляцию, на которой она должна была быть по правильному.