### PR TITLE
Improvements for suite 4

### DIFF
--- a/src/plugins/GUITestBase/src/harness/GUITestLauncher.cpp
+++ b/src/plugins/GUITestBase/src/harness/GUITestLauncher.cpp
@@ -140,7 +140,7 @@ QList<GUITest*> getIdealTestsSplit(int suiteIndex, int suiteCount, const QList<G
     if (suiteCount == 3) {  // Windows & Mac.
         testsPerSuite << 980 << 940 << -1;
     } else if (suiteCount == 4) {
-        testsPerSuite << 670 << 670 << 730 << -1;
+        testsPerSuite << 750 << 750 << 750 << -1;
     } else if (suiteCount == 5) {
         testsPerSuite << 580 << 650 << 530 << 600 << -1;  // Linux.
     }


### PR DESCRIPTION
Добавление четвертой сюиты требует определенных доработок:

- Несмотря на то, что теперь все сюиты укладываются в восемь часов чистого времени (и даже быстрее), есть некоторый перекос в сторону последней сюиты по количеству тестов, из-за чего она гонится дольше. Постарался уравнять этот переком и оставил четвертой сюите некоторый запас, т.к. все новые тесты падают на неё.
- Тест test_4710_1 стабильно падает. Причина - не успевает отработать таска, меняющая состояние красного крстика с disabled на enabled при нажатии на кнопку "Stop" при исполнении схемы WD. Чтобы таска гарантированно отработала добавлено `waitTaskFinished`.
- test_7456 - генерация большого набора коротких последовательностей, открытие их в MSA - падает по таймауту. Я протестировал, на win10-3-vm генерация последовательности как в тесте с сохранением на диск длится 57 секунд + открытие MSA 1 минута 19 секунд итого 2 минуты 16 секунд. На новом win10-5-vm генерация длится 1 минуту 28 секунд, открывание MSA - 1 минуту 38 секунд, т.е. 3 минуты 6 секунд, что больше отведенного таймаута в 3 минуты для `waitTaskFinished()`. Проконсультировался с Вадимом - процессор на сервере, где крутится win10-5-vm послабее для однопоточных вычислений, которыми являются все описанные, и подобное замедление может иметь место быть. В качестве решения - увеличил таймаут.

Еще один тест 5371 падал из-за настроек ОС, фикса в коде не требует.