### PR TITLE
Improve macOS architecture gathering

### DIFF
--- a/src/ugenem/src/SendReportDialog.h
+++ b/src/ugenem/src/SendReportDialog.h
@@ -42,6 +42,8 @@ public:
     QString getArchSuffix() const;
     void setFailedTest(const QString& failedTestStr);
 
+    static bool isRunningUnderRosetta();
+
 private slots:
     void sl_replyFinished(QNetworkReply*);
 

--- a/src/ugeneui/src/shtirlitz/Shtirlitz.cpp
+++ b/src/ugeneui/src/shtirlitz/Shtirlitz.cpp
@@ -49,6 +49,10 @@
 #include "ColorThemeWindow.h"
 #include "StatisticalReportController.h"
 
+#ifdef Q_OS_DARWIN
+#include <sys/sysctl.h>
+#endif
+
 const static char* SETTINGS_NOT_FIRST_LAUNCH = "shtirlitz/not_first_launch";
 const static char* SETTINGS_PREVIOUS_REPORT_DATE = "shtirlitz/previous_report_date";
 const static char* SETTINGS_COUNTERS = "shtirlitz/counters";
@@ -272,6 +276,18 @@ QString Shtirlitz::formSystemReport() {
     return systemReport;
 }
 
+QString Shtirlitz::getCurrentCpuArchitecture() {
+    QString cpuArchitecture = QSysInfo::currentCpuArchitecture();
+#ifdef Q_OS_DARWIN
+    int ret = 0;
+    size_t size = sizeof(ret);
+    if ((sysctlbyname("sysctl.proc_translated", &ret, &size, NULL, 0) == 0) && (ret == 1)) {
+        cpuArchitecture += " (arm64)";
+    }
+#endif
+    return cpuArchitecture;
+}
+
 void Shtirlitz::getSysInfo(QString& name,
                            QString& version,
                            QString& kernelType,
@@ -301,7 +317,7 @@ void Shtirlitz::getSysInfo(QString& name,
     productVersion = QSysInfo::productVersion();
     productType = QSysInfo::productType();
     prettyProductName = QSysInfo::prettyProductName();
-    cpuArchitecture = QSysInfo::currentCpuArchitecture();
+    cpuArchitecture = getCurrentCpuArchitecture();
 }
 
 void Shtirlitz::getFirstLaunchInfo(bool& allVersions, bool& minorVersions) {

--- a/src/ugeneui/src/shtirlitz/Shtirlitz.h
+++ b/src/ugeneui/src/shtirlitz/Shtirlitz.h
@@ -55,6 +55,8 @@ private:
     static QString formCountersReport();
     static QString formSystemReport();
 
+    static QString getCurrentCpuArchitecture();
+
     static void getSysInfo(QString& name,
                            QString& version,
                            QString& kernelType,


### PR DESCRIPTION
На Mac M1 при работе через Розетту архитектура в любом случае определяется как x86_64, из-за чего мы не можем оценить, сколько пользователей на маках у нас работают на Apple SIlicon, а сколько - на Intel. Подредактировал сбор статистики, теперь те, кто работают на M1+Rosetta Будут помечаться как `x86_64 (arm64)`. Что работает протестировал

Upd: добавил аналогичный сбор для креш репортов