### PR TITLE
UGENE-8183 Q_ASSERT when search in MSA

### DIFF
--- a/src/corelibs/U2View/src/ov_msa/find_pattern/FindPatternMsaTask.cpp
+++ b/src/corelibs/U2View/src/ov_msa/find_pattern/FindPatternMsaTask.cpp
@@ -98,7 +98,7 @@ void FindPatternMsaTask::getResultFromTask() {
     }
     std::sort(regions.begin(), regions.end());
     qint64 rowId = msaRow->getRowId();
-    results.insert(rowId, FindPatternInMsaResult(rowId, regions));
+    results.append(FindPatternInMsaResult(rowId, regions));
     currentSequenceIndex++;
 }
 


### PR DESCRIPTION
Проблема та же, что и [тут](https://github.com/ugeneunipro/ugene/pull/1780#issue-3393395671), поскольку `rowId` у MSA считается с 1. По факту, вставлять элемент под индексом `rowId` вообще не нужно, т.к. он хранится в `FindPatternInMsaResult` и, при необходимости, используется значение оттуда.

Теста нет, т.к. проблема не ловится на релизе