### PR TITLE
UGENE-8102 The Restriction enzymes dialog improvements

### DIFF
--- a/src/plugins/enzymes/src/enzymes_dialog/EnzymesSelectorWidget.cpp
+++ b/src/plugins/enzymes/src/enzymes_dialog/EnzymesSelectorWidget.cpp
@@ -59,8 +59,13 @@ EnzymesSelectorWidget::EnzymesSelectorWidget(QWidget* parent)
     filterComboBox->addItem(tr("name"), FILTER_BY_NAME);
     filterComboBox->addItem(tr("sequence"), FILTER_BY_SEQUENCE);
 
-    splitter->setStretchFactor(0, 3);
-    splitter->setStretchFactor(1, 2);
+    selectionSplitter->setStretchFactor(0, 1);
+    selectionSplitter->setStretchFactor(1, 1);
+
+    enzymesSplitter->setStretchFactor(0, 3);
+    enzymesSplitter->setStretchFactor(1, 2);
+
+    checkedEnzymesEdit->setWordWrapMode(QTextOption::WrapAnywhere);
 
     tree->setSortingEnabled(true);
     tree->sortByColumn(0, Qt::AscendingOrder);
@@ -107,11 +112,9 @@ EnzymesSelectorWidget::EnzymesSelectorWidget(QWidget* parent)
     connect(saveEnzymesButton, SIGNAL(clicked()), SLOT(sl_saveEnzymesFile()));
     connect(selectAllButton, SIGNAL(clicked()), SLOT(sl_selectAll()));
     connect(selectNoneButton, SIGNAL(clicked()), SLOT(sl_selectNone()));
-    connect(selectByLengthButton, SIGNAL(clicked()), SLOT(sl_selectByLength()));
     connect(invertSelectionButton, SIGNAL(clicked()), SLOT(sl_inverseSelection()));
     connect(loadSelectionButton, SIGNAL(clicked()), SLOT(sl_loadSelectionFromFile()));
-    connect(saveSelectionButton, SIGNAL(clicked()), SLOT(sl_saveSelectionToFile()));
-    connect(enzymeInfo, SIGNAL(clicked()), SLOT(sl_openDBPage()));
+    connect(saveSelectionButton, SIGNAL(clicked()), SLOT(sl_saveSelectionToFile()));//
     connect(enzymesFilterEdit, &QLineEdit::textChanged, this, &EnzymesSelectorWidget::sl_filterConditionsChanged);
     connect(filterComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &EnzymesSelectorWidget::sl_filterConditionsChanged);
 
@@ -628,29 +631,6 @@ void EnzymesSelectorWidget::sl_selectNone() {
     updateStatus();
 }
 
