### PR TITLE
Fix color theme switching on Workspace tab + fix Project View edited document color

### DIFF
--- a/src/corelibs/U2Gui/src/util/project/ProjectViewModel.cpp
+++ b/src/corelibs/U2Gui/src/util/project/ProjectViewModel.cpp
@@ -36,6 +36,7 @@
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Gui/GUIUtils.h>
+#include <U2Gui/MainWindow.h>
 #include <U2Gui/ObjectViewModel.h>
 
 #include "ConnectionHelper.h"
@@ -44,7 +45,8 @@
 
 namespace U2 {
 
-const QString ProjectViewModel::MODIFIED_ITEM_COLOR = "#0032a0";
+const QString ProjectViewModel::MODIFIED_ITEM_COLOR_LIGHT = "#0032a0";
+const QString ProjectViewModel::MODIFIED_ITEM_COLOR_DARK = "#00aaff";
 
 ProjectViewModel::ProjectViewModel(const ProjectTreeControllerModeSettings& settings, QObject* parent)
     : QAbstractItemModel(parent), settings(settings) {
@@ -879,7 +881,7 @@ QVariant ProjectViewModel::data(Document* doc, int role) const {
 
 QVariant ProjectViewModel::getDocumentTextColorData(Document* doc) const {
     if (doc->isModified()) {
-        return QColor(MODIFIED_ITEM_COLOR);
+        return QColor(AppContext::getMainWindow()->isDarkTheme() ? MODIFIED_ITEM_COLOR_DARK : MODIFIED_ITEM_COLOR_LIGHT);
     } else {
         return QVariant();
     }
@@ -1046,7 +1048,7 @@ QVariant ProjectViewModel::getObjectDecorationData(GObject* obj, bool itemIsEnab
 
 QVariant ProjectViewModel::getObjectTextColorData(GObject* obj) const {
     if (obj->isItemModified()) {
-        return QColor(MODIFIED_ITEM_COLOR);
+        return QColor(AppContext::getMainWindow()->isDarkTheme() ? MODIFIED_ITEM_COLOR_DARK : MODIFIED_ITEM_COLOR_LIGHT);
     } else {
         return {};
     }

--- a/src/corelibs/U2Gui/src/util/project/ProjectViewModel.h
+++ b/src/corelibs/U2Gui/src/util/project/ProjectViewModel.h
@@ -183,7 +183,8 @@ private:
     mutable QHash<Document*, DocumentFolders*> folders;
     ProjectTreeControllerModeSettings settings;
 
-    static const QString MODIFIED_ITEM_COLOR;
+    static const QString MODIFIED_ITEM_COLOR_LIGHT;
+    static const QString MODIFIED_ITEM_COLOR_DARK;
 };
 
 }  // namespace U2

--- a/src/ugeneui/src/workspace/CloudStorageDockWidget.cpp
+++ b/src/ugeneui/src/workspace/CloudStorageDockWidget.cpp
@@ -250,7 +250,7 @@ CloudStorageDockWidget::CloudStorageDockWidget(WorkspaceService* _workspaceServi
     stateLabel = new QLabel();
     stateLabel->setTextFormat(Qt::RichText);
     stateLabel->setOpenExternalLinks(false);
-    stateLabel->setStyleSheet(QString("background: %1; padding: 10px;").arg(QPalette().base().color().name()));
+    updateStateLabelBackground();
 
     treeView = new QTreeView();
     treeView->setModel(&treeViewModel);
@@ -381,6 +381,8 @@ bool CloudStorageDockWidget::eventFilter(QObject* watched, QEvent* event) {
 
 void CloudStorageDockWidget::sl_colorThemeSwitched() {
     updateTreeViewIconsRecursively(treeViewModel.invisibleRootItem());
+    updateStateLabelBackground();
+    updateStateLabelTextOnly();
 }
 
 void CloudStorageDockWidget::updateTreeViewIconsRecursively(QStandardItem* item) {
@@ -608,10 +610,8 @@ void CloudStorageDockWidget::updateActionsState() const {
 
 void CloudStorageDockWidget::updateStateLabelText() {
     disconnect(stateLabel, &QLabel::linkActivated, this, nullptr);
-    const auto isLoggedIn = workspaceService->isLoggedIn();
-    stateLabel->setText(isLoggedIn
-                            ? tr(R"(Loading file list...<br><br><br><a href="logout"><span style=\"color: %1;\">Logout</span></a>)").arg(Theme::hyperlinkColorLabelHtmlStr())
-                            : tr(R"(Please <a href="login"><span style=\"color: %1;\">log in to Workspace</span></a> to access cloud storage)").arg(Theme::hyperlinkColorLabelHtmlStr()));
+
+    updateStateLabelTextOnly();
 
     connect(stateLabel, &QLabel::linkActivated, this, [&](const QString& link) {
         if (link == "login") {
@@ -620,6 +620,17 @@ void CloudStorageDockWidget::updateStateLabelText() {
             workspaceService->logout();
         }
     });
+}
+
+void CloudStorageDockWidget::updateStateLabelTextOnly() {
+    const auto isLoggedIn = workspaceService->isLoggedIn();
+    stateLabel->setText(isLoggedIn
+                            ? tr(R"(Loading file list...<br><br><br><a href="logout"><span style=\"color: %1;\">Logout</span></a>)").arg(Theme::hyperlinkColorLabelHtmlStr())
+                            : tr(R"(Please <a href="login"><span style=\"color: %1;\">log in to Workspace</span></a> to access cloud storage)").arg(Theme::hyperlinkColorLabelHtmlStr()));
+}
+
+void CloudStorageDockWidget::updateStateLabelBackground() {
+    stateLabel->setStyleSheet(QString("background: %1; padding: 10px;").arg(QPalette().base().color().name()));
 }
 
 CloudStorageService* CloudStorageDockWidget::getCloudStorageService() const {

--- a/src/ugeneui/src/workspace/CloudStorageDockWidget.h
+++ b/src/ugeneui/src/workspace/CloudStorageDockWidget.h
@@ -62,6 +62,8 @@ private:
 
     void updateActionsState() const;
     void updateStateLabelText();
+    void updateStateLabelTextOnly();
+    void updateStateLabelBackground();
     CloudStorageService* getCloudStorageService() const;
 
     WorkspaceService* workspaceService = nullptr;


### PR DESCRIPTION
Исправлены проблемы смены темы:

- Вкладка Wokspace до авторизации и текст на ней не меняли цвет
- Цвет текста объекта в Project View когда объект отредактирован был темно синим и плохо различимым в темном режиме