### PR TITLE
win xml test fix 4182/test_0002.xml flaky

### DIFF
--- a/tests/regression_wd_suite.xml
+++ b/tests/regression_wd_suite.xml
@@ -1,4 +1,4 @@
-<suite name="Regression suite">
+<suite test-timeout="360" name="Regression suite">
 
     <test-dir test-ext="*.xml" path="regression" test-format="XML"/>
 </suite>


### PR DESCRIPTION
Из-за джавы которая нужна для внешнего инструмента в этом тесте, он очень долго стартует и завершается. Кроме как измененеием таймаута в сюите не поправить. Данные используемые в этом тесте на скорость выполнения не влияют.