-void EnzymesSelectorWidget::sl_selectByLength() {
-    bool ok;
-    int len = QInputDialog::getInt(this, tr("Minimum length"), tr("Enter minimum length of recognition sites"), minLength, 1, 20, 1, &ok);
-    if (ok) {
-        minLength = len;
-        ignoreItemChecks = true;
-        for (int i = 0, n = tree->topLevelItemCount(); i < n; i++) {
-            auto gi = static_cast<EnzymeGroupTreeItem*>(tree->topLevelItem(i));
-            for (int j = 0, m = gi->childCount(); j < m; j++) {
-                auto item = static_cast<EnzymeTreeItem*>(gi->child(j));
-                if (item->enzyme->seq.length() < len) {
-                    item->setCheckState(0, Qt::Unchecked);
-                } else {
-                    item->setCheckState(0, Qt::Checked);
-                }
-            }
-            gi->updateVisual();
-        }
-        ignoreItemChecks = false;
-    }
-    updateStatus();
-}
-
 void EnzymesSelectorWidget::sl_inverseSelection() {
     ignoreItemChecks = true;
     for (int i = 0, n = tree->topLevelItemCount(); i < n; i++) {
@@ -686,21 +666,6 @@ void EnzymesSelectorWidget::sl_saveSelectionToFile() {
         QTextStream out(&data);
         out << selectionData;
     }
-}
-
-void EnzymesSelectorWidget::sl_openDBPage() {
-    QTreeWidgetItem* ci = tree->currentItem();
-    EnzymeTreeItem* item = ci == nullptr || ci->parent() == 0 ? nullptr : static_cast<EnzymeTreeItem*>(tree->currentItem());
-    if (item == nullptr) {
-        QMessageBox::critical(this, tr("Error!"), tr("No enzyme selected!"));
-        return;
-    }
-    QString id = item->enzyme->id;
-    if (id.isEmpty()) {
-        QMessageBox::critical(this, L10N::errorTitle(), tr("Selected enzyme has no ID!"));
-        return;
-    }
-    GUIUtils::runWebBrowser("http://rebase.neb.com/cgi-bin/reb_get.pl?enzname=" + id);
 }
 
 void EnzymesSelectorWidget::sl_itemChanged(QTreeWidgetItem* item, int col) {

--- a/src/plugins/enzymes/src/enzymes_dialog/EnzymesSelectorWidget.cpp
+++ b/src/plugins/enzymes/src/enzymes_dialog/EnzymesSelectorWidget.cpp
@@ -114,7 +114,7 @@ EnzymesSelectorWidget::EnzymesSelectorWidget(QWidget* parent)
     connect(selectNoneButton, SIGNAL(clicked()), SLOT(sl_selectNone()));
     connect(invertSelectionButton, SIGNAL(clicked()), SLOT(sl_inverseSelection()));
     connect(loadSelectionButton, SIGNAL(clicked()), SLOT(sl_loadSelectionFromFile()));
-    connect(saveSelectionButton, SIGNAL(clicked()), SLOT(sl_saveSelectionToFile()));//
+    connect(saveSelectionButton, SIGNAL(clicked()), SLOT(sl_saveSelectionToFile()));
     connect(enzymesFilterEdit, &QLineEdit::textChanged, this, &EnzymesSelectorWidget::sl_filterConditionsChanged);
     connect(filterComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &EnzymesSelectorWidget::sl_filterConditionsChanged);
 

--- a/src/plugins/enzymes/src/enzymes_dialog/EnzymesSelectorWidget.h
+++ b/src/plugins/enzymes/src/enzymes_dialog/EnzymesSelectorWidget.h
@@ -110,11 +110,9 @@ private slots:
     void sl_saveEnzymesFile();
     void sl_selectAll();
     void sl_selectNone();
-    void sl_selectByLength();
     void sl_inverseSelection();
     void sl_saveSelectionToFile();
     void sl_loadSelectionFromFile();
-    void sl_openDBPage();
     void sl_itemChanged(QTreeWidgetItem* item, int col);
     void sl_filterConditionsChanged();
     void sl_findSingleEnzymeTaskStateChanged();

--- a/src/plugins/enzymes/src/enzymes_dialog/EnzymesSelectorWidget.ui
+++ b/src/plugins/enzymes/src/enzymes_dialog/EnzymesSelectorWidget.ui
@@ -10,289 +10,328 @@
     <x>0</x>
     <y>0</y>
     <width>893</width>
-    <height>539</height>
+    <height>792</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>600</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Find Restriction Sites</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_6">
+  <layout class="QVBoxLayout" name="verticalLayout_4">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="10,1">
-     <property name="leftMargin">
-      <number>0</number>
-     </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
+    <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <layout class="QVBoxLayout" name="verticalLayout_4">
+      <widget class="QLabel" name="filterBy_label">
+       <property name="text">
+        <string>Filter by:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="filterComboBox"/>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="enzymesFilterEdit"/>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QSplitter" name="enzymesSplitter">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
+     <widget class="QWidget" name="">
+      <layout class="QHBoxLayout" name="horizontalLayout_7" stretch="10,1">
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout">
+        <widget class="QTreeWidget" name="tree">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>5</verstretch>
+          </sizepolicy>
+         </property>
+         <column>
+          <property name="text">
+           <string>Name</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Accession</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Type</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Sequence</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Organizm / Details</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Suppliers</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,0,0,0,0,0,0">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <property name="sizeConstraint">
+          <enum>QLayout::SizeConstraint::SetMinAndMaxSize</enum>
+         </property>
          <item>
-          <widget class="QLabel" name="filterBy_label">
+          <widget class="QPushButton" name="enzymesFileButton">
+           <property name="toolTip">
+            <string>Load enzymes database</string>
+           </property>
            <property name="text">
-            <string>Filter by:</string>
+            <string>Open enzymes </string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QComboBox" name="filterComboBox"/>
+          <widget class="QPushButton" name="saveEnzymesButton">
+           <property name="toolTip">
+            <string>Export current selection as new database</string>
+           </property>
+           <property name="text">
+            <string>Export enzymes</string>
+           </property>
+          </widget>
          </item>
          <item>
-          <widget class="QLineEdit" name="enzymesFilterEdit"/>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer">
+          <widget class="Line" name="line_2">
            <property name="orientation">
             <enum>Qt::Orientation::Horizontal</enum>
            </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="selectAllButton">
+           <property name="toolTip">
+            <string>Select all enzymes in the table</string>
+           </property>
+           <property name="text">
+            <string>Select All</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="selectNoneButton">
+           <property name="toolTip">
+            <string>Empty selection</string>
+           </property>
+           <property name="text">
+            <string>Select None</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="invertSelectionButton">
+           <property name="toolTip">
+            <string>Invert current selection</string>
+           </property>
+           <property name="text">
+            <string>Invert selection</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Orientation::Vertical</enum>
+           </property>
            <property name="sizeHint" stdset="0">
             <size>
-             <width>40</width>
-             <height>20</height>
+             <width>20</width>
+             <height>40</height>
             </size>
            </property>
           </spacer>
          </item>
         </layout>
        </item>
-       <item>
-        <widget class="QSplitter" name="splitter">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
-         <widget class="QTreeWidget" name="tree">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>5</verstretch>
-           </sizepolicy>
+      </layout>
+     </widget>
+     <widget class="QSplitter" name="selectionSplitter">
+      <property name="orientation">
+       <enum>Qt::Orientation::Horizontal</enum>
+      </property>
+      <widget class="QWidget" name="">
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <item>
+           <widget class="QLabel" name="label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Checked enzymes</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="saveSelectionButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>50</width>
+              <height>20</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>Save selected enzymes list to a text file</string>
+            </property>
+            <property name="text">
+             <string>Save</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="loadSelectionButton">
+            <property name="maximumSize">
+             <size>
+              <width>50</width>
+              <height>20</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>Hint: selection file should contain enzymes' names separtated by whitespaces or commas</string>
+            </property>
+            <property name="text">
+             <string>Load</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Orientation::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QPlainTextEdit" name="checkedEnzymesEdit">
+          <property name="verticalScrollBarPolicy">
+           <enum>Qt::ScrollBarPolicy::ScrollBarAsNeeded</enum>
           </property>
-          <column>
-           <property name="text">
-            <string>Name</string>
-           </property>
-          </column>
-          <column>
-           <property name="text">
-            <string>Accession</string>
-           </property>
-          </column>
-          <column>
-           <property name="text">
-            <string>Type</string>
-           </property>
-          </column>
-          <column>
-           <property name="text">
-            <string>Sequence</string>
-           </property>
-          </column>
-          <column>
-           <property name="text">
-            <string>Organizm / Details</string>
-           </property>
-          </column>
-          <column>
-           <property name="text">
-            <string>Suppliers</string>
-           </property>
-          </column>
+          <property name="lineWrapMode">
+           <enum>QPlainTextEdit::LineWrapMode::WidgetWidth</enum>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+          <property name="plainText">
+           <string/>
+          </property>
          </widget>
-         <widget class="QWidget" name="layoutWidget">
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
-           <property name="topMargin">
-            <number>10</number>
-           </property>
-           <item>
-            <layout class="QVBoxLayout" name="verticalLayout_2">
-             <item>
-              <widget class="QLabel" name="label">
-               <property name="text">
-                <string>Checked enzymes</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPlainTextEdit" name="checkedEnzymesEdit">
-               <property name="verticalScrollBarPolicy">
-                <enum>Qt::ScrollBarPolicy::ScrollBarAsNeeded</enum>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <layout class="QVBoxLayout" name="verticalLayout">
-             <item>
-              <widget class="QLabel" name="label_3">
-               <property name="text">
-                <string>Selected enzyme info</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QTextBrowser" name="teSelectedEnzymeInfo">
-               <property name="lineWrapMode">
-                <enum>QTextEdit::LineWrapMode::NoWrap</enum>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-               <property name="textInteractionFlags">
-                <set>Qt::TextInteractionFlag::TextBrowserInteraction</set>
-               </property>
-               <property name="openExternalLinks">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-          </layout>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="">
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <item>
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Selected enzyme info</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_6">
+            <property name="orientation">
+             <enum>Qt::Orientation::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QTextBrowser" name="teSelectedEnzymeInfo">
+          <property name="lineWrapMode">
+           <enum>QTextEdit::LineWrapMode::NoWrap</enum>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::TextInteractionFlag::TextBrowserInteraction</set>
+          </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
          </widget>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,0,0,0,0,0,0,0,0,0,0,1">
-       <property name="spacing">
-        <number>6</number>
-       </property>
-       <property name="sizeConstraint">
-        <enum>QLayout::SizeConstraint::SetMinAndMaxSize</enum>
-       </property>
-       <item>
-        <widget class="QPushButton" name="enzymesFileButton">
-         <property name="toolTip">
-          <string>Load enzymes database</string>
-         </property>
-         <property name="text">
-          <string>Open enzymes </string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="saveEnzymesButton">
-         <property name="toolTip">
-          <string>Export current selection as new database</string>
-         </property>
-         <property name="text">
-          <string>Export enzymes</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Line" name="line_2">
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="selectAllButton">
-         <property name="toolTip">
-          <string>Select all enzymes in the table</string>
-         </property>
-         <property name="text">
-          <string>Select All</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="selectNoneButton">
-         <property name="toolTip">
-          <string>Empty selection</string>
-         </property>
-         <property name="text">
-          <string>Select None</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="selectByLengthButton">
-         <property name="toolTip">
-          <string>Select enzymes by length of recognition sequence</string>
-         </property>
-         <property name="text">
-          <string>Select by length</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="invertSelectionButton">
-         <property name="toolTip">
-          <string>Invert current selection</string>
-         </property>
-         <property name="text">
-          <string>Invert selection</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="loadSelectionButton">
-         <property name="toolTip">
-          <string>Hint: selection file should contain enzymes' names separtated by whitespaces or commas</string>
-         </property>
-         <property name="text">
-          <string>Load selection</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="saveSelectionButton">
-         <property name="toolTip">
-          <string>Save selected enzymes list to a text file</string>
-         </property>
-         <property name="text">
-          <string>Save selection</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Line" name="line">
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="enzymeInfo">
-         <property name="text">
-          <string>REBASE Info</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-    </layout>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </widget>
    </item>
    <item>
     <widget class="QGroupBox" name="groupBox_3">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
      <property name="title">
       <string>Enzyme table filter</string>
      </property>

--- a/src/plugins/enzymes/transl/russian.ts
+++ b/src/plugins/enzymes/transl/russian.ts
@@ -269,7 +269,7 @@
     <message>
         <location filename="../src/DigestSequenceDialog.ui" line="78"/>
         <source>Selected enzymes:</source>
-        <translation>Выбранные сайты:</translation>
+        <translation>Выбранные энзимы:</translation>
     </message>
     <message>
         <location filename="../src/DigestSequenceDialog.ui" line="91"/>
@@ -584,7 +584,7 @@
     <message>
         <location filename="../src/enzymes_dialog/EnzymesSelectorWidget.ui" line="140"/>
         <source>Selected enzyme info</source>
-        <translation>Выделенный сайт</translation>
+        <translation>Выделенный энзим</translation>
     </message>
     <message>
         <location filename="../src/enzymes_dialog/EnzymesSelectorWidget.ui" line="206"/>


### PR DESCRIPTION
Сделал все то, что описано в задаче, за исключением последнего пункта, т.к. он уже был кем-то сделан до меня. Теперь диалог выглядит следующим образом:
![image](https://github.com/user-attachments/assets/98962c6d-6d9d-452f-9314-d21284c372ee)

Были удалены кнопки, функционал которых дублируется ("выделить по длине", вместо которой можно использовать более удобную фильтрацию по длине сайта рестрикции и "Rebase info", т.к. переход с информацией на страницу можно осуществить чезрез гиперссылку из окна с информацией об энзиме). Кнопки "Save" и "Load" переместил к списку выделенных энзимов, теперь интуитивно понятно, что они связаны. Благодарая этому блок кнопок справа больше не выглядит таким пугающим.

Выделеные энзимы и информация об энзиме теперь располагаются во всю ширину диалога. Дополнительно - добавил между этими двумя текстовыми окнами сплиттер, чтобы можно было менять их размер относительно друг друга, может быть удобно, если в одном окне много информации, а в другом - мало. Плюс мелкие правки, которые не видны.

Дополнительно: я бы хотел удалить блок "Results count filter", т.к. мне он кажется избыточным и он сильно перегружает и без того немаленький диалог. Я ни в одном аналогичном юджину приложении не видел ничего подобного. К тому же, в информации об энзиме теперь есть счетчик сайтов в последовательности, который может показать пользователю количство тех или иных энзимов, что достаточно схоже по функционалу. Что думаешь на этот счет?