### PR TITLE
Crash on export alignment to fasta file without name #1799

### DIFF
--- a/src/corelibs/U2Gui/src/util/ExportDocumentDialogController.cpp
+++ b/src/corelibs/U2Gui/src/util/ExportDocumentDialogController.cpp
@@ -138,7 +138,7 @@ GObject* ExportDocumentDialogController::getSourceObject() const {
 void ExportDocumentDialogController::accept() {
     QFileInfo urlInfo(getDocumentURL());
     if (urlInfo.baseName().isEmpty() || urlInfo.isDir()) {
-        QMessageBox::critical(this, L10N::errorTitle(), tr("Please select a file with a non-empty name."));
+        QMessageBox::critical(this, L10N::errorTitle(), tr("File name is required."));
         return;
     }
     return QDialog::accept();

--- a/src/corelibs/U2Gui/src/util/ExportDocumentDialogController.cpp
+++ b/src/corelibs/U2Gui/src/util/ExportDocumentDialogController.cpp
@@ -21,11 +21,14 @@
 
 #include "ExportDocumentDialogController.h"
 
+#include <QFileInfo>
+#include <QMessageBox>
 #include <QPushButton>
 
 #include <U2Core/AppContext.h>
 #include <U2Core/GObject.h>
 #include <U2Core/GUrlUtils.h>
+#include <U2Core/L10n.h>
 
 #include <U2Gui/HelpButton.h>
 
@@ -130,6 +133,15 @@ Document* ExportDocumentDialogController::getSourceDoc() const {
 
 GObject* ExportDocumentDialogController::getSourceObject() const {
     return sourceObject;
+}
+
+void ExportDocumentDialogController::accept() {
+    QFileInfo urlInfo(getDocumentURL());
+    if (urlInfo.baseName().isEmpty() || urlInfo.isDir()) {
+        QMessageBox::critical(this, L10N::errorTitle(), tr("Please select a file with a non-empty name."));
+        return;
+    }
+    return QDialog::accept();
 }
 
 }  // namespace U2

--- a/src/corelibs/U2Gui/src/util/ExportDocumentDialogController.h
+++ b/src/corelibs/U2Gui/src/util/ExportDocumentDialogController.h
@@ -49,6 +49,9 @@ public:
     Document* getSourceDoc() const;
     GObject* getSourceObject() const;
 
+public slots:
+    virtual void accept();
+
 private:
     void initSaveController(const QList<GObject*>& objects, const QString& fileUrl);
     static DocumentFormatConstraints getAcceptableConstraints(const QList<GObject*>& objects);

--- a/src/corelibs/U2View/src/ov_msa/move_to_object/MoveToObjectMaController.cpp
+++ b/src/corelibs/U2View/src/ov_msa/move_to_object/MoveToObjectMaController.cpp
@@ -153,10 +153,8 @@ void MoveToObjectMaController::runMoveSelectedRowsToNewFileDialog() {
     QList<qint64> rowIdsToRemove = msaObject->getRowIdsByRowIndexes(selectedMaRowIndexes);
     SAFE_POINT(!rowIdsToRemove.isEmpty(), "rowIdsToRemove is empty", );
 
-    QFileInfo urlInfo(url);
-    CHECK_EXT(!urlInfo.baseName().isEmpty() && !urlInfo.isDir(), QMessageBox::critical(ui, L10N::errorTitle(), tr("Please select a file with a non-empty name.")), );
     Msa msaToExport;
-    msaToExport->setName(urlInfo.baseName());
+    msaToExport->setName(QFileInfo(url).baseName());
     msaToExport->setAlphabet(msaObject->getAlphabet());
     for (int maRowIndex : qAsConst(selectedMaRowIndexes)) {
         const MsaRow& row = msaObject->getRow(maRowIndex);

--- a/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/ExportDocumentDialogFiller.cpp
+++ b/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/ExportDocumentDialogFiller.cpp
@@ -20,6 +20,8 @@
  */
 
 #include <base_dialogs/GTFileDialog.h>
+#include <base_dialogs/MessageBoxFiller.h>
+
 #include <primitives/GTCheckBox.h>
 #include <primitives/GTComboBox.h>
 #include <primitives/GTLineEdit.h>
@@ -35,9 +37,11 @@
 namespace U2 {
 
 #define GT_CLASS_NAME "ExportDocumentDialogFiller"
-ExportDocumentDialogFiller::ExportDocumentDialogFiller(const QString& _path, const QString& _name, ExportDocumentDialogFiller::FormatToUse _format, bool compressFile, bool addToProject, GTGlobals::UseMethod method)
+ExportDocumentDialogFiller::ExportDocumentDialogFiller(const QString& _path, const QString& _name, ExportDocumentDialogFiller::FormatToUse _format, 
+                                                       bool compressFile, bool addToProject, GTGlobals::UseMethod method, bool _handleErrorMessageBox)
     : Filler("ExportDocumentDialog"),
-      path(_path), name(_name), useMethod(method), format(_format), compressFile(compressFile), addToProject(addToProject) {
+      path(_path), name(_name), useMethod(method), format(_format), compressFile(compressFile),
+      addToProject(addToProject), handleErrorMessageBox(_handleErrorMessageBox) {
     if (!path.isEmpty()) {
         path = GTFileDialog::toAbsoluteNativePath(_path, true);
     }
@@ -75,8 +79,14 @@ void ExportDocumentDialogFiller::commonScenario() {
         auto addCheckBox = GTWidget::findCheckBox("addToProjCheck", dialog);
         GTCheckBox::setChecked(addCheckBox, addToProject);
     }
-
+    if (handleErrorMessageBox) {
+        GTUtilsDialog::waitForDialog(new MessageBoxDialogFiller(QMessageBox::Ok, "Please select a file with a non-empty name."));
+    }
     GTUtilsDialog::clickButtonBox(dialog, QDialogButtonBox::Ok);
+    if (handleErrorMessageBox) {
+        GTGlobals::sleep();
+        GTUtilsDialog::clickButtonBox(dialog, QDialogButtonBox::Cancel);
+    }
 }
 #undef GT_CLASS_NAME
 

--- a/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/ExportDocumentDialogFiller.cpp
+++ b/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/ExportDocumentDialogFiller.cpp
@@ -38,10 +38,10 @@ namespace U2 {
 
 #define GT_CLASS_NAME "ExportDocumentDialogFiller"
 ExportDocumentDialogFiller::ExportDocumentDialogFiller(const QString& _path, const QString& _name, ExportDocumentDialogFiller::FormatToUse _format, 
-                                                       bool compressFile, bool addToProject, GTGlobals::UseMethod method, bool _handleErrorMessageBox)
+                                                       bool compressFile, bool addToProject, GTGlobals::UseMethod method, QString _expectedError)
     : Filler("ExportDocumentDialog"),
       path(_path), name(_name), useMethod(method), format(_format), compressFile(compressFile),
-      addToProject(addToProject), handleErrorMessageBox(_handleErrorMessageBox) {
+      addToProject(addToProject), expectedError(_expectedError) {
     if (!path.isEmpty()) {
         path = GTFileDialog::toAbsoluteNativePath(_path, true);
     }
@@ -79,11 +79,11 @@ void ExportDocumentDialogFiller::commonScenario() {
         auto addCheckBox = GTWidget::findCheckBox("addToProjCheck", dialog);
         GTCheckBox::setChecked(addCheckBox, addToProject);
     }
-    if (handleErrorMessageBox) {
-        GTUtilsDialog::waitForDialog(new MessageBoxDialogFiller(QMessageBox::Ok, "Please select a file with a non-empty name."));
+    if (!expectedError.isEmpty()) {
+        GTUtilsDialog::waitForDialog(new MessageBoxDialogFiller(QMessageBox::Ok, expectedError));
     }
     GTUtilsDialog::clickButtonBox(dialog, QDialogButtonBox::Ok);
-    if (handleErrorMessageBox) {
+    if (!expectedError.isEmpty()) {
         GTGlobals::sleep();
         GTUtilsDialog::clickButtonBox(dialog, QDialogButtonBox::Cancel);
     }

--- a/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/ExportDocumentDialogFiller.h
+++ b/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/ExportDocumentDialogFiller.h
@@ -45,7 +45,8 @@ public:
     };
 
     ExportDocumentDialogFiller(const QString& _path = "", const QString& _name = "", ExportDocumentDialogFiller::FormatToUse _format = ExportDocumentDialogFiller::Genbank, 
-                               bool compressFile = false, bool addToProject = false, GTGlobals::UseMethod method = GTGlobals::UseMouse);
+                               bool compressFile = false, bool addToProject = false, GTGlobals::UseMethod method = GTGlobals::UseMouse, 
+                               bool handleErrorMessageBox = false);
     void commonScenario() override;
 
 private:
@@ -54,6 +55,7 @@ private:
     FormatToUse format;
     bool compressFile;
     bool addToProject;
+    bool handleErrorMessageBox;
     QMap<FormatToUse, QString> comboBoxItems;
 };
 }  // namespace U2

--- a/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/ExportDocumentDialogFiller.h
+++ b/src/plugins/GUITestBase/src/runnables/ugene/corelibs/U2Gui/ExportDocumentDialogFiller.h
@@ -46,7 +46,7 @@ public:
 
     ExportDocumentDialogFiller(const QString& _path = "", const QString& _name = "", ExportDocumentDialogFiller::FormatToUse _format = ExportDocumentDialogFiller::Genbank, 
                                bool compressFile = false, bool addToProject = false, GTGlobals::UseMethod method = GTGlobals::UseMouse, 
-                               bool handleErrorMessageBox = false);
+                               QString expectedError = QString());
     void commonScenario() override;
 
 private:
@@ -55,7 +55,7 @@ private:
     FormatToUse format;
     bool compressFile;
     bool addToProject;
-    bool handleErrorMessageBox;
+    QString expectedError;
     QMap<FormatToUse, QString> comboBoxItems;
 };
 }  // namespace U2

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_8001_9000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_8001_9000.cpp
@@ -1548,8 +1548,7 @@ GUI_TEST_CLASS_DEFINITION(test_8163) {
     GTUtilsMsaEditor::checkMsaEditorWindowIsActive();
 
     GTUtilsMsaEditor::selectRowsByName({"Zychia_baranovi"});
-    GTUtilsDialog::waitForDialog(new MessageBoxDialogFiller(QMessageBox::Ok, "Please select a file with a non-empty name."));
-    GTUtilsDialog::waitForDialog(new ExportDocumentDialogFiller(sandBoxDir, "", ExportDocumentDialogFiller::FASTA, false, true));
+    GTUtilsDialog::waitForDialog(new ExportDocumentDialogFiller(sandBoxDir, "", ExportDocumentDialogFiller::FASTA, false, true, GTGlobals::UseMouse, true));
     GTMenu::clickMainMenuItem({"Actions", "Export", "Move selected rows to another alignment", "Create a new alignment"});
     GTUtilsTaskTreeView::waitTaskFinished();
 }

--- a/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_8001_9000.cpp
+++ b/src/plugins/GUITestBase/src/tests/regression_scenarios/GTTestsRegressionScenarios_8001_9000.cpp
@@ -1548,7 +1548,7 @@ GUI_TEST_CLASS_DEFINITION(test_8163) {
     GTUtilsMsaEditor::checkMsaEditorWindowIsActive();
 
     GTUtilsMsaEditor::selectRowsByName({"Zychia_baranovi"});
-    GTUtilsDialog::waitForDialog(new ExportDocumentDialogFiller(sandBoxDir, "", ExportDocumentDialogFiller::FASTA, false, true, GTGlobals::UseMouse, true));
+    GTUtilsDialog::waitForDialog(new ExportDocumentDialogFiller(sandBoxDir, "", ExportDocumentDialogFiller::FASTA, false, true, GTGlobals::UseMouse, "File name is required."));
     GTMenu::clickMainMenuItem({"Actions", "Export", "Move selected rows to another alignment", "Create a new alignment"});
     GTUtilsTaskTreeView::waitTaskFinished();
 }
@@ -1556,7 +1556,7 @@ GUI_TEST_CLASS_DEFINITION(test_8163) {
 GUI_TEST_CLASS_DEFINITION(test_8164) {
     GTFileDialog::openFile(dataDir + "samples/CLUSTALW/COI.aln");
     GTUtilsMsaEditor::checkMsaEditorWindowIsActive();
-    GTUtilsDialog::waitForDialog(new ExportDocumentDialogFiller(sandBoxDir, "COI_test_8164.pdb", ExportDocumentDialogFiller::CLUSTALW, false, true));
+    GTUtilsDialog::waitForDialog(new ExportDocumentDialogFiller(sandBoxDir, "COI_test_8164.pdb", ExportDocumentDialogFiller::CLUSTALW, false, "File name is required."));
     GTUtilsMsaEditor::selectRowsByName({"Zychia_baranovi"});
     GTMenu::clickMainMenuItem({"Actions", "Export", "Move selected rows to another alignment", "Create a new alignment"});
     GTUtilsTaskTreeView::waitTaskFinished();


### PR DESCRIPTION
Сделал по предложенному варианту b - перенес проверку имени файла непосредственно в метод accept()  диалога экспорта.