### PR TITLE
UGENE-8177 Selection is increasing on right mouse button

### DIFF
--- a/src/corelibs/U2View/src/ov_sequence/GSequenceLineView.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/GSequenceLineView.cpp
@@ -160,7 +160,7 @@ void GSequenceLineView::mousePressEvent(QMouseEvent* me) {
     }
 
     Qt::CursorShape shape = cursor().shape();
-    if (shape != Qt::ArrowCursor) {
+    if (shape != Qt::ArrowCursor && (me->buttons() & Qt::LeftButton)) {
         moveBorder(me->pos());
         QWidget::mousePressEvent(me);
         return;
@@ -170,6 +170,7 @@ void GSequenceLineView::mousePressEvent(QMouseEvent* me) {
     SAFE_POINT(lastPressPos >= visibleRange.startPos && lastPressPos <= visibleRange.endPos(), "Last mouse press position is out of visible range!", );
 
     if (me->button() == Qt::RightButton) {
+        setCursor(Qt::ArrowCursor);
         QWidget::mousePressEvent(me);
         return;
     }


### PR DESCRIPTION
Две проблемы:
1. Нет проверки на нажимаемую кнопку мыши при клике на край выделения.
2. После появления контекстного меню, остается активным тот курсор, который был представлен в момент нажатия правой кнопкой мыши. Из-за этого, если закрыть контекстное меню, кликнув левой кнопкой куда угодно, выделение расширяется до этой точки.

Пиксельхантинг, написать тест проблематично