### PR TITLE
UGENE-7159 _INSTALL_TO_PATH_ACTION is not working on Big Sur (macOS)

### DIFF
--- a/src/ugeneui/src/main_window/MainWindowImpl.cpp
+++ b/src/ugeneui/src/main_window/MainWindowImpl.cpp
@@ -477,7 +477,7 @@ void MainWindowImpl::sl_installToPathAction() {
 
     bool success = true;
     QString exePath = AppContext::getWorkingDirectoryPath() + "/";
-    QString installationPath = "/usr/bin/";
+    QString installationPath = "/usr/local/bin/";
     QStringList tools;
     tools << "ugene"
           << "ugeneui"
@@ -496,7 +496,7 @@ void MainWindowImpl::sl_installToPathAction() {
                 // HACK: sleep because otherwise QFileInfo::exists might return false
                 sleep(100);
                 wait(nullptr);
-                if (!QFileInfo(symlink).exists()) {
+                if (!QFileInfo::exists(symlink)) {
                     QMessageBox::critical(nullptr, tr("Installation failed"), tr("Failed to enable terminal usage: couldn't install '%1'").arg(symlink));
                     success = false;
                     break;

--- a/src/ugeneui/src/main_window/MainWindowImpl.h
+++ b/src/ugeneui/src/main_window/MainWindowImpl.h
@@ -39,9 +39,6 @@ class QToolBar;
 
 #if defined(Q_OS_DARWIN) && !defined(_DEBUG)
 #    define _INSTALL_TO_PATH_ACTION
-// TODO: Temporary disable menu item which creates link to app on desktop
-//       Need to fix for Catalina/Big Sur
-#    undef _INSTALL_TO_PATH_ACTION
 #endif
 
 namespace U2 {


### PR DESCRIPTION
Речь идет о кнопке, которая на macOS позволяет добавить симлинки на исполняемые файлы UGENE в директорию, которая содержится в PATH. Таким образом, UGENE можно запустить из терминала командами `ugene`/`ugenecl`/`ugeneui`. 

Этот функционал отвалился начиная с macOS Catalina 10.15 из-за того, что симлинки клались в директорию `/usr/bin/`, которая, начиная с этой версии ОС, стала read-only даже под sudo (пруф [тут](https://support.apple.com/guide/security/signed-system-volume-security-secd698747c9/web)). Поэтому, теперь предлагается устанавливать подобные вещи в `/usr/local/`, а в нашем случае - в `/usr/local/bin/` (см [тут](https://support.apple.com/en-us/102149)). Исправил, плюс изменил  устаревшую `QFileInfo(symlink).exists())` на более современную `QFileInfo::exists(symlink)`