### PR TITLE
UGENE-8146 Crash on opening UGENE from command line with url parameter

### DIFF
--- a/src/corelibs/U2Core/src/models/DocumentModel.cpp
+++ b/src/corelibs/U2Core/src/models/DocumentModel.cpp
@@ -622,7 +622,6 @@ void Document::setName(const QString& newName) {
 }
 
 void Document::setURL(const GUrl& newUrl) {
-    assert(!isLoaded() || !isStateLocked());
     if (url == newUrl) {
         return;
     }

--- a/src/corelibs/U2Formats/src/PlainTextFormat.cpp
+++ b/src/corelibs/U2Formats/src/PlainTextFormat.cpp
@@ -42,6 +42,7 @@ PlainTextFormat::PlainTextFormat(QObject* p)
 Document* PlainTextFormat::loadTextDocument(IOAdapterReader& reader, const U2DbiRef& dbiRef, const QVariantMap& hints, U2OpStatus& os) {
     // Read the whole text file.
     QString text;
+    QString baseName = reader.getURL().baseFileName();
     reader.read(os, text, -1);
     CHECK_OP(os, nullptr);
 
@@ -52,7 +53,7 @@ Document* PlainTextFormat::loadTextDocument(IOAdapterReader& reader, const U2Dbi
 
     QVariantMap textObjectHints;
     textObjectHints.insert(DBI_FOLDER_HINT, hints.value(DBI_FOLDER_HINT, U2ObjectDbi::ROOT_FOLDER));
-    TextObject* textObject = TextObject::createInstance(text, reader.getURL().baseFileName(), dbiRef, os, textObjectHints);
+    TextObject* textObject = TextObject::createInstance(text, baseName, dbiRef, os, textObjectHints);
     CHECK_OP(os, nullptr);
     QList<GObject*> objects = {textObject};
     return new Document(this, reader.getFactory(), reader.getURL(), dbiRef, objects, hints);


### PR DESCRIPTION
Урл запоминаем до чтения так как после он становился пустым из-за чего и был креш, вызывался метод HttpFileAdapter::close().
Ассерт убрал, так как он срабатывает в данном сценарии, но ни на что не влияет.
Есть идеи как написать тест?