### PR TITLE
1801 UGENE hangs when loading an alignment with a large number of sequences

### DIFF
--- a/src/corelibs/U2Gui/src/ObjectViewTasks.cpp
+++ b/src/corelibs/U2Gui/src/ObjectViewTasks.cpp
@@ -46,7 +46,7 @@ namespace U2 {
 /* TRANSLATOR U2::ObjectViewTask */
 
 ObjectViewTask::ObjectViewTask(GObjectViewController* _view, const QString& stateName, const QVariantMap& s)
-    : Task("", TaskFlag_NoRun), taskType(Type_Update), stateData(s), view(_view), stateIsIllegal(false) {
+    : Task("", TaskFlag_None), taskType(Type_Update), stateData(s), view(_view), stateIsIllegal(false) {
     assert(view != nullptr);
     const QString& vName = view->getName();
     setTaskName(tr("Update '%1' to '%2' state").arg(vName).arg(stateName));
@@ -54,7 +54,7 @@ ObjectViewTask::ObjectViewTask(GObjectViewController* _view, const QString& stat
 }
 
 ObjectViewTask::ObjectViewTask(GObjectViewFactoryId fid, const QString& vName, const QVariantMap& s)
-    : Task("", TaskFlag_NoRun), taskType(Type_Open), stateData(s), view(nullptr), viewName(vName), stateIsIllegal(false) {
+    : Task("", TaskFlag_None), taskType(Type_Open), stateData(s), view(nullptr), viewName(vName), stateIsIllegal(false) {
     if (vName.isEmpty()) {
         QString factoryName = AppContext::getObjectViewFactoryRegistry()->getFactoryById(fid)->getName();
         setTaskName(tr("Open new '%1'").arg(factoryName));
@@ -73,6 +73,10 @@ void ObjectViewTask::prepare() {
             processed.insert(pd);
         }
     }
+}
+
+void ObjectViewTask::run() {
+    loadCache();
 }
 
 Task::ReportResult ObjectViewTask::report() {

--- a/src/corelibs/U2Gui/src/ObjectViewTasks.h
+++ b/src/corelibs/U2Gui/src/ObjectViewTasks.h
@@ -48,8 +48,13 @@ public:
     ObjectViewTask(GObjectViewFactoryId fid, const QString& viewName = QString(), const QVariantMap& s = QVariantMap());
 
     void prepare() override;
+    void run() override;
     ReportResult report() override;
 
+    // Override these methods in subclasses if needed
+    // loadCache() is called from the separate thread in run() u
+    // use it to load cache from DB, which loads long enough
+    virtual void loadCache() {};
     virtual void open() {};
     virtual void update() {};
 

--- a/src/corelibs/U2View/src/ov_msa/MaEditorTasks.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorTasks.cpp
@@ -81,6 +81,12 @@ OpenMaEditorTask::OpenMaEditorTask(Document* doc, GObjectViewFactoryId fid, GObj
     documentsToLoad.append(doc);
 }
 
+void OpenMaEditorTask::loadCache() {
+    SAFE_POINT_NN(maObject, );
+
+    maObject->getAlignment(); // to load and cache the alignment
+}
+
 void OpenMaEditorTask::open() {
     if (stateInfo.hasError() || (maObject.isNull() && documentsToLoad.isEmpty())) {
         return;

--- a/src/corelibs/U2View/src/ov_msa/MaEditorTasks.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorTasks.cpp
@@ -82,12 +82,6 @@ OpenMaEditorTask::OpenMaEditorTask(Document* doc, GObjectViewFactoryId fid, GObj
 }
 
 void OpenMaEditorTask::loadCache() {
-    SAFE_POINT_NN(maObject, );
-
-    maObject->getAlignment(); // to load and cache the alignment
-}
-
-void OpenMaEditorTask::open() {
     if (stateInfo.hasError() || (maObject.isNull() && documentsToLoad.isEmpty())) {
         return;
     }
@@ -111,6 +105,11 @@ void OpenMaEditorTask::open() {
             return;
         }
     }
+
+    maObject->getAlignment(); // to load and cache the alignment
+}
+
+void OpenMaEditorTask::open() {
     viewName = GObjectViewUtils::genUniqueViewName(maObject->getDocument(), maObject);
     uiLog.details(tr("Opening MSA editor for object: %1").arg(maObject->getGObjectName()));
 

--- a/src/corelibs/U2View/src/ov_msa/MaEditorTasks.h
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorTasks.h
@@ -44,6 +44,8 @@ public:
     OpenMaEditorTask(UnloadedObject* obj, GObjectViewFactoryId fid, GObjectType type);
     OpenMaEditorTask(Document* doc, GObjectViewFactoryId fid, GObjectType type);
 
+    void loadCache() override;
+
     void open() override;
 
     static void updateTitle(MsaEditor* msaEd);


### PR DESCRIPTION
[Тут](https://github.com/ugeneunipro/ugene/blob/4284bf72b5e52b3a23d05b59791274f6d704180b/src/corelibs/U2View/src/ov_msa/MaEditorFactory.cpp#L161) имеется проверка на максимально возможную длину выравнивания. Чтобы получить текущую длину, UGENE лезет в базу и вычисляет эту информацию, сравнив длины всех существующих последовательностей, предвариательно прикрутив к ним гэп-модели - в целом, он кеширует вообще все, что только может вытянуть из базы. На маленьких выравниваниях это работает быстро, но на больших достаточно долго. Это происходит в главном потоке, следовательно, UGENE виснет.

Это проблема есть не только у множественного выравнивания, но и у других вьюшек - например, у последовательности с большим количеством аннотаций - поэтому, я предлагаю добавить общий код, который будет выполняться в `run()` делать сложные вычисления, которые нужно сделать после загрузки файла и до открывания вьюшки.