### PR TITLE
HighDpiScaling has been disabled as far as it makes problems on high-scaled display settings

### DIFF
--- a/src/ugeneui/src/Main.cpp
+++ b/src/ugeneui/src/Main.cpp
@@ -433,7 +433,6 @@ int main(int argc, char** argv) {
     // A workaround for https://bugreports.qt.io/browse/QTBUG-87014: "Qt application gets stuck trying to open main window under Big Sur"
     qputenv("QT_MAC_WANTS_LAYER", "1");
 #endif
-    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling, true);
     // QApplication app(argc, argv);
     GApplication app(argc, argv);
 


### PR DESCRIPTION
Если в настройках дисплея задан высокий мастштаб, то включение данного атрибута приводит к раздуванию размеров графического интерфейса до масштаба, в котором с ним не удобно работать, из-за того, что рабочие зоны становятся очень маленькими. При этом, возможностей вернуть все, как было, настройками приложения нет:

![image](https://github.com/user-attachments/assets/bca24eaa-2607-44d8-a00e-3f3c7e940139)

![image](https://github.com/user-attachments/assets/e4d4ba3c-60b3-42bc-8e8b-9bdde3f15a7d)

Предлагаю убрать включение этого аттрибута. Если, по каким-то причинам, он необходим - вернуть в виде опции в "Параметрах".

