### PR TITLE
Add UGENE dark theme counter

### DIFF
--- a/src/ugeneui/src/shtirlitz/Shtirlitz.cpp
+++ b/src/ugeneui/src/shtirlitz/Shtirlitz.cpp
@@ -142,6 +142,10 @@ QList<Task*> Shtirlitz::wakeup() {
             }
         }
     }
+    
+    if (AppContext::getMainWindow()->isDarkTheme()) {
+        GCOUNTER(ctr, "ugeneui starts in dark theme");
+    }
 
     // Check if this version of UGENE is launched for the first time
     // and user did not enabled stats before -> ask to enable


### PR DESCRIPTION
Добавил счетчик запусков UGENE в темной теме. Счетчик добавлен в Штирлица, т.к. в Main.cpp UGENE всегда в светлой теме при первом запуске, а задать темную тему или нет спрашивается позже (как раз в Штрилице, прям перед новым счетчиком). 

Привязал к задаче, чтобы не забыли протестировать.