### PR TITLE
UGENE-8118 Add to Navigation menu "Go to position" item for Sanger Eitor

### DIFF
--- a/src/corelibs/U2View/src/ov_mca/McaEditor.cpp
+++ b/src/corelibs/U2View/src/ov_mca/McaEditor.cpp
@@ -134,8 +134,11 @@ SequenceObjectContext* McaEditor::getReferenceContext() const {
 void McaEditor::sl_onPosChangeRequest() {
     const int position = getUI()->getGotoUserInputValue() - 1;
     CHECK(position >= 0, );
-    const int gaps = position - getUI()->getRefCharController()->getUngappedPosition(position);
+    const int ungappedPos = getUI()->getRefCharController()->getUngappedPosition(position);
+    const int gaps = ungappedPos == -1 ? 1 : position - ungappedPos;
     const QRect selection(position + gaps, 0, 1, ui->getSequenceArea()->getViewRowCount());
+    //const int gapped = getUI()->getRefCharController()->getUngappedPosition(position);
+    //const QRect selection(gapped == -1 ? position : gapped, 0, 1, ui->getSequenceArea()->getViewRowCount());
     getSelectionController()->setSelection(MaEditorSelection({selection}));
 }
 

--- a/src/corelibs/U2View/src/ov_mca/McaEditor.cpp
+++ b/src/corelibs/U2View/src/ov_mca/McaEditor.cpp
@@ -132,13 +132,9 @@ SequenceObjectContext* McaEditor::getReferenceContext() const {
 }
 
 void McaEditor::sl_onPosChangeRequest() {
-    const int position = getUI()->getGotoUserInputValue() - 1;
+    int position = getUI()->getGotoUserInputValue() - 1;
     CHECK(position >= 0, );
-    const int ungappedPos = getUI()->getRefCharController()->getUngappedPosition(position);
-    const int gaps = ungappedPos == -1 ? 1 : position - ungappedPos;
-    const QRect selection(position + gaps, 0, 1, ui->getSequenceArea()->getViewRowCount());
-    //const int gapped = getUI()->getRefCharController()->getUngappedPosition(position);
-    //const QRect selection(gapped == -1 ? position : gapped, 0, 1, ui->getSequenceArea()->getViewRowCount());
+    const QRect selection(getUI()->getRefCharController()->getGappedPos(position), 0, 1, ui->getSequenceArea()->getViewRowCount());
     getSelectionController()->setSelection(MaEditorSelection({selection}));
 }
 

--- a/src/corelibs/U2View/src/ov_mca/McaEditorStatusBar.cpp
+++ b/src/corelibs/U2View/src/ov_mca/McaEditorStatusBar.cpp
@@ -98,7 +98,12 @@ void McaEditorStatusBar::updateLabels() {
     } else {
         int startSelection = selection->getSelectedRegions().first().startPos;
         int refPos = refCharController->getUngappedPosition(startSelection);
-        columnLabel->update(refPos == -1 ? GAP_MARK : QString::number(refPos + 1), ungappedRefLen);
+        QString refPosStr = refPos == -1 ? "+" : "";
+        while (refPos < 0 && startSelection > 0) {
+            refPos = refCharController->getUngappedPosition(--startSelection);
+        }
+        refPosStr.prepend(QString::number(qMax(refPos, 0) + 1));
+        columnLabel->update(refPosStr, ungappedRefLen);
     }
 }
 

--- a/src/corelibs/U2View/src/ov_mca/McaReferenceCharController.cpp
+++ b/src/corelibs/U2View/src/ov_mca/McaReferenceCharController.cpp
@@ -109,6 +109,25 @@ int McaReferenceCharController::getUngappedPosition(int pos) const {
     return -1;
 }
 
+int McaReferenceCharController::getGappedPos(int pos) const {
+    U2OpStatusImpl os;
+    const QByteArray data = refObject->getWholeSequenceData(os);
+    SAFE_POINT_OP(os, -1);
+    int newPos = 0;
+    int symbolsCounter = 0;
+    for (const QChar& c : qAsConst(data)) {
+        const bool notGapChar = c != U2Msa::GAP_CHAR;
+        if (symbolsCounter == pos && notGapChar) {
+            break;
+        }
+        if (notGapChar) {
+            symbolsCounter++;
+        }
+        newPos++;
+    }
+    return newPos;
+}
+
 int McaReferenceCharController::getUngappedLength() const {
     return ungappedLength;
 }

--- a/src/corelibs/U2View/src/ov_mca/McaReferenceCharController.h
+++ b/src/corelibs/U2View/src/ov_mca/McaReferenceCharController.h
@@ -57,6 +57,8 @@ public:
     OffsetRegions getCharRegions(const U2Region& region) const;
 
     int getUngappedPosition(int pos) const;
