### PR TITLE
UGENE-8181 get rid of Q_ASSERFT in Smith-Waterman dialog

### DIFF
--- a/src/corelibs/U2Algorithm/src/smith_waterman/SWMulAlignResultNamesTagsRegistry.cpp
+++ b/src/corelibs/U2Algorithm/src/smith_waterman/SWMulAlignResultNamesTagsRegistry.cpp
@@ -21,6 +21,8 @@
 
 #include "SWMulAlignResultNamesTagsRegistry.h"
 
+#include <U2Core/U2SafePoints.h>
+
 #include <QMutexLocker>
 
 #include "SWMulAlignExternalPropTag.h"
@@ -111,33 +113,34 @@ bool SWMulAlignResultNamesTagsRegistry::registerTag(SWMulAlignResultNamesTag* ta
     return true;
 }
 
-QList<SWMulAlignResultNamesTag*>* SWMulAlignResultNamesTagsRegistry::getTagsWithCorrectOrder() const {
-    QList<SWMulAlignResultNamesTag*>* result = new QList<SWMulAlignResultNamesTag*>;
-    qint16 tagIndex = 0;
-    QString tagShorthand;
-    foreach (SWMulAlignResultNamesTag* tag, tags.values()) {
-        tagShorthand = tag->getShorthand();
+QMap<int, SWMulAlignResultNamesTag*> SWMulAlignResultNamesTagsRegistry::getTagsWithCorrectOrder() const {
+    QMap<int, SWMulAlignResultNamesTag*> result;
+    auto tagsValues = tags.values();
+    for (SWMulAlignResultNamesTag* tag : qAsConst(tagsValues)) {
+        auto tagShorthand = tag->getShorthand();
+        int tagIndex = 0;
 
-        if (SEQ_NAME_PREFIX_TAG_SHORTHAND == tagShorthand)
+        if (tagShorthand == SEQ_NAME_PREFIX_TAG_SHORTHAND) {
             tagIndex = 0;
-        else if (PTRN_NAME_PREFIX_TAG_SHORTHAND == tagShorthand)
+        } else if (tagShorthand == PTRN_NAME_PREFIX_TAG_SHORTHAND) {
             tagIndex = 1;
-        else if (SUBSEQ_START_POS_TAG_SHORTHAND == tagShorthand)
+        } else if (tagShorthand == SUBSEQ_START_POS_TAG_SHORTHAND) {
             tagIndex = 2;
-        else if (SUBSEQ_END_POS_TAG_SHORTHAND == tagShorthand)
+        } else if (tagShorthand == SUBSEQ_END_POS_TAG_SHORTHAND) {
             tagIndex = 3;
-        else if (SUBSEQ_LENGTH_TAG_SHORTHAND == tagShorthand)
+        } else if (tagShorthand == SUBSEQ_LENGTH_TAG_SHORTHAND) {
             tagIndex = 4;
-        else if (COUNTER_TAG_SHORTHAND == tagShorthand)
+        } else if (tagShorthand == COUNTER_TAG_SHORTHAND) {
             tagIndex = 5;
-        else if (DATE_TAG_SHORTHAND == tagShorthand)
+        } else if (tagShorthand == DATE_TAG_SHORTHAND) {
             tagIndex = 6;
-        else if (TIME_TAG_SHORTHAND == tagShorthand)
+        } else if (tagShorthand == TIME_TAG_SHORTHAND) {
             tagIndex = 7;
-        else
-            assert(0);
+        } else {
+            FAIL(QString("Unexpected tagShorthand").arg(tagShorthand), {});
+        }
 
-        result->insert(tagIndex, tag);
+        result.insert(tagIndex, tag);
     }
 
     return result;

--- a/src/corelibs/U2Algorithm/src/smith_waterman/SWMulAlignResultNamesTagsRegistry.cpp
+++ b/src/corelibs/U2Algorithm/src/smith_waterman/SWMulAlignResultNamesTagsRegistry.cpp
@@ -113,8 +113,8 @@ bool SWMulAlignResultNamesTagsRegistry::registerTag(SWMulAlignResultNamesTag* ta
     return true;
 }
 
-QMap<int, SWMulAlignResultNamesTag*> SWMulAlignResultNamesTagsRegistry::getTagsWithCorrectOrder() const {
-    QMap<int, SWMulAlignResultNamesTag*> result;
+QVector<SWMulAlignResultNamesTag*> SWMulAlignResultNamesTagsRegistry::getTagsWithCorrectOrder() const {
+    QVector<SWMulAlignResultNamesTag*> result(tags.count());
     auto tagsValues = tags.values();
     for (SWMulAlignResultNamesTag* tag : qAsConst(tagsValues)) {
         auto tagShorthand = tag->getShorthand();
@@ -140,7 +140,7 @@ QMap<int, SWMulAlignResultNamesTag*> SWMulAlignResultNamesTagsRegistry::getTagsW
             FAIL(QString("Unexpected tagShorthand").arg(tagShorthand), {});
         }
 
-        result.insert(tagIndex, tag);
+        result[tagIndex] = tag;
     }
 
     return result;

--- a/src/corelibs/U2Algorithm/src/smith_waterman/SWMulAlignResultNamesTagsRegistry.h
+++ b/src/corelibs/U2Algorithm/src/smith_waterman/SWMulAlignResultNamesTagsRegistry.h
@@ -80,7 +80,7 @@ public:
 private:
     bool registerTag(SWMulAlignResultNamesTag* tag);
     QString tagExpansion(const QString& shorthand, const QVariant& argument = QVariant()) const;
-    QList<SWMulAlignResultNamesTag*>* getTagsWithCorrectOrder() const;
+    QMap<int, SWMulAlignResultNamesTag*> getTagsWithCorrectOrder() const;
 
     QMutex mutex;
     QHash<const QString, SWMulAlignResultNamesTag*> tags;
@@ -88,15 +88,13 @@ private:
 
 inline QList<QPushButton*>* SWMulAlignResultNamesTagsRegistry::getTagsButtons() const {
     QList<QPushButton*>* tagsButtons = new QList<QPushButton*>;
-    QList<SWMulAlignResultNamesTag*>* arrangedTags = getTagsWithCorrectOrder();
-
-    foreach (SWMulAlignResultNamesTag* tag, *arrangedTags) {
+    auto arrangedTags = getTagsWithCorrectOrder();
+    for (auto tag : qAsConst(arrangedTags)) {
         auto button = new QPushButton(OPEN_SQUARE_BRACKET + tag->getShorthand() +
                                               CLOSE_SQUARE_BRACKET + SHORTHAND_AND_LABEL_SEPARATOR + tag->getLabel());
         button->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
         tagsButtons->append(button);
     }
-    delete arrangedTags;
 
     return tagsButtons;
 }

--- a/src/corelibs/U2Algorithm/src/smith_waterman/SWMulAlignResultNamesTagsRegistry.h
+++ b/src/corelibs/U2Algorithm/src/smith_waterman/SWMulAlignResultNamesTagsRegistry.h
@@ -80,7 +80,7 @@ public:
 private:
     bool registerTag(SWMulAlignResultNamesTag* tag);
     QString tagExpansion(const QString& shorthand, const QVariant& argument = QVariant()) const;
-    QMap<int, SWMulAlignResultNamesTag*> getTagsWithCorrectOrder() const;
+    QVector<SWMulAlignResultNamesTag*> getTagsWithCorrectOrder() const;
 
     QMutex mutex;
     QHash<const QString, SWMulAlignResultNamesTag*> tags;


### PR DESCRIPTION
[Тут](https://github.com/ugeneunipro/ugene/commit/d1966fb906c6ba46f1050505a05c08948775f8c3#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR21) переменная `QT_DISABLE_DEPRECATED_BEFORE` была изменена на `0x050F00`, из-за чего выражение `QT_DEPRECATED_SINCE(5, 15)`, зависящее от `QT_DISABLE_DEPRECATED_BEFORE`, стало `false`. Это вызвало триггер `Q_ASSERT_X` (срабатывает только в дебаге, поэтому тесты не обнаружили) в подкорке Qt в ряде случаев. В коде типа:
```
    QList<QString> list;
    list.insert(1, "test");
```
он срабатывает из-за того, что `QList`'у, начиная с определенной версии Qt, не нравится, что мы вставляем второй по счету элемент, в то время как первый по счету отсутствует. 

Переписал использования указателя(!) на `QList` на более подходящий в этом случае `QMap`. Теста нет, т.к. на диалог SW тестов уже полно, а данный кейс все равно отлавливается только в дебаге.