### PR TITLE
UGENE-8147 [Crash, wd, debug] Close wd tab with Discard button on some debug stage.

### DIFF
--- a/src/plugins/workflow_designer/src/WorkflowInvestigationWidgetsController.cpp
+++ b/src/plugins/workflow_designer/src/WorkflowInvestigationWidgetsController.cpp
@@ -102,8 +102,7 @@ void WorkflowInvestigationWidgetsController::setCurrentInvestigation(const Workf
         container->removeTab(tabNumberForInvestigation);
     }
     investigatedLink = bus;
-    createNewInvestigation();
-    investigationView->setParent(container);
+    createNewInvestigation(container);
     investigatorName = tr("Messages from '") + bus->source()->owner()->getLabel() + tr("' to '") + bus->destination()->owner()->getLabel() + tr("'");
     container->addTab(investigationView, investigatorName);
     container->setCurrentWidget(investigationView);
@@ -133,8 +132,8 @@ void WorkflowInvestigationWidgetsController::resetInvestigations() {
     columnWidths.clear();
 }
 
-void WorkflowInvestigationWidgetsController::createNewInvestigation() {
-    investigationView = new QTableView(qobject_cast<QWidget*>(parent()));
+void WorkflowInvestigationWidgetsController::createNewInvestigation(QWidget* investigationWidgetParent) {
+    investigationView = new QTableView(investigationWidgetParent);
     investigationView->viewport()->installEventFilter(this);
     investigationView->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(investigationView, SIGNAL(customContextMenuRequested(const QPoint&)), SLOT(sl_contextMenuRequested(const QPoint&)));
@@ -181,8 +180,7 @@ void WorkflowInvestigationWidgetsController::setInvestigationWidgetsVisible(bool
             container->hide();
         }
     } else if (visible && investigatedLink != nullptr) {
-        createNewInvestigation();
-        investigationView->setParent(container);
+        createNewInvestigation(container);
         container->addTab(investigationView, investigatorName);
         if (wasDisplayed) {
             container->show();

--- a/src/plugins/workflow_designer/src/WorkflowInvestigationWidgetsController.cpp
+++ b/src/plugins/workflow_designer/src/WorkflowInvestigationWidgetsController.cpp
@@ -82,10 +82,6 @@ WorkflowInvestigationWidgetsController::WorkflowInvestigationWidgetsController(Q
     connect(showAllColumnsAction, SIGNAL(triggered()), SLOT(sl_showAllColumns()));
 }
 
-WorkflowInvestigationWidgetsController::~WorkflowInvestigationWidgetsController() {
-    deleteBusInvestigations();
-}
-
 bool WorkflowInvestigationWidgetsController::eventFilter(QObject* watched, QEvent* event) {
     if (QEvent::Paint == event->type() && investigationView != nullptr && watched == dynamic_cast<QObject*>(investigationView->viewport())) {
         if (investigationView->model() == nullptr && investigatedLink != nullptr) {
@@ -138,7 +134,7 @@ void WorkflowInvestigationWidgetsController::resetInvestigations() {
 }
 
 void WorkflowInvestigationWidgetsController::createNewInvestigation() {
-    investigationView = new QTableView();
+    investigationView = new QTableView(qobject_cast<QWidget*>(parent()));
     investigationView->viewport()->installEventFilter(this);
     investigationView->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(investigationView, SIGNAL(customContextMenuRequested(const QPoint&)), SLOT(sl_contextMenuRequested(const QPoint&)));

--- a/src/plugins/workflow_designer/src/WorkflowInvestigationWidgetsController.h
+++ b/src/plugins/workflow_designer/src/WorkflowInvestigationWidgetsController.h
@@ -72,7 +72,7 @@ private slots:
     void sl_columnsVisibilityResponse();
 
 private:
-    void createNewInvestigation();
+    void createNewInvestigation(QWidget *investigationWidgetParent);
     void createInvestigationModel();
     void adjustInvestigationColumnWidth(WorkflowInvestigationWidget* investigator);
 

--- a/src/plugins/workflow_designer/src/WorkflowInvestigationWidgetsController.h
+++ b/src/plugins/workflow_designer/src/WorkflowInvestigationWidgetsController.h
@@ -41,7 +41,6 @@ class WorkflowInvestigationWidgetsController : public QObject {
     Q_DISABLE_COPY(WorkflowInvestigationWidgetsController)
 public:
     explicit WorkflowInvestigationWidgetsController(QWidget* parent = nullptr);
-    ~WorkflowInvestigationWidgetsController();
 
     void deleteBusInvestigations();
     void resetInvestigations();


### PR DESCRIPTION
removeEventFilter при деструкции не требуется. Выставлен родитель для виджета чтобы удалился корректно при закрытии всей вьюшки.
Напишу тест если исправление устраивает.