+    //returns gapped position for ungapped, in case of problems returns -1
+    int getGappedPos(int pos) const;
     int getUngappedLength() const;
 
 signals:

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/mca_editor/GTTestsMcaEditor.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/mca_editor/GTTestsMcaEditor.cpp
@@ -3401,7 +3401,7 @@ GUI_TEST_CLASS_DEFINITION(test_0041) {
     readLengthString = GTUtilsMcaEditorStatusWidget::getReadUngappedLengthString();
     CHECK_SET_ERR(NONE_MARK == rowNumberString, QString("10. Unexpected row number label: expected '%1', got '%2'").arg(NONE_MARK).arg(rowNumberString));
     CHECK_SET_ERR("16" == rowCountString, QString("10. Unexpected rows count label: expected '%1', got '%2'").arg("16").arg(rowCountString));
-    CHECK_SET_ERR(GAP_MARK == referencePositionString, QString("10. Unexpected reference position label: expected '%1', got '%2'").arg(GAP_MARK).arg(referencePositionString));
+    CHECK_SET_ERR("2071+" == referencePositionString, QString("10. Unexpected reference position label: expected '%1', got '%2'").arg("2071+").arg(referencePositionString));
     CHECK_SET_ERR("11878" == referenceLengthString, QString("10. Unexpected reference length label: expected '%1', got '%2'").arg("11878").arg(referenceLengthString));
     CHECK_SET_ERR(NONE_MARK == readPositionString, QString("10. Unexpected read position label: expected '%1', got '%2'").arg(NONE_MARK).arg(readPositionString));
     CHECK_SET_ERR(NONE_MARK == readLengthString, QString("10. Unexpected read length label: expected '%1', got '%2'").arg(NONE_MARK).arg(readLengthString));
@@ -3469,7 +3469,7 @@ GUI_TEST_CLASS_DEFINITION(test_0041) {
     readLengthString = GTUtilsMcaEditorStatusWidget::getReadUngappedLengthString();
     CHECK_SET_ERR("7" == rowNumberString, QString("14. Unexpected row number label: expected '%1', got '%2'").arg("7").arg(rowNumberString));
     CHECK_SET_ERR("16" == rowCountString, QString("14. Unexpected rows count label: expected '%1', got '%2'").arg("16").arg(rowCountString));
-    CHECK_SET_ERR(GAP_MARK == referencePositionString, QString("14. Unexpected reference position label: expected '%1', got '%2'").arg(GAP_MARK).arg(referencePositionString));
+    CHECK_SET_ERR("3059+" == referencePositionString, QString("14. Unexpected reference position label: expected '%1', got '%2'").arg("3059+").arg(referencePositionString));
     CHECK_SET_ERR("11878" == referenceLengthString, QString("14. Unexpected reference length label: expected '%1', got '%2'").arg("11878").arg(referenceLengthString));
     CHECK_SET_ERR(GAP_MARK == readPositionString, QString("14. Unexpected read position label: expected '%1', got '%2'").arg(GAP_MARK).arg(readPositionString));
     CHECK_SET_ERR("1036" == readLengthString, QString("14. Unexpected read length label: expected '%1', got '%2'").arg("1036").arg(readLengthString));

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_5001_6000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_5001_6000.cpp
@@ -4488,7 +4488,7 @@ GUI_TEST_CLASS_DEFINITION(test_5833) {
     readLengthString = GTUtilsMcaEditorStatusWidget::getReadUngappedLengthString();
     CHECK_SET_ERR("2" == rowNumberString, QString("Unexpected row number label: expected '%1', got '%2'").arg("2").arg(rowNumberString));
     CHECK_SET_ERR("16" == rowsCountString, QString("Unexpected rows count label: expected '%1', got '%2'").arg("16").arg(rowsCountString));
-    CHECK_SET_ERR("gap" == referencePositionString, QString("Unexpected reference position label: expected '%1', got '%2'").arg("gap").arg(referencePositionString));
+    CHECK_SET_ERR("2499+" == referencePositionString, QString("Unexpected reference position label: expected '%1', got '%2'").arg("2499+").arg(referencePositionString));
     CHECK_SET_ERR("11878" == referenceLengthString, QString("Unexpected reference length label: expected '%1', got '%2'").arg("11878").arg(referenceLengthString));
     CHECK_SET_ERR("440" == readPositionString, QString("Unexpected read position label: expected '%1', got '%2'").arg("440").arg(readPositionString));
     CHECK_SET_ERR("1174" == readLengthString, QString("Unexpected read length label: expected '%1', got '%2'").arg("1174").arg(readLengthString));

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_8001_9000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_8001_9000.cpp
@@ -1065,10 +1065,20 @@ GUI_TEST_CLASS_DEFINITION(test_8118) {
 
     CHECK_SET_ERR(GTUtilsMcaEditor::getReferenceArea()->getVisibleRange().endPos() == 599, QString("Unexpected text: slider position doesn't change after 'Go to'"));
 
+    GTUtilsDialog::waitForDialog(new GoToDialogFiller(2082));
+    GTKeyboardDriver::keyClick('g', Qt::ControlModifier);
+    // gapped length returned so it differs with 'go to' value
+    int pos = GTUtilsMcaEditor::getReferenceArea()->getVisibleRange().endPos();
+    CHECK_SET_ERR(GTUtilsMcaEditor::getReferenceArea()->getVisibleRange().endPos() == 2083, QString("Unexpected text: slider position doesn't change after 'Go to'"));
+
+    GTUtilsDialog::waitForDialog(new GoToDialogFiller(2083));
+    GTKeyboardDriver::keyClick('g', Qt::ControlModifier);
+    pos = GTUtilsMcaEditor::getReferenceArea()->getVisibleRange().endPos();
+    CHECK_SET_ERR(GTUtilsMcaEditor::getReferenceArea()->getVisibleRange().endPos() == 2084, QString("Unexpected text: slider position doesn't change after 'Go to'"));
+
     GTUtilsDialog::waitForDialog(new GoToDialogFiller(5666));
     GTKeyboardDriver::keyClick('g', Qt::ControlModifier);
 
-    //gapped length returned so it differs with 'go to' value
     CHECK_SET_ERR(GTUtilsMcaEditor::getReferenceArea()->getVisibleRange().endPos() == 5724, QString("Unexpected text: slider position doesn't change after 'Go to'"));
 }
 

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_8001_9000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_8001_9000.cpp
@@ -1065,20 +1065,17 @@ GUI_TEST_CLASS_DEFINITION(test_8118) {
 
     CHECK_SET_ERR(GTUtilsMcaEditor::getReferenceArea()->getVisibleRange().endPos() == 599, QString("Unexpected text: slider position doesn't change after 'Go to'"));
 
-    GTUtilsDialog::waitForDialog(new GoToDialogFiller(2082));
+    GTUtilsDialog::waitForDialog(new GoToDialogFiller(2081));
     GTKeyboardDriver::keyClick('g', Qt::ControlModifier);
     // gapped length returned so it differs with 'go to' value
-    int pos = GTUtilsMcaEditor::getReferenceArea()->getVisibleRange().endPos();
-    CHECK_SET_ERR(GTUtilsMcaEditor::getReferenceArea()->getVisibleRange().endPos() == 2083, QString("Unexpected text: slider position doesn't change after 'Go to'"));
+    CHECK_SET_ERR(GTUtilsMcaEditor::getReferenceArea()->getVisibleRange().endPos() == 2082, QString("Unexpected text: slider position doesn't change after 'Go to'"));
 
-    GTUtilsDialog::waitForDialog(new GoToDialogFiller(2083));
+    GTUtilsDialog::waitForDialog(new GoToDialogFiller(2082));
     GTKeyboardDriver::keyClick('g', Qt::ControlModifier);
-    pos = GTUtilsMcaEditor::getReferenceArea()->getVisibleRange().endPos();
     CHECK_SET_ERR(GTUtilsMcaEditor::getReferenceArea()->getVisibleRange().endPos() == 2084, QString("Unexpected text: slider position doesn't change after 'Go to'"));
 
     GTUtilsDialog::waitForDialog(new GoToDialogFiller(5666));
-    GTKeyboardDriver::keyClick('g', Qt::ControlModifier);
-
+    GTKeyboardDriver::keyClick('g', Qt::ControlModifier);    
     CHECK_SET_ERR(GTUtilsMcaEditor::getReferenceArea()->getVisibleRange().endPos() == 5724, QString("Unexpected text: slider position doesn't change after 'Go to'"));
 }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/35ac0526-95af-4d7c-b253-4b990fa14def)
Обращаю внимание как сейчас реализована навигация в MCA.
Линейка с позициями сверху и строчка отображающая позицию внизу (обведены красным) не учитывают гэпы поэтому при выборе столбца с гэпами (обведено желтым) имеем  значение "RefPos gap/6321". Что не соответствует поведению например в MSA. Сейчас "Go to position" переходит на позицию с учетом гэпов, поэтому позиция перемещения может не соответствовать позиции на линейке и на указателе позиции.
Если хотим поменять поведение goto, то целесообразно сделать в рамках этого бага. Если хотим поменять линейку + позицию, то думаю лучше завести отдельный баг. Либо ничего не трогать и оставить так как есть.