### PR TITLE
UGENE-8070 Error on converting annotation in FPKM and Differential formats

### DIFF
--- a/src/corelibs/U2Formats/src/FpkmTrackingFormat.cpp
+++ b/src/corelibs/U2Formats/src/FpkmTrackingFormat.cpp
@@ -515,7 +515,6 @@ void FpkmTrackingFormat::storeDocument(Document* doc, IOAdapter* io, U2OpStatus&
     SAFE_POINT(doc != nullptr, "Internal error: NULL Document during saving a FPKM Tracking Format file!", );
     SAFE_POINT(io != nullptr, "Internal error: NULL IOAdapter during saving a FPKM Tracking Format file!", );
 
-    bool noErrorsDuringStoring = true;
     QList<GObject*> annotTables = doc->findGObjectByType(GObjectTypes::ANNOTATION_TABLE);
     if (annotTables.isEmpty()) {
         return;
@@ -558,9 +557,7 @@ void FpkmTrackingFormat::storeDocument(Document* doc, IOAdapter* io, U2OpStatus&
 
                     // Also, validate some fields
                     if ((columnName == TRACKING_ID_COLUMN) && (columnValue.isEmpty())) {
-                        ioLog.trace(tr("FPKM Tracking Format saving error: tracking ID"
-                                       " shouldn't be empty!"));
-                        noErrorsDuringStoring = false;
+                        ioLog.details(tr("FPKM Tracking Format saving: 'tracking ID' shouldn't be empty!"));
                     }
 
                     if (columnName == LOCUS_COLUMN) {
@@ -582,22 +579,20 @@ void FpkmTrackingFormat::storeDocument(Document* doc, IOAdapter* io, U2OpStatus&
                             QString seqNameFromLocusQual;  // Currently, do not verify a sequence name in locus!
                             U2Region regionFromLocusQual;
                             if (!parseLocus(columnValue, seqNameFromLocusQual, regionFromLocusQual)) {
-                                ioLog.trace(tr("FPKM Tracking Format saving error: failed"
+                                ioLog.details(tr("FPKM Tracking Format saving: failed"
                                                " to parse locus qualifier '%1', writing it"
                                                " to the output file anyway!")
                                                 .arg(columnValue));
-                                noErrorsDuringStoring = false;
                             }
 
                             if (regionFromLocusQual != region) {
-                                ioLog.trace(tr("FPKM Tracking Format saving error: an annotation"
+                                ioLog.details(tr("FPKM Tracking Format saving: an annotation"
                                                " region (%1, %2) differs from the information stored in the 'locus'"
                                                " qualifier (%3, %4). Writing the 'locus' qualifier to output!")
                                                 .arg(QString::number(region.startPos)
                                                          .arg(QString::number(region.endPos())
                                                                   .arg(QString::number(regionFromLocusQual.startPos))
                                                                   .arg(QString::number(regionFromLocusQual.endPos())))));
-                                noErrorsDuringStoring = false;
                             }
                         }
                     }
@@ -620,11 +615,6 @@ void FpkmTrackingFormat::storeDocument(Document* doc, IOAdapter* io, U2OpStatus&
                 }
             }
         }
-    }
-
-    if (!noErrorsDuringStoring) {
-        ioLog.error(tr("FPKM Tracking Format saving error: one or more errors occurred while saving a file,"
-                       " see TRACE log for details!"));
     }
 }
 

--- a/tests/regression/8070/test_0001.xml
+++ b/tests/regression/8070/test_0001.xml
@@ -1,0 +1,7 @@
+<multi-test>
+    <run-cmdline task="!common_data_dir!regression/8070/test_scheme_fpkm.uwl"
+                 in="!workflow_samples!../samples/Genbank/murine.gb"
+                 out="!tmp_data_dir!8070.fpkm"
+                 message="FPKM Tracking Format saving: 'tracking ID' shouldn't be empty!"
+    />
+</multi-test>

--- a/tests/regression/8070/test_0002.xml
+++ b/tests/regression/8070/test_0002.xml
@@ -1,0 +1,7 @@
+<multi-test>
+    <run-cmdline task="!common_data_dir!regression/8070/test_scheme_case_dif.uwl"
+                 in="!workflow_samples!../samples/Genbank/murine.gb"
+                 out="!tmp_data_dir!8070.fpkm"
+                 message="Required column is missed: test_id"
+    />
+</multi-test>


### PR DESCRIPTION
В сценарии в обоих случаях аннотации сохраняются в специфические форматы которые требуют наличия определенных квалификаторов в сохраняемых аннотациях - то есть просто любую аннотацию не сохранишь в этом формате.
В первом описаном случае (Diff format) наличие этих квалификаторов необходимо - без них такого типа файлы мы не загружаем.
Во втором в отсутствующих полях пишутся пропуски и результирующий файл потом может быть открыт UGENE.

По этому решил в первом случае ничего не менять, во втором немного модифицировал перевел сообщения и перевел их в статус details, error убрал.

Подойдет такое решение?
Стоит еще модифицировать Diff format чтобы он сохранялся и загружался без обязательных колонок или просто при сохранении заполнять их какими то дефолтными значениями?