### PR TITLE
UGENE-8171 get frame back

### DIFF
--- a/src/corelibs/U2View/src/ov_sequence/PanView.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/PanView.cpp
@@ -654,13 +654,8 @@ void PanViewRenderArea::drawAll(QPaintDevice* pd) {
 
     p.drawPixmap(0, 0, *cachedView);
 
-    // SANGER_TODO: should not be this kind of connection
-    //    ADVSingleSequenceWidget* ssw = panView->seqWidget;
-    //    SAFE_POINT(ssw != NULL, "ADVSingleSequenceWidget is NULL", );
-    //    if (!ssw->isOverviewCollapsed()) {
-    //        //! VIEW_RENDERER_REFACTORING: consider to move frame drawing to renderer
-    //        drawFrame(p);
-    //    }
+    //! VIEW_RENDERER_REFACTORING: consider to move frame drawing to renderer
+    drawFrame(p);
 
     renderer->drawSelection(p, QSize(pd->width(), pd->height()), view->getVisibleRange());
 


### PR DESCRIPTION
Предлагаю вернуть рамку, отбражающую область выделения Details View на Zoom View, т.к. она была удалена без объективных причин (см описание в задаче). 
Перенос в renderer я предлагаю пока (или вообще) не делать, т.к. необходимость сомнительная и это не так просто - GraphView дергает эту функцию, а у него вообще нет рендерера. Придется либо писать ему рендерер, наследуясь от существующих базовых рендереров (может быть долго и не нужно), либо создавать какую-то фейковую заглушку (просто не нужно).
Проверку на невидимость овервью убрал, т.к. не увидел причин её существования.
Гуи теста нет, нужно глазами смотреть.