### PR TITLE
Refactoring regexp core

### DIFF
--- a/src/corelibs/U2Algorithm/src/smith_waterman/SWMulAlignSeqPrefixTag.cpp
+++ b/src/corelibs/U2Algorithm/src/smith_waterman/SWMulAlignSeqPrefixTag.cpp
@@ -21,6 +21,8 @@
 
 #include "SWMulAlignSeqPrefixTag.h"
 
+#include <QRegularExpression>
+
 const QString REG_EXP_PATTERN_FOR_WORDS_SEPARATORS = "\\s|_";
 
 namespace U2 {
@@ -30,7 +32,7 @@ QString SWMulAlignSeqPrefixTag::expandTag(const QVariant& argument) const {
     QString seqName = argument.toString();
     assert(!seqName.isEmpty());
 
-    int lastWordEndPositionInPrefix = seqName.lastIndexOf(QRegExp(REG_EXP_PATTERN_FOR_WORDS_SEPARATORS), prefixLength - 1);
+    int lastWordEndPositionInPrefix = seqName.lastIndexOf(QRegularExpression(REG_EXP_PATTERN_FOR_WORDS_SEPARATORS), prefixLength - 1);
     if (-1 == lastWordEndPositionInPrefix)
         lastWordEndPositionInPrefix = prefixLength - 1;
 

--- a/src/corelibs/U2Algorithm/src/smith_waterman/SmithWatermanReportCallback.cpp
+++ b/src/corelibs/U2Algorithm/src/smith_waterman/SmithWatermanReportCallback.cpp
@@ -478,10 +478,13 @@ void SmithWatermanReportCallbackMAImpl::changeGivenUrlIfDocumentExists(QString& 
     if (curProject->findDocumentByURL(GUrl(givenUrl)) != nullptr) {
         for (size_t i = 1;; i++) {
             QString tmpUrl = givenUrl;
-            QRegExp dotWithExtensionRegExp("\\.{1,1}[^\\.]*$|^[^\\.]*$");
-            dotWithExtensionRegExp.lastIndexIn(tmpUrl);
-            tmpUrl.replace(dotWithExtensionRegExp.capturedTexts().last(),
-                           "(" + QString::number(i) + ")" + dotWithExtensionRegExp.capturedTexts().last());
+            QRegularExpression dotWithExtensionRegExp("\\.[^\\.]*$|^[^\\.]*$");
+            QRegularExpressionMatchIterator it = dotWithExtensionRegExp.globalMatch(tmpUrl);
+            QRegularExpressionMatch m;
+            while (it.hasNext()) {
+                m = it.next();
+            }
+            tmpUrl.replace(m.captured(0), "(" + QString::number(i) + ")" + m.captured(0));
             if (curProject->findDocumentByURL(GUrl(tmpUrl)) == nullptr) {
                 givenUrl = tmpUrl;
                 break;
@@ -489,5 +492,6 @@ void SmithWatermanReportCallbackMAImpl::changeGivenUrlIfDocumentExists(QString& 
         }
     }
 }
+
 
 }  // namespace U2

--- a/src/corelibs/U2Core/src/datatype/PFMatrix.cpp
+++ b/src/corelibs/U2Core/src/datatype/PFMatrix.cpp
@@ -23,6 +23,7 @@
 
 #include <U2Core/DNAAlphabet.h>
 #include <U2Core/U2OpStatusUtils.h>
+#include <QRegularExpression>
 
 #include "DIProperties.h"
 
@@ -39,7 +40,7 @@ JasparInfo::JasparInfo(const QMap<QString, QString>& props)
 JasparInfo::JasparInfo(const QString& line) {
     QStringList parsedData = line.split(";");
     QString idData = parsedData.first();
-    QStringList base = idData.split(QRegExp("\\s"));
+    QStringList base = idData.split(QRegularExpression("\\s+"));
     QString id = base[0];
     properties.insert(QString("id"), id);
     QString name = base[2];

--- a/src/corelibs/U2Core/src/datatype/UdrSchemaRegistry.cpp
+++ b/src/corelibs/U2Core/src/datatype/UdrSchemaRegistry.cpp
@@ -56,8 +56,8 @@ const UdrSchema* UdrSchemaRegistry::getSchemaById(const UdrSchemaId& id) const {
 }
 
 bool UdrSchemaRegistry::isCorrectName(const QByteArray& name) {
-    QRegularExpression regExp("([A-z]|_)([A-z]|_|\\d)*");
-    return regExp.match(name).hasMatch();
+    QRegularExpression re("^[A-Za-z_][A-Za-z0-9_]*$");
+    return re.match(name).hasMatch();
 }
 
 }  // namespace U2

--- a/src/corelibs/U2Core/src/datatype/UdrSchemaRegistry.cpp
+++ b/src/corelibs/U2Core/src/datatype/UdrSchemaRegistry.cpp
@@ -21,7 +21,7 @@
 
 #include "UdrSchemaRegistry.h"
 
-#include <QRegExp>
+#include <QRegularExpression>
 
 #include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
@@ -56,8 +56,8 @@ const UdrSchema* UdrSchemaRegistry::getSchemaById(const UdrSchemaId& id) const {
 }
 
 bool UdrSchemaRegistry::isCorrectName(const QByteArray& name) {
-    QRegExp regExp("([A-z]|_)([A-z]|_|\\d)*");
-    return regExp.exactMatch(name);
+    QRegularExpression regExp("([A-z]|_)([A-z]|_|\\d)*");
+    return regExp.match(name).hasMatch();
 }
 
 }  // namespace U2

--- a/src/corelibs/U2Core/src/datatype/primers/PrimerStatistics.cpp
+++ b/src/corelibs/U2Core/src/datatype/primers/PrimerStatistics.cpp
@@ -74,7 +74,7 @@ bool PrimerStatistics::validatePrimerLength(const QByteArray& primer) {
 
 QString PrimerStatistics::getDoubleStringValue(double value) {
     QString result = QString::number(value, 'f', 2);
-    result.remove(QRegExp("\\.?0+$"));
+    result.remove(QRegularExpression("\\.?0+$"));
     return result;
 }
 
@@ -351,7 +351,7 @@ void PrimersPairStatistics::addDimersToReport(QString& report) const {
 
 QString PrimersPairStatistics::toString(double value) {
     QString result = QString::number(value, 'f', 2);
-    result.remove(QRegExp("\\.?0+$"));
+    result.remove(QRegularExpression("\\.?0+$"));
     return result;
 }
 

--- a/src/corelibs/U2Core/src/datatype/primers/PrimerValidator.cpp
+++ b/src/corelibs/U2Core/src/datatype/primers/PrimerValidator.cpp
@@ -27,20 +27,20 @@
 namespace U2 {
 
 PrimerValidator::PrimerValidator(QObject* parent, bool allowExtended)
-    : QRegExpValidator(parent) {
+    : QRegularExpressionValidator(parent) {
     const DNAAlphabet* alphabet = AppContext::getDNAAlphabetRegistry()->findById(
         allowExtended ? BaseDNAAlphabetIds::NUCL_DNA_EXTENDED() : BaseDNAAlphabetIds::NUCL_DNA_DEFAULT());
     QByteArray alphabetChars = alphabet->getAlphabetChars(true);
     // Gaps are not allowed
     alphabetChars.remove(alphabetChars.indexOf('-'), 1);
-    setRegExp(QRegExp(QString("[%1]+").arg(alphabetChars.constData())));
+    setRegularExpression(QRegularExpression(QString("[%1]+").arg(alphabetChars.constData())));
 }
 
 QValidator::State PrimerValidator::validate(QString& input, int& pos) const {
     input = input.simplified();
     input = input.toUpper();
     input.remove(" ");
-    return QRegExpValidator::validate(input, pos);
+    return QRegularExpressionValidator ::validate(input, pos);
 }
 
 }  // namespace U2

--- a/src/corelibs/U2Core/src/datatype/primers/PrimerValidator.h
+++ b/src/corelibs/U2Core/src/datatype/primers/PrimerValidator.h
@@ -22,15 +22,16 @@
 #pragma once
 
 #include <QValidator>
+#include <QRegularExpressionValidator>
 
 #include <U2Core/global.h>
 
 namespace U2 {
 /**
  * @PrimerValidator
- * QRegExpValidator improving for primers. Make possible to type nucleotide or nucleotide-extended characters.
+ * QRegularExpressionValidator improving for primers. Make possible to type nucleotide or nucleotide-extended characters.
  */
-class U2CORE_EXPORT PrimerValidator : public QRegExpValidator {
+class U2CORE_EXPORT PrimerValidator : public QRegularExpressionValidator {
 public:
     PrimerValidator(QObject* parent, bool allowExtended = true);
 

--- a/src/corelibs/U2Core/src/dbi/U2DbiUtils.cpp
+++ b/src/corelibs/U2Core/src/dbi/U2DbiUtils.cpp
@@ -176,7 +176,7 @@ QString U2DbiUtils::makeFolderCanonical(const QString& folder) {
     }
 
     QString result = folder.startsWith(U2ObjectDbi::ROOT_FOLDER + U2ObjectDbi::PATH_SEP) ? folder : U2ObjectDbi::ROOT_FOLDER + U2ObjectDbi::PATH_SEP + folder;
-    result.replace(QRegExp(U2ObjectDbi::PATH_SEP + "+"), U2ObjectDbi::PATH_SEP);
+    result.replace(QRegularExpression(U2ObjectDbi::PATH_SEP + "+"), U2ObjectDbi::PATH_SEP);
 
     if (U2ObjectDbi::ROOT_FOLDER != result &&
         result.endsWith(U2ObjectDbi::ROOT_FOLDER)) {

--- a/src/corelibs/U2Core/src/globals/CustomExternalTool.cpp
+++ b/src/corelibs/U2Core/src/globals/CustomExternalTool.cpp
@@ -60,7 +60,7 @@ void CustomExternalTool::setPredefinedVersion(const QString& version) {
     predefinedVersion = version;
 }
 
-void CustomExternalTool::setVersionRegExp(const QRegExp& _versionRegExp) {
+void CustomExternalTool::setVersionRegExp(const QRegularExpression& _versionRegExp) {
     versionRegExp = _versionRegExp;
 }
 

--- a/src/corelibs/U2Core/src/globals/CustomExternalTool.h
+++ b/src/corelibs/U2Core/src/globals/CustomExternalTool.h
@@ -38,7 +38,7 @@ public:
     void setValidationArguments(const QStringList& arguments);
     void setValidationExpectedText(const QString& text);
     void setPredefinedVersion(const QString& version);
-    void setVersionRegExp(const QRegExp& versionRegExp);
+    void setVersionRegExp(const QRegularExpression& versionRegExp);
     void setToolkitName(const QString& toolkitName);
     void setDependencies(const QStringList& dependencies);
     void setConfigFilePath(const QString& configFilePath);

--- a/src/corelibs/U2Core/src/globals/ExternalToolRegistry.cpp
+++ b/src/corelibs/U2Core/src/globals/ExternalToolRegistry.cpp
@@ -109,7 +109,7 @@ const QString& ExternalTool::getPredefinedVersion() const {
     return predefinedVersion;
 }
 
-const QRegExp& ExternalTool::getVersionRegExp() const {
+const QRegularExpression& ExternalTool::getVersionRegExp() const {
     return versionRegExp;
 }
 

--- a/src/corelibs/U2Core/src/globals/ExternalToolRegistry.h
+++ b/src/corelibs/U2Core/src/globals/ExternalToolRegistry.h
@@ -86,7 +86,7 @@ public:
       * Returns an empty string if can't derive the tool version by the path. */
     virtual const QString getVersionFromToolPath(const QString& toolPath) const;
     const QString& getPredefinedVersion() const;
-    const QRegExp& getVersionRegExp() const;
+    const QRegularExpression& getVersionRegExp() const;
     const QString& getToolKitName() const;
     const StrStrMap& getErrorDescriptions() const;
     const StrStrMap& getAdditionalInfo() const;
@@ -144,7 +144,7 @@ protected:
     QString validationMessageRegExp;  // expected message in the validation run output
     QString version;  // tool version
     QString predefinedVersion;  // tool's predefined version, this value is used if tool is not validated and there is no possibility to get actual version
-    QRegExp versionRegExp;  // RegExp to get the version from the validation run output
+    QRegularExpression versionRegExp;  // RegExp to get the version from the validation run output
     bool isValidTool;  // tool state
 
     /** If true the tool was already checked/validated by UGENE. */

--- a/src/corelibs/U2Core/src/globals/GUrl.cpp
+++ b/src/corelibs/U2Core/src/globals/GUrl.cpp
@@ -23,6 +23,7 @@
 
 #include <QDataStream>
 #include <QDir>
+#include <QRegularExpression>
 
 #include "U2SafePoints.h"
 
@@ -110,7 +111,7 @@ GUrlType GUrl::getURLType(const QString& rawUrl) {
         result = GUrl_Http;
     } else if (rawUrl.startsWith("ftp://")) {
         result = GUrl_Ftp;
-    } else if (!rawUrl.startsWith("file://") && rawUrl.contains(QRegExp("^([\\.\\w-]+@)?[\\.\\w-]+:\\d*(/[\\w-]*)?$"))) {
+    } else if (!rawUrl.startsWith("file://") && rawUrl.contains(QRegularExpression("^([\\.\\w-]+@)?[\\.\\w-]+:\\d*(/[\\w-]*)?$"))) {
         return GUrl_Network;
     } else if (rawUrl.startsWith(U2_VFS_URL_PREFIX)) {
         result = GUrl_VFSFile;

--- a/src/corelibs/U2Core/src/tasks/CmdlineTaskRunner.cpp
+++ b/src/corelibs/U2Core/src/tasks/CmdlineTaskRunner.cpp
@@ -380,7 +380,7 @@ void CmdlineTaskRunner::sl_onReadStandardOutput() {
     }
 
     for (const QString& line : qAsConst(lines)) {
-        QStringList words = line.split(QRegExp("\\s+"), Qt::SkipEmptyParts);
+        QStringList words = line.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
         for (const QString& word : qAsConst(words)) {
             if (word.startsWith(OUTPUT_PROGRESS_TAG)) {
                 QString numStr = word.mid(OUTPUT_PROGRESS_TAG.size());

--- a/src/corelibs/U2Core/src/util/DatatypeSerializeUtils.cpp
+++ b/src/corelibs/U2Core/src/util/DatatypeSerializeUtils.cpp
@@ -22,6 +22,7 @@
 #include "DatatypeSerializeUtils.h"
 
 #include <QBitArray>
+#include <QRegularExpression>
 #include <QStack>
 #include <QtEndian>
 
@@ -227,7 +228,7 @@ static void packTreeNode(QString& resultText, const PhyNode* node, U2OpStatus& o
             resultText.append(QString::number(childBranch->distance));
         }
         resultText.append(")");
-    } else if (node->name.contains(QRegExp("\\s|[(]|[)]|[:]|[;]|[,]"))) {
+    } else if (node->name.contains(QRegularExpression("\\s|[(]|[)]|[:]|[;]|[,]"))) {
         resultText.append(QString("\'%1\'").arg(node->name));
     } else {
         resultText.append(node->name);

--- a/src/corelibs/U2Core/src/util/FilesIterator.cpp
+++ b/src/corelibs/U2Core/src/util/FilesIterator.cpp
@@ -36,12 +36,10 @@ FilesIterator* FilesIteratorFactory::createFileList(const QStringList& files) {
 /************************************************************************/
 DirectoryScanner::DirectoryScanner(const QStringList& dirs, const QString& _includeFilter, const QString& _excludeFilter, bool _recursive)
     : FilesIterator(), includeFilter(_includeFilter), excludeFilter(_excludeFilter), recursive(_recursive),
-      incRx(includeFilter), excRx(excludeFilter) {
+      incRx(QRegularExpression::wildcardToRegularExpression(includeFilter)), excRx(QRegularExpression::wildcardToRegularExpression(excludeFilter)) {
     foreach (const QString& dirPath, dirs) {
         unusedDirs << QFileInfo(dirPath);
     }
-    incRx.setPatternSyntax(QRegExp::Wildcard);
-    excRx.setPatternSyntax(QRegExp::Wildcard);
 }
 
 QString DirectoryScanner::getNextFile() {
@@ -71,10 +69,10 @@ QString DirectoryScanner::getNextFile() {
 bool DirectoryScanner::isPassedByFilters(const QString& fileName) const {
     bool passed = true;
     if (!includeFilter.isEmpty()) {
-        passed = incRx.exactMatch(fileName);
+        passed = incRx.match(fileName).hasMatch();
     }
     if (!excludeFilter.isEmpty()) {
-        passed = passed && !excRx.exactMatch(fileName);
+        passed = passed && !excRx.match(fileName).hasMatch();
     }
 
     return passed;

--- a/src/corelibs/U2Core/src/util/FilesIterator.h
+++ b/src/corelibs/U2Core/src/util/FilesIterator.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <QDir>
+#include <QRegularExpression>
 
 #include <U2Core/global.h>
 
@@ -66,8 +67,8 @@ private:
 
     QStringList usedDirs;
     QFileInfoList unusedDirs;
-    QRegExp incRx;
-    QRegExp excRx;
+    QRegularExpression incRx;
+    QRegularExpression excRx;
 
     QStringList readyResults;
 

--- a/src/corelibs/U2Core/src/util/GUrlUtils.cpp
+++ b/src/corelibs/U2Core/src/util/GUrlUtils.cpp
@@ -22,6 +22,7 @@
 #include "GUrlUtils.h"
 
 #include <QDir>
+#include <QRegularExpression>
 
 #include <U2Core/AppContext.h>
 #include <U2Core/AppSettings.h>
@@ -71,7 +72,7 @@ GUrl GUrlUtils::ensureFileExt(const GUrl& url, const QStringList& typeExt) {
 }
 
 bool GUrlUtils::containSpaces(const QString& string) {
-    return string.contains(QRegExp("\\s"));
+    return string.contains(QRegularExpression("\\s"));
 }
 
 GUrl GUrlUtils::changeFileExt(const GUrl& url, const DocumentFormatId& newFormatId) {
@@ -351,7 +352,7 @@ QString GUrlUtils::getDefaultDataPath() {
 }
 
 QString GUrlUtils::getQuotedString(const QString& inString) {
-    if (inString.contains(QRegExp("\\s"))) {
+    if (inString.contains(QRegularExpression("\\s"))) {
         return "\"" + inString + "\"";
     }
     return inString;
@@ -454,8 +455,8 @@ QString GUrlUtils::getPairedFastqFilesBaseName(const QString& sourceFileUrl, boo
 
 QString GUrlUtils::fixFileName(const QString& fileName) {
     QString result = fileName;
-    result.replace(QRegExp("[^0-9a-zA-Z._\\-]"), "_");
-    result.replace(QRegExp("_+"), "_");
+    result.replace(QRegularExpression("[^0-9a-zA-Z._\\-]"), "_");
+    result.replace(QRegularExpression("_+"), "_");
 
     // Truncate long file names a bit more to allow suffix adjustments (rolling) later.
     result.truncate(MAX_OS_FILE_NAME_LENGTH - 50);

--- a/src/corelibs/U2Core/src/util/StrPackUtils.cpp
+++ b/src/corelibs/U2Core/src/util/StrPackUtils.cpp
@@ -33,16 +33,16 @@ const QString StrPackUtils::MAP_SEPARATOR = ";";
 const QString StrPackUtils::PAIR_CONNECTOR = "=";
 
 const QString StrPackUtils::listSeparatorPattern = QString("^\\%2|(?!\\\\)\\%2%1\\%2|\\%2$").arg(LIST_SEPARATOR);
-const QRegExp StrPackUtils::listSingleQuoteSeparatorRegExp(listSeparatorPattern.arg("\'"));
-const QRegExp StrPackUtils::listDoubleQuoteSeparatorRegExp(listSeparatorPattern.arg("\""));
+const QRegularExpression StrPackUtils::listSingleQuoteSeparatorRegExp(listSeparatorPattern.arg("\'"));
+const QRegularExpression StrPackUtils::listDoubleQuoteSeparatorRegExp(listSeparatorPattern.arg("\""));
 
 const QString StrPackUtils::mapSeparatorPattern = QString("(?!\\\\)\\%2%1\\%2").arg(MAP_SEPARATOR);
-const QRegExp StrPackUtils::mapSingleQuoteSeparatorRegExp(mapSeparatorPattern.arg("\'"));
-const QRegExp StrPackUtils::mapDoubleQuoteSeparatorRegExp(mapSeparatorPattern.arg("\""));
+const QRegularExpression StrPackUtils::mapSingleQuoteSeparatorRegExp(mapSeparatorPattern.arg("\'"));
+const QRegularExpression StrPackUtils::mapDoubleQuoteSeparatorRegExp(mapSeparatorPattern.arg("\""));
 
 const QString StrPackUtils::pairSeparatorPattern = QString("^\\%2|(?!\\\\)\\%2%1\\%2|\\%2$").arg(PAIR_CONNECTOR);
-const QRegExp StrPackUtils::pairSingleQuoteSeparatorRegExp(pairSeparatorPattern.arg("\'"));
-const QRegExp StrPackUtils::pairDoubleQuoteSeparatorRegExp(pairSeparatorPattern.arg("\""));
+const QRegularExpression StrPackUtils::pairSingleQuoteSeparatorRegExp(pairSeparatorPattern.arg("\'"));
+const QRegularExpression StrPackUtils::pairDoubleQuoteSeparatorRegExp(pairSeparatorPattern.arg("\""));
 
 static bool registerMetaTypes() {
     qRegisterMetaType<StrStrMap>("StrStrMap");
@@ -69,7 +69,7 @@ QString StrPackUtils::packStringList(const QStringList& list, Options options) {
 
 QStringList StrPackUtils::unpackStringList(const QString& string, Options options) {
     QStringList unpackedList;
-    const QRegExp separator = (options == SingleQuotes ? listSingleQuoteSeparatorRegExp : listDoubleQuoteSeparatorRegExp);
+    const QRegularExpression separator = (options == SingleQuotes ? listSingleQuoteSeparatorRegExp : listDoubleQuoteSeparatorRegExp);
     foreach (const QString& escapedString, string.split(separator, Qt::SkipEmptyParts)) {
         unpackedList << unescapeCharacters(escapedString);
     }
@@ -101,9 +101,9 @@ QString StrPackUtils::packMap(const StrStrMap& map, Options options) {
 
 StrStrMap StrPackUtils::unpackMap(const QString& string, Options options) {
     StrStrMap map;
-    QRegExp elementsSeparator = options == SingleQuotes ? mapSingleQuoteSeparatorRegExp : mapDoubleQuoteSeparatorRegExp;
+    QRegularExpression elementsSeparator = options == SingleQuotes ? mapSingleQuoteSeparatorRegExp : mapDoubleQuoteSeparatorRegExp;
     foreach (const QString& pair, string.split(elementsSeparator, Qt::SkipEmptyParts)) {
-        QRegExp keyValueSeparator = options == SingleQuotes ? pairSingleQuoteSeparatorRegExp : pairDoubleQuoteSeparatorRegExp;
+        QRegularExpression keyValueSeparator = options == SingleQuotes ? pairSingleQuoteSeparatorRegExp : pairDoubleQuoteSeparatorRegExp;
         QStringList splitPair = pair.split(keyValueSeparator, Qt::SkipEmptyParts);
         Q_ASSERT(splitPair.size() <= 2);
         if (!splitPair.empty()) {  // splitPair can be empty if both key and value are empty strings.

--- a/src/corelibs/U2Core/src/util/StrPackUtils.h
+++ b/src/corelibs/U2Core/src/util/StrPackUtils.h
@@ -24,7 +24,7 @@
 #include <QBitArray>
 #include <QCoreApplication>
 #include <QMap>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QStringList>
 #include <QVariant>
 
@@ -64,16 +64,16 @@ private:
     static const QString PAIR_CONNECTOR;
 
     static const QString listSeparatorPattern;
-    static const QRegExp listSingleQuoteSeparatorRegExp;
-    static const QRegExp listDoubleQuoteSeparatorRegExp;
+    static const QRegularExpression listSingleQuoteSeparatorRegExp;
+    static const QRegularExpression listDoubleQuoteSeparatorRegExp;
 
     static const QString mapSeparatorPattern;
-    static const QRegExp mapSingleQuoteSeparatorRegExp;
-    static const QRegExp mapDoubleQuoteSeparatorRegExp;
+    static const QRegularExpression mapSingleQuoteSeparatorRegExp;
+    static const QRegularExpression mapDoubleQuoteSeparatorRegExp;
 
     static const QString pairSeparatorPattern;
-    static const QRegExp pairSingleQuoteSeparatorRegExp;
-    static const QRegExp pairDoubleQuoteSeparatorRegExp;
+    static const QRegularExpression pairSingleQuoteSeparatorRegExp;
+    static const QRegularExpression pairDoubleQuoteSeparatorRegExp;
 
     static const bool isMetaTypesRegistered;
 };

--- a/src/corelibs/U2Core/src/util/U1AnnotationUtils.cpp
+++ b/src/corelibs/U2Core/src/util/U1AnnotationUtils.cpp
@@ -662,11 +662,11 @@ void FixAnnotationsUtils::fixAnnotationQualifiers(Annotation* an) {
                 break;
             }
 
+            lastFoundPos = match.capturedEnd();
             const QString matchedRegion = match.captured(0);
             const qint64 start = match.captured(1).toLongLong() - 1;  // position starts with 0
             const qint64 end = match.captured(2).toLongLong() - 1;
 
-            lastFoundPos = match.capturedEnd(0);
             U2Region referencedRegion(start, end - start + 1);
             if (isRegionValid(referencedRegion)) {
                 QList<QVector<U2Region>> newRegions = U1AnnotationUtils::fixLocationsForReplacedRegion(regionToReplace,
@@ -690,8 +690,6 @@ void FixAnnotationsUtils::fixAnnotationQualifiers(Annotation* an) {
                     annotationForReport[an].append(QStrStrPair(qual.name, matchedRegion));
                 }
             }
-
-            lastFoundPos += match.capturedEnd();
         }
 
         if (newQualifierValue != qual.value) {

--- a/src/corelibs/U2Designer/src/MarkerEditorWidget.cpp
+++ b/src/corelibs/U2Designer/src/MarkerEditorWidget.cpp
@@ -145,8 +145,8 @@ bool MarkerEditorWidget::checkAddMarkerGroupResult(Marker* newMarker, QString& m
         }
     }
 
-    QRegExp rx("\\s");
-    if (rx.indexIn(newMarker->getName()) >= 0) {
+    QRegularExpression rx("\\s");
+    if (rx.match(newMarker->getName()).capturedEnd() >= 0) {
         message.append(tr("Marker's name contains spaces: %1").arg(newMarker->getName()));
         return false;
     }

--- a/src/corelibs/U2Designer/src/NewGrouperSlotDialog.cpp
+++ b/src/corelibs/U2Designer/src/NewGrouperSlotDialog.cpp
@@ -48,7 +48,7 @@ NewGrouperSlotDialog::NewGrouperSlotDialog(QWidget* parent, QList<Descriptor>& i
 void NewGrouperSlotDialog::accept() {
     QString name = slotNameEdit->text();
 
-    static const QRegExp invalidSymbols("[\\.,:;\\?@]");
+    static const QRegularExpression invalidSymbols("[\\.,:;\\?@]");
     QString error;
     if (name.isEmpty()) {
         error = tr("Empty output slot name.");

--- a/src/corelibs/U2Designer/src/OutputFileDialog.cpp
+++ b/src/corelibs/U2Designer/src/OutputFileDialog.cpp
@@ -58,7 +58,7 @@ OutputFileDialog::OutputFileDialog(RunFileSystem* _rfs, bool _saveDir, Completio
         if (filler != nullptr) {
             new BaseCompleter(filler, nameEdit);
         }
-        nameEdit->setValidator(new QRegExpValidator(QRegExp("[^" + BAD_CHARS + "]+"), this));
+        nameEdit->setValidator(new QRegularExpressionValidator(QRegularExpression("[^" + BAD_CHARS + "]+"), this));
     }
     updateFocus();
     setupSettings();
@@ -218,7 +218,7 @@ CreateDirectoryDialog::CreateDirectoryDialog(RunFileSystem* _rfs, const QString&
     }
     sl_textChanged();
 
-    nameEdit->setValidator(new QRegExpValidator(QRegExp("[^" + BAD_CHARS + "\\\\\\/]+"), this));
+    nameEdit->setValidator(new QRegularExpressionValidator(QRegularExpression("[^" + BAD_CHARS + "\\\\\\/]+"), this));
 
     connect(nameEdit, SIGNAL(textEdited(const QString&)), SLOT(sl_textChanged()));
 }

--- a/src/corelibs/U2Designer/src/PrompterBase.h
+++ b/src/corelibs/U2Designer/src/PrompterBase.h
@@ -46,7 +46,7 @@ public:
     }
 
     static bool isWildcardURL(const QString& url) {
-        return url.indexOf(QRegExp("[*?\\[\\]]")) >= 0;
+        return url.indexOf(QRegularExpression("[*?\\[\\]]")) >= 0;
     }
 
     ActorDocument* createDescription(Actor*) override = 0;

--- a/src/corelibs/U2Designer/src/wizard/TophatSamplesWidgetController.cpp
+++ b/src/corelibs/U2Designer/src/wizard/TophatSamplesWidgetController.cpp
@@ -62,8 +62,8 @@ void TophatSamplesWidgetController::renameSample(int pos, const QString& newName
         os.setError(tr("Sample name can not be empty"));
         return;
     }
-    QRegExp regExp("\\w+");
-    if (!regExp.exactMatch(newName)) {
+    QRegularExpression regExp("^\\w+$");
+    if (!regExp.match(newName).hasMatch()) {
         os.setError(tr("Sample name can consist only of Latin letters, numbers and the '_' symbol"));
         return;
     }
@@ -246,7 +246,7 @@ class SampleNameEdit : public QLineEdit {
 public:
     SampleNameEdit(TophatSamples* samples, const QString& name, QWidget* parent)
         : QLineEdit(name, parent), samples(samples), initialName(name) {
-        setValidator(new QRegExpValidator(QRegExp("\\w*"), this));
+        setValidator(new QRegularExpressionValidator(QRegularExpression("\\w*"), this));
         setObjectName(name);
     }
 

--- a/src/corelibs/U2Formats/src/AbstractVariationFormat.cpp
+++ b/src/corelibs/U2Formats/src/AbstractVariationFormat.cpp
@@ -237,7 +237,7 @@ FormatCheckResult AbstractVariationFormat::checkRawTextData(const QString& dataP
     int idx = 0;
     int mismatchesNumber = 0;
     int cellsNumber = 0;
-    QRegExp wordExp("\\D+");
+    QRegularExpression wordExp("^\\D+$");
     for (const QString& originalLine : qAsConst(lines)) {
         bool skipLastLine = lines.size() != 1 && idx == lines.size() - 1;
         if (skipLastLine) {
@@ -276,10 +276,10 @@ FormatCheckResult AbstractVariationFormat::checkRawTextData(const QString& dataP
                     col.toInt(&isCorrect);
                     break;
                 case ColumnRole_RefData:
-                    isCorrect = wordExp.exactMatch(col);
+                    isCorrect = wordExp.match(col).hasMatch();
                     break;
                 case ColumnRole_ObsData:
-                    isCorrect = wordExp.exactMatch(col);
+                    isCorrect = wordExp.match(col).hasMatch();
                     break;
                 default:
                     break;

--- a/src/corelibs/U2Formats/src/BedFormat.cpp
+++ b/src/corelibs/U2Formats/src/BedFormat.cpp
@@ -362,7 +362,7 @@ bool getAttributeValue(const QString& line, const QString& attrName, QString& at
         attrEndIndex = line.indexOf("\"", attrBeginIndex + 1);
     } else {
         parenthesisAreUsed = false;
-        attrEndIndex = line.indexOf(QRegExp("\\s"), attrIndex);
+        attrEndIndex = line.indexOf(QRegularExpression("\\s"), attrIndex);
         if (-1 == attrEndIndex) {
             attrEndIndex = line.size();
         }

--- a/src/corelibs/U2Formats/src/EMBLPlainTextFormat.cpp
+++ b/src/corelibs/U2Formats/src/EMBLPlainTextFormat.cpp
@@ -68,7 +68,7 @@ FormatCheckResult EMBLPlainTextFormat::checkRawTextData(const QByteArray& rawDat
     }
     bool tokenMatched = TextUtils::equals("ID   ", data, 5);
     if (tokenMatched) {
-        if (QString(rawData).contains(QRegExp("\\d+ AA."))) {
+        if (QString(rawData).contains(QRegularExpression("\\d+ AA."))) {
             return FormatDetection_NotMatched;
         }
         return FormatDetection_HighSimilarity;
@@ -148,7 +148,7 @@ bool EMBLPlainTextFormat::readEntry(ParserState* st, U2SequenceImporter& seqImpo
         }
         if (st->hasKey("AC")) {
             QVariant v = st->entry->tags.value(DNAInfo::ACCESSION);
-            QStringList l = st->value().split(QRegExp(";\\s*"), Qt::SkipEmptyParts);
+            QStringList l = st->value().split(QRegularExpression(";\\s*"), Qt::SkipEmptyParts);
             st->entry->tags[DNAInfo::ACCESSION] = QVariantUtils::addStr2List(v, l);
             continue;
         }

--- a/src/corelibs/U2Formats/src/GFFFormat.cpp
+++ b/src/corelibs/U2Formats/src/GFFFormat.cpp
@@ -239,7 +239,7 @@ void GFFFormat::load(IOAdapter* io, const U2DbiRef& dbiRef, QList<GObject*>& obj
     CHECK_EXT(!io->hasError(), os.setError(io->errorString()), );
     buff[len] = '\0';
     QString qstrbuf(buff.data());
-    QStringList words = qstrbuf.split(QRegExp("\\s+"));
+    QStringList words = qstrbuf.split(QRegularExpression("\\s+"));
     bool isOk;
     QSet<AnnotationTableObject*> atoSet;
     QMap<QString, U2SequenceObject*> seqMap;
@@ -585,11 +585,11 @@ QStringList GFFFormat::parseLine(const QString& line) const {
 }
 
 QString normalizeQualifier(QString qual) {
-    QRegExp rx("  +");
+    QRegularExpression rx("  +");
     if (qual.contains(rx)) {
         qual.replace(rx, " ");
     }
-    QRegExp rxN("\n+");
+    QRegularExpression rxN("\n+");
     qual.replace(rxN, " ");
     return qual;
 }

--- a/src/corelibs/U2Formats/src/GenbankPlainTextFormat.cpp
+++ b/src/corelibs/U2Formats/src/GenbankPlainTextFormat.cpp
@@ -117,13 +117,13 @@ bool GenbankPlainTextFormat::readIdLine(ParserState* st) {
     }
 
     QString locusStr = st->value();
-    QStringList tokens = locusStr.split(QRegExp("(\t| )"), Qt::SkipEmptyParts);  // separators: tabs and spaces
+    QStringList tokens = locusStr.split(QRegularExpression("(\t| )"), Qt::SkipEmptyParts);  // separators: tabs and spaces
     if (tokens.isEmpty()) {
         st->si.setError(tr("Error parsing LOCUS line"));
         return false;
     }
     // try improving name readability
-    tokens[0] = tokens[0].replace(QRegExp("_(?![0-9])"), QChar(' '));
+    tokens[0] = tokens[0].replace(QRegularExpression("_(?![0-9])"), QChar(' '));
     st->entry->name = tokens[0];
 
     if (tokens.size() >= 3 && (tokens[2] == "bp" || tokens[2] == "aa")) {
@@ -351,14 +351,14 @@ QString GenbankPlainTextFormat::getFeatureTypeString(U2FeatureType featureType, 
 }
 
 bool GenbankPlainTextFormat::breakQualifierOnSpaceOnly(const QString& qualifierName) const {
-    QRegExp spacelessQualifierCatcher = QRegExp("^/?(" +
+    QRegularExpression spacelessQualifierCatcher("^/?(" +
                                                 GBFeatureUtils::QUALIFIER_TRANSLATION +
                                                 "|" +
                                                 GBFeatureUtils::QUALIFIER_NAME +
                                                 "|" +
                                                 GBFeatureUtils::QUALIFIER_GROUP +
                                                 ")");
-    return -1 == spacelessQualifierCatcher.indexIn(qualifierName);
+    return !spacelessQualifierCatcher.match(qualifierName).hasMatch();
 }
 
 const QMap<U2FeatureType, GBFeatureKey> GenbankPlainTextFormat::additionalFeatureTypes = GenbankPlainTextFormat::initAdditionalFeatureTypes();

--- a/src/corelibs/U2Formats/src/KrakenResultsPlainTextFormat.cpp
+++ b/src/corelibs/U2Formats/src/KrakenResultsPlainTextFormat.cpp
@@ -30,6 +30,8 @@
 
 #include "KrakenResultsPlainTextFormat.h"
 
+#include <QRegularExpression>
+
 namespace U2 {
 
 static const QString PAIRED_READS_DELIMITER = "|:|";
@@ -82,7 +84,7 @@ FormatCheckResult KrakenResultsPlainTextFormat::checkRawTextData(const QString& 
         lines.removeLast();
     }    
     for (const QString& line : qAsConst(lines)) {
-        const QStringList words = line.split(QRegExp("\\s+"), Qt::SkipEmptyParts);
+        const QStringList words = line.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
         // first word - 'C' or 'U'
         if (words.size() > 4 && (words[0] == "C" || words[0] == "U")) {
             bool isNumber = false;
@@ -121,7 +123,7 @@ LineParseResult parse(const QString& line, int lineNumber, ReadsType& readsInFil
                 .arg(QString::number(lineNumber))), result);
         }
     }
-    const QStringList words = line.split(QRegExp("\\s+"));
+    const QStringList words = line.split(QRegularExpression("\\s+"));
     CHECK_EXT(words[0] == "C" || words[0] == "U", os.setError(
         KrakenResultsPlainTextFormat::tr("Error on line %1, 1st word should be \"C\" or \"U\".").arg(QString::number(lineNumber))), result);
     result.left.first = words[1];

--- a/src/corelibs/U2Formats/src/MSFFormat.cpp
+++ b/src/corelibs/U2Formats/src/MSFFormat.cpp
@@ -33,6 +33,8 @@
 #include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
 
+#include <QRegularExpression>
+
 namespace U2 {
 
 const int MSFFormat::CHECK_SUM_MOD = 10000;
@@ -155,7 +157,7 @@ void MSFFormat::load(IOAdapterReader& reader, const U2DbiRef& dbiRef, QList<GObj
     }
 
     // Read sequences.
-    QRegExp coordsRegexp("^\\d+(\\s+\\d+)?$");
+    QRegularExpression coordsRegexp("^\\d+(\\s+\\d+)?$");
     int maRowIndex = 0;
     bool prevLineIsEmpty = false;
     while (!os.isCoR() && !reader.atEnd()) {
@@ -166,7 +168,7 @@ void MSFFormat::load(IOAdapterReader& reader, const U2DbiRef& dbiRef, QList<GObj
         // Skip empty lines and lines with coordinates.
         // 2 empty lines in a row or a line with coordinates make a new block: this way we support both
         // MSFs with block coordinates and without (blocks separated by 2-empty lines only).
-        bool isCoordsRegexMatched = coordsRegexp.indexIn(line) != -1;
+        bool isCoordsRegexMatched = coordsRegexp.match(line).hasMatch();
         if (line.isEmpty() || isCoordsRegexMatched) {
             if (isCoordsRegexMatched || prevLineIsEmpty) {
                 maRowIndex = 0;

--- a/src/corelibs/U2Formats/src/NEXUSFormat.cpp
+++ b/src/corelibs/U2Formats/src/NEXUSFormat.cpp
@@ -240,7 +240,7 @@ QStringList Tokenizer::getUntil(const QString& what, Qt::CaseSensitivity cs) {
     return words;
 }
 
-QString Tokenizer::readUntil(const QRegExp& regExpMatcher) {
+QString Tokenizer::readUntil(const QRegularExpression& regExpMatcher) {
     // push 'next' token back
     QString str = next + buffStream.readAll();
     QString result = "";
@@ -420,14 +420,14 @@ bool NEXUSParser::readDataContents(Context& ctx) {
                 name.replace('_', ' ');
 
                 // Read value
-                QString value = tz.readUntil(QRegExp("(;|\\n|\\r)"));
+                QString value = tz.readUntil(QRegularExpression("(;|\\n|\\r)"));
 
                 // The value is the last in the section if there is an empty new line at the end.
                 QString trailingSpaces = tz.whiteSpacesAfterLastToken;
                 bool isLastValueInTheSection = trailingSpaces.count('\r') >= 2 || trailingSpaces.count('\n') >= 2;
 
                 // Remove spaces
-                value.remove(QRegExp("\\s"));
+                value.remove(QRegularExpression("\\s"));
 
                 // Replace gaps
                 if (ctx.contains("gap")) {
@@ -810,10 +810,10 @@ void writeMAligment(const Msa& ma, bool simpleName, IOAdapter* io, U2OpStatus&) 
     foreach (const MsaRow& row, rows) {
         QString name = row->getName();
 
-        if (name.contains(QRegExp("\\s|\\W"))) {
+        if (name.contains(QRegularExpression("\\s|\\W"))) {
             if (simpleName) {
                 name.replace(' ', '_');
-                int idx = name.indexOf(QRegExp("\\s|\\W"));
+                int idx = name.indexOf(QRegularExpression("\\s|\\W"));
                 if (idx != -1) {
                     name = name.left(idx);
                 }
@@ -860,7 +860,7 @@ static void writeNode(const PhyNode* node, IOAdapter* io) {
         }
         io->writeBlock(")", 1);
     } else {
-        bool containsSpaces = node->name.contains(QRegExp("\\s"));
+        bool containsSpaces = node->name.contains(QRegularExpression("\\s"));
         if (containsSpaces) {
             io->writeBlock("'", 1);
         }

--- a/src/corelibs/U2Formats/src/NEXUSParser.h
+++ b/src/corelibs/U2Formats/src/NEXUSParser.h
@@ -54,7 +54,7 @@ public:
 
     void skipUntil(const QString& what, Qt::CaseSensitivity cs = Qt::CaseInsensitive);
 
-    QString readUntil(const QRegExp& regExpMatcher);
+    QString readUntil(const QRegularExpression& regExpMatcher);
 
     bool isEof() {
         return io->isEof();

--- a/src/corelibs/U2Formats/src/NewickFormat.cpp
+++ b/src/corelibs/U2Formats/src/NewickFormat.cpp
@@ -118,7 +118,7 @@ FormatCheckResult NewickFormat::checkRawTextData(const QString& dataPrefix, cons
     if (!dataPrefix.contains(';') || (!dataPrefix.contains('(') && dataPrefix.contains(','))) {
         return FormatDetection_LowSimilarity;
     }
-    if (QRegExp("[a-zA-Z\r\n]*").exactMatch(dataPrefix)) {
+    if (QRegularExpression("^[a-zA-Z\r\n]*$").match(dataPrefix).hasMatch()) {
         return FormatDetection_LowSimilarity;
     }
     int braces = (dataPrefix.contains('(') ? 1 : 0) + (dataPrefix.contains(')') ? 1 : 0);

--- a/src/corelibs/U2Formats/src/PDBFormat.cpp
+++ b/src/corelibs/U2Formats/src/PDBFormat.cpp
@@ -303,7 +303,7 @@ void PDBFormat::PDBParser::parseMacromolecularContent(bool firstCompndLine, U2Op
             int index = returnEndOfNameIndexAndUpdateParserState(specification);
             currentMoleculeName = specification.mid(MOLECULE_TAG.size() + 1, index - MOLECULE_TAG.size() - 1).trimmed();
         } else if (specification.startsWith(CHAIN_TAG)) {
-            QStringList idetifiers = specification.split(QRegExp(",|:|;"));
+            QStringList idetifiers = specification.split(QRegularExpression(",|:|;"));
             for (int i = 1; i < idetifiers.size(); i++) {
                 QString identifier = idetifiers.at(i).trimmed();
                 if (identifier.size() > 0 && !currentMoleculeName.isEmpty()) {
@@ -544,7 +544,7 @@ void PDBFormat::PDBParser::parseSequence(BioStruct3D& biostruct, U2OpStatus& ti)
         seqResMap.insert(chainIdentifier, QByteArray());
     }
 
-    QStringList residues = currentPDBLine.mid(19).split(QRegExp("\\s+"), Qt::SkipEmptyParts);
+    QStringList residues = currentPDBLine.mid(19).split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
     QByteArray sequencePart;
     foreach (QString name, residues) {
         SharedResidue residue(new ResidueData);
@@ -584,7 +584,7 @@ void PDBFormat::PDBParser::parseSplitSection(U2OpStatus& /*ti*/) {
     9 - 10 Continuation continuation Allows concatenation of multiple records.
     12 - 15 IDcode idCode ID code of related entry.
     .. every 2 spaces IDcode*/
-    QStringList ids = currentPDBLine.mid(11).split(QRegExp("\\s+"), Qt::SkipEmptyParts);
+    QStringList ids = currentPDBLine.mid(11).split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
     ioLog.trace(QString("The list of SPLIT ids is %1").arg(ids.join(",")));
 }
 
@@ -627,8 +627,9 @@ void PDBFormat::PDBParser::updateResidueIndexes(BioStruct3D& /*biostruc*/) {
 }
 
 int PDBFormat::PDBParser::returnEndOfNameIndexAndUpdateParserState(const QString& specification) {
-    static const QRegExp end(";\\s*$");
-    int index = end.indexIn(specification);
+    static const QRegularExpression end(";\\s*$");
+    QRegularExpressionMatch match = end.match(specification);
+    int index = match.hasMatch() ? match.capturedStart(0) : -1;
     if (index < 0) {
         return specification.size();
     }

--- a/src/corelibs/U2Formats/src/RawDNASequenceFormat.cpp
+++ b/src/corelibs/U2Formats/src/RawDNASequenceFormat.cpp
@@ -123,7 +123,7 @@ Document* RawDNASequenceFormat::loadTextDocument(IOAdapterReader& reader, const 
 }
 
 FormatCheckResult RawDNASequenceFormat::checkRawTextData(const QString& dataPrefix, const GUrl&) const {
-    if (QRegExp("[a-zA-Z\r\n\\*-]*").exactMatch(dataPrefix)) {
+    if (QRegularExpression("^[a-zA-Z\r\n\\*-]*$").match(dataPrefix).hasMatch()) {
         return FormatDetection_VeryHighSimilarity;
     }
     // returning 'very low chance' here just because it's impossible to have 100% detection for this format.

--- a/src/corelibs/U2Formats/src/SAMFormat.cpp
+++ b/src/corelibs/U2Formats/src/SAMFormat.cpp
@@ -104,7 +104,8 @@ FormatCheckResult SAMFormat::checkRawTextData(const QByteArray& rawData, const G
     }
     QRegularExpression rx("^@[A-Za-z][A-Za-z](\\t[A-Za-z][A-Za-z]:[ -~]+)");
     // try to find SAM header
-    if (rx.match(rawData).capturedEnd() != 0) {
+    QRegularExpressionMatch m = rx.match(QString::fromUtf8(rawData));
+    if (!m.hasMatch() || m.capturedStart() != 0) {
         // if no header try to parse first alignment line
         QList<QByteArray> fieldValues = rawData.split('\n')[0].split(SPACE);
         int readFieldsCount = fieldValues.count();

--- a/src/corelibs/U2Formats/src/SAMFormat.h
+++ b/src/corelibs/U2Formats/src/SAMFormat.h
@@ -24,6 +24,8 @@
 #include <U2Core/BaseDocumentFormats.h>
 #include <U2Core/DocumentModel.h>
 
+#include <QRegularExpression>
+
 #include "TextDocumentFormat.h"
 
 namespace U2 {
@@ -55,12 +57,12 @@ public:
             : name(_name), precompiled(_pattern) {
         }
         QString name;
-        QRegExp getPattern() const {
-            return QRegExp(precompiled);
+        QRegularExpression getPattern() const {
+            return precompiled;
         }
 
     private:
-        const QRegExp precompiled;
+        const QRegularExpression precompiled;
     };
 
 protected:

--- a/src/corelibs/U2Formats/src/StockholmFormat.cpp
+++ b/src/corelibs/U2Formats/src/StockholmFormat.cpp
@@ -22,6 +22,7 @@
 #include "StockholmFormat.h"
 
 #include <QTextStream>
+#include <QRegularExpression>
 
 #include <U2Core/GAutoDeleteList.h>
 #include <U2Core/IOAdapter.h>
@@ -479,7 +480,7 @@ static void save(IOAdapterWriter& writer, const Msa& msa, const QString& name, U
     writer.write(os, StockholmFormat::UNI_ANNOTATION_MARK + "\n\n");
     CHECK_OP(os, );
 
-    QString idValue = QString(name).replace(QRegExp("\\s"), "_");
+    QString idValue = QString(name).replace(QRegularExpression("\\s"), "_");
     writer.write(os, StockholmFormat::FILE_ANNOTATION_ID + " " + idValue + "\n\n");
     CHECK_OP(os, );
 

--- a/src/corelibs/U2Formats/src/StreamSequenceWriter.cpp
+++ b/src/corelibs/U2Formats/src/StreamSequenceWriter.cpp
@@ -29,11 +29,13 @@
 
 #include <U2Formats/FastaFormat.h>
 
+#include <QRegularExpression>
+
 namespace U2 {
 
 StreamShortReadsWriter::StreamShortReadsWriter(const GUrl& url, const QString& refName, int refLength)
     : numSeqWritten(0), refSeqLength(refLength) {
-    refSeqName = QString(refName).replace(QRegExp("\\s|\\t"), "_").toLatin1();
+    refSeqName = QString(refName).replace(QRegularExpression("\\s|\\t"), "_").toLatin1();
 
     IOAdapterFactory* iof = AppContext::getIOAdapterRegistry()->getIOAdapterFactoryById(BaseIOAdapters::LOCAL_FILE);
     io = iof->createIOAdapter();

--- a/src/corelibs/U2Formats/src/StreamSequenceWriter.h
+++ b/src/corelibs/U2Formats/src/StreamSequenceWriter.h
@@ -53,7 +53,7 @@ public:
         refSeqLength = l;
     }
     void setRefSeqName(const QString& name) {
-        refSeqName = QString(name).replace(QRegExp("\\s|\\t"), "_").toLatin1();
+        refSeqName = QString(name).replace(QRegularExpression("\\s|\\t"), "_").toLatin1();
     }
     int getNumSeqWritten() {
         return numSeqWritten;

--- a/src/corelibs/U2Formats/src/SwissProtPlainTextFormat.cpp
+++ b/src/corelibs/U2Formats/src/SwissProtPlainTextFormat.cpp
@@ -89,7 +89,7 @@ FormatCheckResult SwissProtPlainTextFormat::checkRawTextData(const QByteArray& r
     }
     bool tokenMatched = TextUtils::equals("ID   ", data, 5);
     if (tokenMatched) {
-        if (QString(rawData).contains(QRegExp("\\d+ AA."))) {
+        if (QString(rawData).contains(QRegularExpression("\\d+ AA."))) {
             return FormatDetection_HighSimilarity;
         }
         return FormatDetection_NotMatched;
@@ -149,7 +149,7 @@ bool SwissProtPlainTextFormat::readEntry(ParserState* st, U2SequenceImporter& se
         }
         if (st->hasKey("AC")) {  // The AC (ACcession number) line lists the accession number(s) associated with an entry.
             QVariant v = st->entry->tags.value(DNAInfo::ACCESSION);
-            QStringList l = st->value().split(QRegExp(";\\s*"), Qt::SkipEmptyParts);
+            QStringList l = st->value().split(QRegularExpression(";\\s*"), Qt::SkipEmptyParts);
             st->entry->tags[DNAInfo::ACCESSION] = QVariantUtils::addStr2List(v, l);
             continue;
         }
@@ -402,7 +402,7 @@ SharedAnnotationData SwissProtPlainTextFormat::readAnnotationOldFormat(IOAdapter
 
     processAnnotationRegion(a, startInt, endInt, offset);
 
-    QString valQStr = QString::fromLatin1(cbuff).split(QRegExp("\\n")).first().mid(34);
+    QString valQStr = QString::fromLatin1(cbuff).split(QRegularExpression("\\n")).first().mid(34);
     bool isDescription = true;
 
     const QByteArray& aminoQ = GBFeatureUtils::QUALIFIER_AMINO_STRAND;
@@ -426,7 +426,7 @@ SharedAnnotationData SwissProtPlainTextFormat::readAnnotationOldFormat(IOAdapter
         // parse line
         if (cbuff[A_COL] != '/') {  // continue of description
             valQStr.append(" ");
-            valQStr.append(QString::fromLatin1(cbuff).split(QRegExp("\\n")).takeAt(0).mid(34));
+            valQStr.append(QString::fromLatin1(cbuff).split(QRegularExpression("\\n")).takeAt(0).mid(34));
         } else {
             for (; QN_COL < len && TextUtils::LINE_BREAKS[(uchar)cbuff[len - 1]]; len--) {
             };  // remove line breaks

--- a/src/corelibs/U2Formats/src/tasks/ConvertAssemblyToSamTask.cpp
+++ b/src/corelibs/U2Formats/src/tasks/ConvertAssemblyToSamTask.cpp
@@ -111,7 +111,7 @@ void ConvertAssemblyToSamTask::run() {
         U2Assembly assembly = handle->dbi->getAssemblyDbi()->getAssemblyObject(id, stateInfo);
         CHECK_OP(stateInfo, );
         U2EntityRef ref(handle->dbi->getDbiRef(), id);
-        QString name = assembly.visualName.replace(QRegExp("\\s|\\t"), "_").toLatin1();
+        QString name = assembly.visualName.replace(QRegularExpression("\\s|\\t"), "_").toLatin1();
         doc->addObject(new AssemblyObject(name, ref));
     }
 

--- a/src/corelibs/U2Formats/src/util/SnpeffInfoParser.cpp
+++ b/src/corelibs/U2Formats/src/util/SnpeffInfoParser.cpp
@@ -25,6 +25,8 @@
 #include <U2Core/U2OpStatus.h>
 #include <U2Core/U2SafePoints.h>
 
+#include <QRegularExpression>
+
 namespace U2 {
 
 const QString SnpeffInfoParser::PAIRS_SEPARATOR = ";";
@@ -209,11 +211,11 @@ QStringList EffParser::getQualifierNames() const {
 }
 
 QStringList EffParser::getValues(const QString& entry) const {
-    QRegExp regexp("^(\\w+)\\((.*)\\)$");
+    QRegularExpression regexp("^(\\w+)\\((.*)\\)$");
     QStringList values;
-    regexp.indexIn(entry);
-    values << regexp.cap(1);
-    values << regexp.cap(2).split(EFFECT_DATA_SEPARATOR);
+    QRegularExpressionMatch match = regexp.match(entry);
+    values << match.captured(1);
+    values << match.captured(2).split(EFFECT_DATA_SEPARATOR);
     return values;
 }
 

--- a/src/corelibs/U2Gui/src/util/DownloadRemoteFileDialog.cpp
+++ b/src/corelibs/U2Gui/src/util/DownloadRemoteFileDialog.cpp
@@ -183,7 +183,7 @@ void DownloadRemoteFileDialog::accept() {
     }
 
     QString dbId = getDBId();
-    QStringList resIds = resourceId.split(QRegExp("[\\s,;]+"));
+    QStringList resIds = resourceId.split(QRegularExpression("[\\s,;]+"));
     QList<Task*> tasks;
 
     QString fileFormat;

--- a/src/corelibs/U2Gui/src/util/ScriptHighlighter.h
+++ b/src/corelibs/U2Gui/src/util/ScriptHighlighter.h
@@ -23,6 +23,8 @@
 
 #include <QSyntaxHighlighter>
 
+#include <QRegularExpression>
+
 namespace U2 {
 
 class ScriptHighlighter : public QSyntaxHighlighter {
@@ -35,14 +37,14 @@ protected:
 
 private:
     struct HighlightingRule {
-        QRegExp pattern;
+        QRegularExpression pattern;
         QTextCharFormat format;
     };
 
     QVector<HighlightingRule> highlightingRules;
 
-    QRegExp commentStartExpression;
-    QRegExp commentEndExpression;
+    QRegularExpression commentStartExpression;
+    QRegularExpression commentEndExpression;
 
     QTextCharFormat keywordFormat;
     QTextCharFormat classFormat;

--- a/src/corelibs/U2Gui/src/util/SeqPasterWidgetController.cpp
+++ b/src/corelibs/U2Gui/src/util/SeqPasterWidgetController.cpp
@@ -122,7 +122,7 @@ void SeqPasterWidgetController::sl_currentIndexChanged(const QString& newText) {
 }
 
 QString SeqPasterWidgetController::addSequence(const QString& name, QString data) {
-    QByteArray seq = data.remove(QRegExp("\\s")).toLatin1();
+    QByteArray seq = data.remove(QRegularExpression("\\s")).toLatin1();
 
     const DNAAlphabet* alph = nullptr;
     if (ui->groupBox->isChecked()) {

--- a/src/corelibs/U2Gui/src/util/logview/LogView.cpp
+++ b/src/corelibs/U2Gui/src/util/logview/LogView.cpp
@@ -168,7 +168,7 @@ void LogViewWidget::sl_onTextEdited(const QString& text) {
 }
 
 bool LogViewWidget::isShown(const QString& txt) {
-    return !highlighter->reg_exp.match(txt, 0).hasMatch();
+    return highlighter->reg_exp.match(txt).hasMatch();
 }
 
 void LogViewWidget::sl_openSettingsDialog() {

--- a/src/corelibs/U2Gui/src/util/logview/LogView.h
+++ b/src/corelibs/U2Gui/src/util/logview/LogView.h
@@ -26,7 +26,7 @@
 #include <QHash>
 #include <QLineEdit>
 #include <QPlainTextEdit>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QShortcut>
 #include <QSyntaxHighlighter>
 #include <QTimer>
@@ -43,7 +43,7 @@ public:
         : QSyntaxHighlighter(doc) {
     }
 
-    QRegExp reg_exp;
+    QRegularExpression reg_exp;
     void highlightBlock(const QString& text) override;
 };
 

--- a/src/corelibs/U2Lang/src/model/Marker.cpp
+++ b/src/corelibs/U2Lang/src/model/Marker.cpp
@@ -270,10 +270,9 @@ bool Marker::getMarkerStringResult(const QVariant& object, QVariantList& expr) {
     } else if (MarkerUtils::CONTAINS_OPERATION == operation) {
         return obj.contains(val);
     } else if (MarkerUtils::REGEXP_OPERATION == operation) {
-        QRegExp rx(val);
-        rx.setPatternSyntax(QRegExp::Wildcard);
-
-        return rx.exactMatch(obj);
+        QRegularExpression rx(QRegularExpression::wildcardToRegularExpression(val));
+        QRegularExpressionMatch match = rx.match(obj);
+        return match.hasMatch() && match.capturedLength(0) == obj.length();
     }
 
     return false;

--- a/src/corelibs/U2Lang/src/support/BaseNGSWorker.cpp
+++ b/src/corelibs/U2Lang/src/support/BaseNGSWorker.cpp
@@ -148,7 +148,7 @@ void BaseNGSParser::parseOutput(const QString& partOfLog) {
 }
 
 void BaseNGSParser::parseErrOutput(const QString& partOfLog) {
-    lastPartOfLog = partOfLog.split(QRegExp("(\n|\r)"));
+    lastPartOfLog = partOfLog.split(QRegularExpression("(\n|\r)"));
     lastPartOfLog.first() = lastErrLine + lastPartOfLog.first();
     lastErrLine = lastPartOfLog.takeLast();
     foreach (QString buf, lastPartOfLog) {

--- a/src/corelibs/U2Lang/src/support/WorkflowUtils.cpp
+++ b/src/corelibs/U2Lang/src/support/WorkflowUtils.cpp
@@ -123,7 +123,7 @@ void WorkflowUtils::setQObjectProperties(QObject& o, const QVariantMap& params) 
 QStringList WorkflowUtils::expandToUrls(const QString& s) {
     QStringList urls = s.split(";");
     QStringList result;
-    QRegExp wcard("[*?\\[\\]]");
+    QRegularExpression wcard("[*?\\[\\]]");
     for (QString url : qAsConst(urls)) {
         int idx = url.indexOf(wcard);
         if (idx >= 0) {

--- a/src/corelibs/U2Lang/src/support/serialize/HRSchemaSerializer.cpp
+++ b/src/corelibs/U2Lang/src/support/serialize/HRSchemaSerializer.cpp
@@ -124,7 +124,7 @@ const QString HRSchemaSerializer::SCHEMA_PATHS_SETTINGS_TAG = "workflow_settings
 QString HRSchemaSerializer::valueString(const QString& s, bool quoteEmpty) {
     QString str = s;
     str.replace("\"", "'");
-    if (str.contains(QRegExp("\\s")) || str.contains(Constants::SEMICOLON) ||
+    if (str.contains(QRegularExpression("\\s")) || str.contains(Constants::SEMICOLON) ||
         str.contains(Constants::EQUALS_SIGN) || str.contains(Constants::DATAFLOW_SIGN) ||
         str.contains(Constants::BLOCK_START) || str.contains(Constants::BLOCK_END) ||
         str.contains(Constants::SINGLE_QUOTE) || str.contains(OldConstants::MARKER_START) ||
@@ -493,7 +493,7 @@ URLContainer* HRSchemaSerializer::parseDirectoryUrl(Tokenizer& tokenizer) {
 }
 
 Actor* HRSchemaSerializer::parseElementsDefinition(Tokenizer& tokenizer, const QString& actorName, QMap<QString, Actor*>& actorMap, QMap<ActorId, ActorId>* idMap) {
-    if (actorName.contains(QRegExp("\\s"))) {
+    if (actorName.contains(QRegularExpression("\\s"))) {
         throw ReadFailed(tr("Element name cannot contain whitespaces: '%1'").arg(actorName));
     }
     if (actorName.contains(Constants::DOT)) {
@@ -1612,7 +1612,7 @@ static QString elementsDefinitionBlock(Actor* actor, bool copyMode) {
                 }
             }
             QString attributeId = attribute->getId();
-            assert(!attributeId.contains(QRegExp("\\s")));
+            assert(!attributeId.contains(QRegularExpression("\\s")));
 
             const AttributeScript& attrScript = attribute->getAttributeScript();
             if (!attrScript.isEmpty()) {
@@ -1690,7 +1690,7 @@ QString HRSchemaSerializer::elementsDefinition(const QList<Actor*>& procs, const
     QString res;
     foreach (Actor* actor, procs) {
         QString idStr = nmap[actor->getId()];
-        SAFE_POINT(!idStr.contains(QRegExp("\\s")), "Error: element name in the workflow file contains spaces", QString());
+        SAFE_POINT(!idStr.contains(QRegularExpression("\\s")), "Error: element name in the workflow file contains spaces", QString());
         res += makeBlock(idStr, Constants::NO_NAME, elementsDefinitionBlock(actor, copyMode));
     }
     return res + Constants::NEW_LINE;
@@ -1879,7 +1879,7 @@ HRSchemaSerializer::NamesMap HRSchemaSerializer::generateElementNames(const QLis
     QMap<ActorId, QString> nmap;
     foreach (Actor* proc, procs) {
         QString id = aid2str(proc->getId());
-        QString name = id.replace(QRegExp("\\s"), "-");
+        QString name = id.replace(QRegularExpression("\\s"), "-");
         nmap[proc->getId()] = name;  // generateElementName(proc, nmap.values());
     }
     return nmap;

--- a/src/corelibs/U2Lang/src/support/serialize/HRVisualSerializer.cpp
+++ b/src/corelibs/U2Lang/src/support/serialize/HRVisualSerializer.cpp
@@ -183,7 +183,7 @@ void HRVisualParser::parseLinkVisualBlock(const QString& from, const QString& to
 }
 
 QPointF HRVisualParser::string2Point(const QString& str, U2OpStatus& os) {
-    QStringList list = str.split(QRegExp("\\s"), Qt::SkipEmptyParts);
+    QStringList list = str.split(QRegularExpression("\\s"), Qt::SkipEmptyParts);
     if (list.size() != 2) {
         os.setError(HRVisualParser::tr("Cannot parse coordinates from '%1'").arg(str));
         return QPointF(0.0, 0.0);
@@ -222,7 +222,7 @@ QFont HRVisualParser::string2Font(const QString& str, U2OpStatus& os) {
 }
 
 QRectF HRVisualParser::string2Rect(const QString& str, U2OpStatus& os) {
-    QStringList list = str.split(QRegExp("\\s"));
+    QStringList list = str.split(QRegularExpression("\\s"));
     if (list.size() != 4) {
         os.setError(HRVisualParser::tr("Cannot parse rectangle from '%1'").arg(str));
     }

--- a/src/corelibs/U2Private/src/ConsoleLogDriver.cpp
+++ b/src/corelibs/U2Private/src/ConsoleLogDriver.cpp
@@ -127,7 +127,7 @@ void ConsoleLogDriver::setLogSettings() {
         QString logFormat = cmd->getParameterValue(CMDLineCoreOptions::LOG_FORMAT);
         settings.showLevel = logFormat.contains("L", Qt::CaseSensitive);
         settings.showCategory = logFormat.contains("C", Qt::CaseSensitive);
-        settings.showDate = logFormat.contains(QRegExp("[M{2}Y{2,4}d{2}H{2}m{2}s{2}z{3}]"));
+        settings.showDate = logFormat.contains(QRegularExpression("[M{2}Y{2,4}d{2}H{2}m{2}s{2}z{3}]"));
         settings.logPattern = logFormat;
     } else if (cmd->hasParameter(LOG_SHOW_DATE_CMD_OPTION) ||  // old options
                cmd->hasParameter(LOG_SHOW_LEVEL_CMD_OPTION) ||
@@ -169,7 +169,7 @@ void ConsoleLogDriver::setLogSettings() {
     LogServer* ls = LogServer::getInstance();
     const QStringList& categoryList = ls->getCategories();
     logLevel = logLevel.remove(" ");
-    QStringList cats = logLevel.split(QRegExp("[,=]"));
+    QStringList cats = logLevel.split(QRegularExpression("[,=]"));
 
     LogCategories::init();
     if (cats.size() == 1) {

--- a/src/corelibs/U2Private/src/PluginDescriptor.cpp
+++ b/src/corelibs/U2Private/src/PluginDescriptor.cpp
@@ -23,6 +23,7 @@
 
 #include <QDir>
 #include <QDomDocument>
+#include <QRegularExpression>
 
 #include <U2Core/GAutoDeleteList.h>
 #include <U2Core/L10n.h>
@@ -56,7 +57,7 @@ static PlatformArch archFromText(const QString& text) {
 
 static PluginMode modeFromText(const QString& text) {
     QString trimmed = text.trimmed().toLower();
-    QStringList tokens = trimmed.split(QRegExp("[\\s,]"), Qt::SkipEmptyParts);
+    QStringList tokens = trimmed.split(QRegularExpression("[\\s,]"), Qt::SkipEmptyParts);
     PluginMode result;
     if (tokens.isEmpty()) {
         result |= PluginMode_Malformed;

--- a/src/corelibs/U2Script/src/SchemeWrapper.h
+++ b/src/corelibs/U2Script/src/SchemeWrapper.h
@@ -126,7 +126,7 @@ private:
         bool& replaceIfExists);
     U2ErrorType insertUrlInAttributeInRange(int* start, int* end);
     U2ErrorType addActorBindingsBlock(int* position);
-    static QRegExp getBlockStartPattern(const QString& blockName);
+    static QRegularExpression getBlockStartPattern(const QString& blockName);
 
     QString pathToScheme;
     QString schemeContent;

--- a/src/corelibs/U2Test/src/GTest.cpp
+++ b/src/corelibs/U2Test/src/GTest.cpp
@@ -25,6 +25,7 @@
 #include <QDomDocument>
 #include <QFile>
 #include <QMap>
+#include <QRegularExpression>
 
 #include <U2Core/AppContext.h>
 #include <U2Core/Timer.h>
@@ -121,7 +122,7 @@ static QStringList findAllFiles(const QString& dirPath, const QString& ext, bool
     return res;
 }
 
-static QString addExcludeTests(const QString& fullTestDirPath, const QString& str, QList<QRegExp>& xList) {
+static QString addExcludeTests(const QString& fullTestDirPath, const QString& str, QList<QRegularExpression>& xList) {
     QString err;
 
     if (str.isEmpty()) {
@@ -129,7 +130,8 @@ static QString addExcludeTests(const QString& fullTestDirPath, const QString& st
     }
 
     foreach (const QString& s, str.split(",")) {
-        QRegExp r(fullTestDirPath + "/" + s.trimmed(), Qt::CaseSensitive, QRegExp::Wildcard);
+        QString pattern = QRegularExpression::wildcardToRegularExpression(fullTestDirPath + "/" + s.trimmed());
+        QRegularExpression r(pattern, QRegularExpression::NoPatternOption);
         if (!r.isValid()) {
             err = QString("Invalid exclude: %1").arg(s);
             break;
@@ -219,7 +221,7 @@ GTestSuite* GTestSuite::readTestSuite(const QString& url, QString& err) {
             break;
         }
 
-        QList<QRegExp> excludeRexExList;
+        QList<QRegularExpression> excludeRexExList;
         err = addExcludeTests(fullTestDirPath, testDirEl.attribute("exclude"), excludeRexExList);
         if (!err.isEmpty()) {
             break;
@@ -329,7 +331,7 @@ QList<GTestSuite*> GTestSuite::readTestSuiteList(const QString& url, QStringList
         return result;
     }
     QString suiteFileContent = suitListFile.readAll();
-    QStringList suiteNamesList = suiteFileContent.split(QRegExp("\\s+"));
+    QStringList suiteNamesList = suiteFileContent.split(QRegularExpression("\\s+"));
     for (auto suiteName : qAsConst(suiteNamesList)) {
         if (suiteName.isEmpty()) {
             continue;

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyReadsAreaHint.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyReadsAreaHint.cpp
@@ -128,7 +128,7 @@ QString getReadNameWrapped(QString n) {
         n = n.trimmed();
         if (n.size() > AssemblyReadsAreaHint::LETTER_MAX_COUNT) {
             QString sub = n.mid(0, AssemblyReadsAreaHint::LETTER_MAX_COUNT);
-            int pos = sub.lastIndexOf(QRegExp("\\s+"));
+            int pos = sub.lastIndexOf(QRegularExpression("\\s+"));
             if (pos == -1) {
                 pos = sub.size();
             }

--- a/src/corelibs/U2View/src/ov_assembly/ExportCoverageDialog.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/ExportCoverageDialog.cpp
@@ -118,7 +118,7 @@ void ExportCoverageDialog::init(QString assemblyName) {
     formats.addFormat(ExportCoverageSettings::BEDGRAPH, QStringList() << ExportCoverageSettings::BEDGRAPH_EXTENSION);
 
     LastUsedDirHelper dirHelper(DIR_HELPER_NAME, GUrlUtils::getDefaultDataPath());
-    assemblyName.replace(QRegExp("[^0-9a-zA-Z._\\-]"), "_").replace(QRegExp("_+"), "_");
+    assemblyName.replace(QRegularExpression("[^0-9a-zA-Z._\\-]"), "_").replace(QRegularExpression("_+"), "_");
     conf.defaultFileName = dirHelper.dir + "/" + assemblyName + "_coverage" +
                            cbFormat->itemData(cbFormat->currentIndex()).toString() + (chbCompress->isChecked() ? ExportCoverageSettings::COMPRESSED_EXTENSION : "");
 

--- a/src/corelibs/U2View/src/ov_mca/McaEditorSequenceArea.cpp
+++ b/src/corelibs/U2View/src/ov_mca/McaEditorSequenceArea.cpp
@@ -453,8 +453,8 @@ void McaEditorSequenceArea::insertChar(char newCharacter) {
 
 bool McaEditorSequenceArea::isCharacterAcceptable(const QString& text) const {
     static const QString alphabetCharacters = AppContext::getDNAAlphabetRegistry()->findById(BaseDNAAlphabetIds::NUCL_DNA_EXTENDED())->getAlphabetChars();
-    static const QRegExp dnaExtendedCharacterOrGap(QString("([%1]| |-|%2)").arg(alphabetCharacters).arg(emDash));
-    return dnaExtendedCharacterOrGap.exactMatch(text);
+    static const QRegularExpression dnaExtendedCharacterOrGap(QString("^([%1]| |-|%2)$").arg(alphabetCharacters).arg(emDash));
+    return dnaExtendedCharacterOrGap.match(text).hasMatch();
 }
 
 const QString& McaEditorSequenceArea::getInacceptableCharacterErrorMessage() const {

--- a/src/corelibs/U2View/src/ov_msa/MaEditorSequenceArea.cpp
+++ b/src/corelibs/U2View/src/ov_msa/MaEditorSequenceArea.cpp
@@ -1587,8 +1587,8 @@ void MaEditorSequenceArea::exitFromEditCharacterMode() {
 }
 
 bool MaEditorSequenceArea::isCharacterAcceptable(const QString& text) const {
-    static const QRegExp latinCharacterOrGap(QString("([A-Z]| |-|%1)").arg(emDash));
-    return latinCharacterOrGap.exactMatch(text);
+    static const QRegularExpression latinCharacterOrGap(QString("^([A-Z]| |-|%1)$").arg(emDash));
+    return latinCharacterOrGap.match(text).hasMatch();
 }
 
 const QString& MaEditorSequenceArea::getInacceptableCharacterErrorMessage() const {

--- a/src/corelibs/U2View/src/ov_msa/find_pattern/FindPatternMsaWidget.cpp
+++ b/src/corelibs/U2View/src/ov_msa/find_pattern/FindPatternMsaWidget.cpp
@@ -628,7 +628,7 @@ bool FindPatternMsaWidget::verifyPatternAlphabet() {
             setMessageFlag(PatternWrongRegExp, true);
             result = false;
         } else {
-            QRegExp regExp(reText.toUtf8());
+            QRegularExpression regExp(reText.toUtf8());
             if (regExp.isValid()) {
                 setMessageFlag(PatternWrongRegExp, false);
             } else {
@@ -708,7 +708,7 @@ QStringList FindPatternMsaWidget::getPatternsFromTextPatternField(U2OpStatus& os
         }
         return result;
     }
-    return inputText.split(QRegExp("\n"), Qt::SkipEmptyParts);
+    return inputText.split(QRegularExpression("\n"), Qt::SkipEmptyParts);
 }
 
 #define FIND_PATTER_LAST_DIR "Find_msa_pattern_last_dir"
@@ -718,7 +718,7 @@ void FindPatternMsaWidget::startFindPatternInMsaTask(const QStringList& patterns
     CHECK(!patterns.isEmpty(), );
 
     if (selectedAlgorithm == FindAlgorithmPatternSettings_RegExp) {
-        QRegExp regExp(textPattern->toPlainText());
+        QRegularExpression regExp(textPattern->toPlainText());
         CHECK(regExp.isValid(), );
     }
 

--- a/src/corelibs/U2View/src/ov_sequence/find_pattern/FindPatternWidget.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/find_pattern/FindPatternWidget.cpp
@@ -870,7 +870,7 @@ bool FindPatternWidget::verifyPatternAlphabet() {
             setMessageFlag(PatternWrongRegExp, true);
             result = false;
         } else {
-            QRegExp regExp(pattern.toUtf8());
+            QRegularExpression regExp(pattern.toUtf8());
             if (regExp.isValid()) {
                 setMessageFlag(PatternWrongRegExp, false);
             } else {
@@ -968,7 +968,7 @@ QList<QPair<QString, QString>> FindPatternWidget::getPatternsFromTextPatternFiel
     QList<NamePattern> result = FastaFormat::getSequencesAndNamesFromUserInput(inputText, os);
 
     if (result.isEmpty()) {
-        QStringList patterns = inputText.split(QRegExp("\n"), Qt::SkipEmptyParts);
+        QStringList patterns = inputText.split(QRegularExpression("\n"), Qt::SkipEmptyParts);
         for (const QString& pattern : qAsConst(patterns)) {
             result.append(qMakePair(QString(""), pattern));
         }
@@ -1022,7 +1022,7 @@ void FindPatternWidget::initFindPatternTask(const QList<NamePattern>& patterns) 
     CHECK(!patterns.isEmpty(), );
 
     if (selectedAlgorithm == FindAlgorithmPatternSettings_RegExp) {
-        QRegExp regExp(textPattern->toPlainText());
+        QRegularExpression regExp(textPattern->toPlainText());
         CHECK(regExp.isValid(), );
     }
     ADVSequenceObjectContext* activeContext = annotatedDnaView->getActiveSequenceContext();

--- a/src/corelibs/U2View/src/util_smith_waterman/SmithWatermanDialog.cpp
+++ b/src/corelibs/U2View/src/util_smith_waterman/SmithWatermanDialog.cpp
@@ -21,7 +21,7 @@
 
 #include <QCheckBox>
 #include <QMessageBox>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QStringList>
 
 #include <U2Algorithm/SmithWatermanReportCallback.h>
@@ -624,15 +624,15 @@ bool SmithWatermanDialog::readPattern(DNATranslation* aminoTT) {
 }
 
 void SmithWatermanDialog::stripFormatSymbolsFromPattern(QString& pattern) {
-    const qint32 fastaSequenceNameStart = pattern.indexOf(QRegExp("\\s*>"));
+    const qint32 fastaSequenceNameStart = pattern.indexOf(QRegularExpression("\\s*>"));
 
     if (0 == fastaSequenceNameStart)
-        pattern = pattern.split(QRegExp("\\s+"), Qt::SkipEmptyParts).last();
+        pattern = pattern.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts).last();
     else if (-1 != fastaSequenceNameStart)
         return;
     else {
-        pattern.replace(QRegExp("\\s+"), "");
-        pattern.replace(QRegExp("\\d+"), "");
+        pattern.replace(QRegularExpression("\\s+"), "");
+        pattern.replace(QRegularExpression("\\d+"), "");
     }
 }
 

--- a/src/plugins/external_tool_support/src/bedtools/BedtoolsSupport.cpp
+++ b/src/plugins/external_tool_support/src/bedtools/BedtoolsSupport.cpp
@@ -46,7 +46,7 @@ BedtoolsSupport::BedtoolsSupport(const QString& path)
     validationMessageRegExp = "bedtools v";
     description = tr("<i>Bedtools</i>: flexible tools for genome arithmetic and DNA sequence analysis.");
 
-    versionRegExp = QRegExp("bedtools v(\\d+.\\d+.\\d+)");
+    versionRegExp = QRegularExpression("bedtools v(\\d+.\\d+.\\d+)");
     validationArguments << "--version";
     toolKitName = "bedtools";
 

--- a/src/plugins/external_tool_support/src/bigWigTools/BigWigSupport.cpp
+++ b/src/plugins/external_tool_support/src/bigWigTools/BigWigSupport.cpp
@@ -45,7 +45,7 @@ BigWigSupport::BigWigSupport(const QString& path)
     validationMessageRegExp = "bedGraphToBigWig";
     description = tr("<i>bedGraphToBigWig</i>: convert a bedGraph file to bigWig format.");
 
-    versionRegExp = QRegExp("bedGraphToBigWig v (\\d+)");
+    versionRegExp = QRegularExpression("bedGraphToBigWig v (\\d+)");
     validationArguments << "";
     toolKitName = "bedGraphToBigWig";
 

--- a/src/plugins/external_tool_support/src/blast/BlastSupport.cpp
+++ b/src/plugins/external_tool_support/src/blast/BlastSupport.cpp
@@ -84,44 +84,44 @@ BlastSupport::BlastSupport(const QString& id)
         executableFileName = isOsWindows() ? "blastn.exe" : "blastn";
         validationMessageRegExp = "Nucleotide-Nucleotide BLAST";
         description = tr("The <i>blastn</i> tool searches a nucleotide database using a nucleotide query.");
-        versionRegExp = QRegExp("Nucleotide-Nucleotide BLAST (\\d+\\.\\d+\\.\\d+)");
+        versionRegExp = QRegularExpression("Nucleotide-Nucleotide BLAST (\\d+\\.\\d+\\.\\d+)");
     } else if (id == ET_BLASTP_ID) {
         executableFileName = isOsWindows() ? "blastp.exe" : "blastp";
         validationMessageRegExp = "Protein-Protein BLAST";
         description = tr("The <i>blastp</i> tool searches a protein database using a protein query.");
-        versionRegExp = QRegExp("Protein-Protein BLAST (\\d+\\.\\d+\\.\\d+)");
+        versionRegExp = QRegularExpression("Protein-Protein BLAST (\\d+\\.\\d+\\.\\d+)");
     } else if (id == ET_BLASTX_ID) {
         executableFileName = isOsWindows() ? "blastx.exe" : "blastx";
         validationMessageRegExp = "Translated Query-Protein Subject";
         description = tr("The <i>blastx</i> tool searches a protein database using a translated nucleotide query.");
-        versionRegExp = QRegExp("Translated Query-Protein Subject BLAST (\\d+\\.\\d+\\.\\d+)");
+        versionRegExp = QRegularExpression("Translated Query-Protein Subject BLAST (\\d+\\.\\d+\\.\\d+)");
     } else if (id == ET_TBLASTN_ID) {
         executableFileName = isOsWindows() ? "tblastn.exe" : "tblastn";
         validationMessageRegExp = "Protein Query-Translated Subject";
         description = tr("The <i>tblastn</i> compares a protein query against a translated nucleotide database");
-        versionRegExp = QRegExp("Protein Query-Translated Subject BLAST (\\d+\\.\\d+\\.\\d+)");
+        versionRegExp = QRegularExpression("Protein Query-Translated Subject BLAST (\\d+\\.\\d+\\.\\d+)");
     } else if (id == ET_TBLASTX_ID) {
         executableFileName = isOsWindows() ? "tblastx.exe" : "tblastx";
         validationMessageRegExp = "Translated Query-Translated Subject";
         description = tr("The <i>tblastx</i> translates the query nucleotide sequence in all six possible frames and compares it against the six-frame translations of a nucleotide sequence database.");
-        versionRegExp = QRegExp("Translated Query-Translated Subject BLAST (\\d+\\.\\d+\\.\\d+)");
+        versionRegExp = QRegularExpression("Translated Query-Translated Subject BLAST (\\d+\\.\\d+\\.\\d+)");
     } else if (id == ET_RPSBLAST_ID) {
         executableFileName = isOsWindows() ? "rpsblast.exe" : "rpsblast";
         validationMessageRegExp = "Reverse Position Specific BLAST";
         description = "";
-        versionRegExp = QRegExp("Reverse Position Specific BLAST (\\d+\\.\\d+\\.\\d+)");
+        versionRegExp = QRegularExpression("Reverse Position Specific BLAST (\\d+\\.\\d+\\.\\d+)");
     } else if (id == ET_BLASTDBCMD_ID) {
         executableFileName = isOsWindows() ? "blastdbcmd.exe" : "blastdbcmd";
         validationArguments << "--help";
         validationMessageRegExp = "blastdbcmd";
         description = tr("The <i>BlastDBCmd</i> fetches protein or nucleotide sequences from BLAST database based on a query.");
-        versionRegExp = QRegExp("BLAST database client, version (\\d+\\.\\d+\\.\\d+)");
+        versionRegExp = QRegularExpression("BLAST database client, version (\\d+\\.\\d+\\.\\d+)");
     } else if (id == ET_MAKEBLASTDB_ID) {
         executableFileName = isOsWindows() ? "makeblastdb.exe" : "makeblastdb";
         validationArguments << "-help";
         validationMessageRegExp = "makeblastdb";
         description = tr("The <i>makeblastdb</i> formats protein or nucleotide source databases before these databases can be searched by other BLAST tools.");
-        versionRegExp = QRegExp("Application to create BLAST databases, version (\\d+\\.\\d+\\.\\d+)");
+        versionRegExp = QRegularExpression("Application to create BLAST databases, version (\\d+\\.\\d+\\.\\d+)");
     } else {
         FAIL("Unsupported blast tool: " + id, );
     }

--- a/src/plugins/external_tool_support/src/bowtie/BowtieSupport.cpp
+++ b/src/plugins/external_tool_support/src/bowtie/BowtieSupport.cpp
@@ -57,7 +57,7 @@ BowtieSupport::BowtieSupport(const QString& id)
                      "Bowtie indexes the genome with a Burrows-Wheeler index to keep "
                      "its memory footprint small: typically about 2.2 GB for the human "
                      "genome (2.9 GB for paired-end).");
-    versionRegExp = QRegExp("version (\\d+\\.\\d+\\.\\d+)");
+    versionRegExp = QRegularExpression("version (\\d+\\.\\d+\\.\\d+)");
     toolKitName = "Bowtie";
 
     if (isOsWindows()) {

--- a/src/plugins/external_tool_support/src/bowtie2/Bowtie2Support.cpp
+++ b/src/plugins/external_tool_support/src/bowtie2/Bowtie2Support.cpp
@@ -39,7 +39,7 @@ Bowtie2Support::Bowtie2Support(const QString& id)
     : ExternalTool(id, "bowtie2", "") {
 
     toolKitName = "Bowtie2";
-    versionRegExp = QRegExp("version (\\d+\\.\\d+\\.\\d+[.]{0,1}[\\d+]{0,1})");
+    versionRegExp = QRegularExpression("version (\\d+\\.\\d+\\.\\d+[.]{0,1}[\\d+]{0,1})");
 
     if (id == ET_BOWTIE2_ALIGN_ID) {  // Bowtie2-align
         name = "Bowtie 2 aligner";

--- a/src/plugins/external_tool_support/src/bwa/BwaSupport.cpp
+++ b/src/plugins/external_tool_support/src/bwa/BwaSupport.cpp
@@ -42,7 +42,7 @@ BwaSupport::BwaSupport()
     description = tr("<i>Burrows-Wheeler Aligner (BWA)</i> is an efficient program "
                      "that aligns relatively short nucleotide sequences "
                      "against a long reference sequence such as the human genome.");
-    versionRegExp = QRegExp("Version: (\\d+\\.\\d+\\.\\d+-r\\d+)");
+    versionRegExp = QRegularExpression("Version: (\\d+\\.\\d+\\.\\d+-r\\d+)");
     toolKitName = "BWA";
     if (isOsWindows()) {
         pathChecks << ExternalTool::PathChecks::NonLatinArguments

--- a/src/plugins/external_tool_support/src/cap3/CAP3Support.cpp
+++ b/src/plugins/external_tool_support/src/cap3/CAP3Support.cpp
@@ -61,7 +61,7 @@ CAP3Support::CAP3Support(const QString& id, const QString& name, const QString& 
     description += tr("<br><br> Huang, X. and Madan, A.  (1999)");
     description += tr("<br>CAP3: A DNA Sequence Assembly Program,");
     description += tr("<br>Genome Research, 9: 868-877.");
-    versionRegExp = QRegExp("VersionDate: (\\d+\\/\\d+\\/\\d+)");
+    versionRegExp = QRegularExpression("VersionDate: (\\d+\\/\\d+\\/\\d+)");
     toolKitName = "CAP3";
 }
 

--- a/src/plugins/external_tool_support/src/clustalo/ClustalOSupport.cpp
+++ b/src/plugins/external_tool_support/src/clustalo/ClustalOSupport.cpp
@@ -62,7 +62,7 @@ ClustalOSupport::ClustalOSupport()
     validationArguments << "--help";
     validationMessageRegExp = "Clustal Omega";
     description = tr("<i>Clustal Omega</i> is a free sequence alignment software for proteins.");
-    versionRegExp = QRegExp("Clustal Omega - (\\d+\\.\\d+\\.\\d+).*");
+    versionRegExp = QRegularExpression("Clustal Omega - (\\d+\\.\\d+\\.\\d+).*");
     toolKitName = "ClustalO";
     if (isOsWindows()) {
         pathChecks << ExternalTool::PathChecks::NonLatinTemporaryDirPath;

--- a/src/plugins/external_tool_support/src/clustalw/ClustalWSupport.cpp
+++ b/src/plugins/external_tool_support/src/clustalw/ClustalWSupport.cpp
@@ -64,7 +64,7 @@ ClustalWSupport::ClustalWSupport()
     validationArguments << "-help";
     validationMessageRegExp = "CLUSTAL";
     description = tr("<i>ClustalW</i> is a free sequence alignment software for DNA or proteins.");
-    versionRegExp = QRegExp("CLUSTAL (\\d+\\.\\d+) Multiple Sequence Alignments");
+    versionRegExp = QRegularExpression("CLUSTAL (\\d+\\.\\d+) Multiple Sequence Alignments");
     toolKitName = "ClustalW";
     if (isOsWindows()) {
         pathChecks << ExternalTool::PathChecks::NonLatinTemporaryDirPath;

--- a/src/plugins/external_tool_support/src/cufflinks/CufflinksSupport.cpp
+++ b/src/plugins/external_tool_support/src/cufflinks/CufflinksSupport.cpp
@@ -46,7 +46,7 @@ CufflinksSupport::CufflinksSupport(const QString& id, const QString& name, const
     : ExternalTool(id, "cufflinks", name, path) {
 
     toolKitName = "Cufflinks";
-    versionRegExp = QRegExp("v(\\d+\\.\\d+\\.\\d+)");
+    versionRegExp = QRegularExpression("v(\\d+\\.\\d+\\.\\d+)");
 
     // Cuffcompare
     if (name == ET_CUFFCOMPARE) {

--- a/src/plugins/external_tool_support/src/fastqc/FastqcSupport.cpp
+++ b/src/plugins/external_tool_support/src/fastqc/FastqcSupport.cpp
@@ -48,7 +48,7 @@ FastQCSupport::FastQCSupport()
     validationMessageRegExp = "FastQC v";
     description = tr("<i>FastQC</i>: A quality control tool for high throughput sequence data.");
 
-    versionRegExp = QRegExp("FastQC v(\\d+.\\d+.\\d+)");
+    versionRegExp = QRegularExpression("FastQC v(\\d+.\\d+.\\d+)");
     toolKitName = "FastQC";
 
     toolRunnerProgram = PerlSupport::ET_PERL_ID;

--- a/src/plugins/external_tool_support/src/fasttree/FastTreeSupport.cpp
+++ b/src/plugins/external_tool_support/src/fasttree/FastTreeSupport.cpp
@@ -42,7 +42,7 @@ FastTreeSupport::FastTreeSupport()
     validationArguments << "-expert";
     validationMessageRegExp = "Detailed usage for FastTree";
     description = tr("<i>FastTree</i> builds phylogenetic trees from alignments of nucleotide or protein sequences.<br>FastTree can handle alignments with up to a million of sequences.");
-    versionRegExp = QRegExp(R"(Detailed usage for FastTree (\d+\.\d+\.\d+).*)");
+    versionRegExp = QRegularExpression(R"(Detailed usage for FastTree (\d+\.\d+\.\d+).*)");
     toolKitName = "FastTree";
 
     PhyTreeGeneratorRegistry* registry = AppContext::getPhyTreeGeneratorRegistry();

--- a/src/plugins/external_tool_support/src/hmmer/HmmerSupport.cpp
+++ b/src/plugins/external_tool_support/src/hmmer/HmmerSupport.cpp
@@ -59,7 +59,7 @@ HmmerSupport::HmmerSupport(const QString& id, const QString& name)
     : ExternalTool(id, "hmmer3", name) {
 
     toolKitName = "HMMER";
-    versionRegExp = QRegExp("HMMER (\\d+.\\d+.\\d+\\w?)");
+    versionRegExp = QRegularExpression("HMMER (\\d+.\\d+.\\d+\\w?)");
 
     if (id == BUILD_TOOL_ID) {
         initBuild();

--- a/src/plugins/external_tool_support/src/iqtree/IQTreeSupport.cpp
+++ b/src/plugins/external_tool_support/src/iqtree/IQTreeSupport.cpp
@@ -43,7 +43,7 @@ IQTreeSupport::IQTreeSupport()
     validationArguments << "--version";
     validationMessageRegExp = "IQ-TREE";
     description = tr("<i>IQ-TREE</i>  Efficient software for phylogenomic inference");
-    versionRegExp = QRegExp("IQ-TREE .* version (\\d+\\.\\d+\\.\\d+).*");
+    versionRegExp = QRegularExpression("IQ-TREE .* version (\\d+\\.\\d+\\.\\d+).*");
     toolKitName = "IQ-TREE";
 
     // register the method

--- a/src/plugins/external_tool_support/src/java/JavaSupport.cpp
+++ b/src/plugins/external_tool_support/src/java/JavaSupport.cpp
@@ -39,7 +39,7 @@ JavaSupport::JavaSupport()
 
     description += tr("Java Platform lets you develop and deploy Java applications on desktops and servers.<br><i>(Requires Java 8 or higher)</i>.<br>"
                       "Java can be freely downloaded on the official web-site: https://www.java.com/en/download/");
-    versionRegExp = QRegExp("(\\d+.\\d+.\\d+(_\\d+)?)");
+    versionRegExp = QRegularExpression("(\\d+.\\d+.\\d+(_\\d+)?)");
     toolKitName = "Java";
 
     muted = true;

--- a/src/plugins/external_tool_support/src/kalign/KalignSupport.cpp
+++ b/src/plugins/external_tool_support/src/kalign/KalignSupport.cpp
@@ -58,7 +58,7 @@ Kalign3Support::Kalign3Support()
     validationMessageRegExp = "kalign \\d+\\.\\d+\\.\\d+";
     validationArguments << "--version";
     description = tr("<i>Kalign</i> is a fast multiple sequence alignment program for biological sequences.");
-    versionRegExp = QRegExp("kalign (\\d+\\.\\d+\\.\\d+)");
+    versionRegExp = QRegularExpression("kalign (\\d+\\.\\d+\\.\\d+)");
     toolKitName = "Kalign";
 
     AppContext::getAlignmentAlgorithmsRegistry()->registerAlgorithm(new Kalign3PairwiseAlignmentAlgorithm());

--- a/src/plugins/external_tool_support/src/kraken2/Kraken2Support.cpp
+++ b/src/plugins/external_tool_support/src/kraken2/Kraken2Support.cpp
@@ -37,7 +37,7 @@ Kraken2Support::Kraken2Support()
     toolKitName = "Kraken 2";
 
     validationArguments << "--version";
-    versionRegExp = QRegExp("Kraken version (\\d+\\.\\d+(\\.\\d+)?(\\-[a-zA-Z]*)?)");
+    versionRegExp = QRegularExpression("Kraken version (\\d+\\.\\d+(\\.\\d+)?(\\-[a-zA-Z]*)?)");
     dependencies << "USUPP_PERL";
     toolRunnerProgram = "USUPP_PERL";
     executableFileName = "kraken2";

--- a/src/plugins/external_tool_support/src/mafft/MAFFTSupport.cpp
+++ b/src/plugins/external_tool_support/src/mafft/MAFFTSupport.cpp
@@ -57,7 +57,7 @@ MAFFTSupport::MAFFTSupport()
     validationArguments << "-help";
     validationMessageRegExp = "MAFFT";
     description = tr("<i>MAFFT</i> is a multiple sequence alignment program for unix-like operating systems. ");
-    versionRegExp = QRegExp("MAFFT v(\\d+\\.\\d+\\w)");
+    versionRegExp = QRegularExpression("MAFFT v(\\d+\\.\\d+\\w)");
     toolKitName = "MAFFT";
 
     AlignmentAlgorithmsRegistry* registry = AppContext::getAlignmentAlgorithmsRegistry();

--- a/src/plugins/external_tool_support/src/mfold/MfoldSupport.cpp
+++ b/src/plugins/external_tool_support/src/mfold/MfoldSupport.cpp
@@ -68,7 +68,7 @@ MfoldSupport::MfoldSupport()
 
     static const QString MFOLD_VERSION_REGEXP = "(\\d+\\.\\d+)";
     validationMessageRegExp = "mfold version " + MFOLD_VERSION_REGEXP;
-    versionRegExp = QRegExp(MFOLD_VERSION_REGEXP);
+    versionRegExp = QRegularExpression(MFOLD_VERSION_REGEXP);
 }
 
 GObjectViewWindowContext* MfoldSupport::getViewContext() const {

--- a/src/plugins/external_tool_support/src/mrbayes/MrBayesSupport.cpp
+++ b/src/plugins/external_tool_support/src/mrbayes/MrBayesSupport.cpp
@@ -63,7 +63,7 @@ MrBayesSupport::MrBayesSupport()
                      "The posterior probability distribution of trees is impossible to calculate analytically; "
                      "instead, MrBayes uses a simulation technique called Markov chain Monte Carlo (or MCMC) "
                      "to approximate the posterior probabilities of trees.");
-    versionRegExp = QRegExp("MrBayes v(\\d+\\.\\d+\\.\\d+)");
+    versionRegExp = QRegularExpression("MrBayes v(\\d+\\.\\d+\\.\\d+)");
     toolKitName = "MrBayes";
 
     // register the method

--- a/src/plugins/external_tool_support/src/perl/PerlSupport.cpp
+++ b/src/plugins/external_tool_support/src/perl/PerlSupport.cpp
@@ -44,7 +44,7 @@ PerlSupport::PerlSupport()
     validationArguments << "--version";
 
     description += tr("Perl scripts interpreter");
-    versionRegExp = QRegExp("(\\d+.\\d+.\\d+)");
+    versionRegExp = QRegularExpression("(\\d+.\\d+.\\d+)");
     toolKitName = "perl";
 
     muted = true;

--- a/src/plugins/external_tool_support/src/phyml/PhyMLSupport.cpp
+++ b/src/plugins/external_tool_support/src/phyml/PhyMLSupport.cpp
@@ -41,7 +41,7 @@ PhyMLSupport::PhyMLSupport()
     validationArguments << "--help";
     validationMessageRegExp = "PhyML";
     description = tr("<i>PhyML</i> is a simple, fast, and accurate algorithm to estimate large phylogenies by maximum likelihood");
-    versionRegExp = QRegExp("- PhyML (\\d+(\\.\\d+)*)");
+    versionRegExp = QRegularExpression("- PhyML (\\d+(\\.\\d+)*)");
     toolKitName = "PhyML";
 
     // register the method

--- a/src/plugins/external_tool_support/src/python/Python3ModuleCutadaptSupport.cpp
+++ b/src/plugins/external_tool_support/src/python/Python3ModuleCutadaptSupport.cpp
@@ -45,7 +45,7 @@ Python3ModuleCutadaptSupport::Python3ModuleCutadaptSupport()
     toolKitName = "python3";
     dependencies << Python3Support::ET_PYTHON_ID;
     validationMessageRegExp = "(\\d+.\\d+)";
-    versionRegExp = QRegExp(validationMessageRegExp);
+    versionRegExp = QRegularExpression(validationMessageRegExp);
     executableFileName = "cutadapt";
     muted = true;
 

--- a/src/plugins/external_tool_support/src/python/Python3Support.cpp
+++ b/src/plugins/external_tool_support/src/python/Python3Support.cpp
@@ -42,7 +42,7 @@ Python3Support::Python3Support()
     validationArguments << "--version";
 
     description += tr("Python scripts interpreter");
-    versionRegExp = QRegExp(PYTHON_VERSION_REGEXP);
+    versionRegExp = QRegularExpression(PYTHON_VERSION_REGEXP);
     toolKitName = "python3";
 
     muted = true;

--- a/src/plugins/external_tool_support/src/samtools/BcfToolsSupport.cpp
+++ b/src/plugins/external_tool_support/src/samtools/BcfToolsSupport.cpp
@@ -39,7 +39,7 @@ BcfToolsSupport::BcfToolsSupport()
 
     validationMessageRegExp = "bcftools \\(Tools for data in the VCF/BCF formats\\)";
     description = "<i>BCFtools</i> is a set of utilities for data in the VCF/BCF formats";
-    versionRegExp = QRegExp("Version: (\\d+.\\d+.\\d+)");
+    versionRegExp = QRegularExpression("Version: (\\d+.\\d+.\\d+)");
 
     toolKitName = "SAMtools";
 

--- a/src/plugins/external_tool_support/src/samtools/SamToolsExtToolSupport.cpp
+++ b/src/plugins/external_tool_support/src/samtools/SamToolsExtToolSupport.cpp
@@ -46,7 +46,7 @@ SamToolsExtToolSupport::SamToolsExtToolSupport()
     description = "<i>SAMtools</i> is a set of utilities for interacting"
                   " with and post-processing short DNA sequence read alignments."
                   " This external tool is required to run <i>TopHat</i> external tool.";
-    versionRegExp = QRegExp("Version: (\\d+.\\d+.\\d+)");
+    versionRegExp = QRegularExpression("Version: (\\d+.\\d+.\\d+)");
 
     toolKitName = "SAMtools";
 

--- a/src/plugins/external_tool_support/src/samtools/TabixSupport.cpp
+++ b/src/plugins/external_tool_support/src/samtools/TabixSupport.cpp
@@ -45,7 +45,7 @@ TabixSupport::TabixSupport()
     validationArguments << "-help";
     validationMessageRegExp = "tabix";
     description = tr("<i>Tabix</i> is a generic indexer for TAB-delimited genome position files");
-    versionRegExp = QRegExp("Version: (\\d+.\\d+.\\d+)");
+    versionRegExp = QRegularExpression("Version: (\\d+.\\d+.\\d+)");
     toolKitName = "SAMtools";
 }
 

--- a/src/plugins/external_tool_support/src/snpeff/SnpEffSupport.cpp
+++ b/src/plugins/external_tool_support/src/snpeff/SnpEffSupport.cpp
@@ -49,7 +49,7 @@ SnpEffSupport::SnpEffSupport()
     validationMessageRegExp = "Usage: snpEff \\[command\\] \\[options\\] \\[files\\]";
     description = tr("<i>SnpEff</i>: Genetic variant annotation and effect prediction toolbox.");
 
-    versionRegExp = QRegExp("version SnpEff (\\d+.\\d+)");
+    versionRegExp = QRegularExpression("version SnpEff (\\d+.\\d+)");
     validationArguments << "-h";
     toolKitName = "SnpEff";
 

--- a/src/plugins/external_tool_support/src/spades/SpadesSupport.cpp
+++ b/src/plugins/external_tool_support/src/spades/SpadesSupport.cpp
@@ -49,7 +49,7 @@ SpadesSupport::SpadesSupport()
     validationMessageRegExp = "SPAdes";
     description = tr("<i>SPAdes</i> - St. Petersburg genome assembler - is intended for both standard isolates and single-cell MDA bacteria assemblies. Official site: http://bioinf.spbau.ru/spades");
     validationArguments << "--version";
-    versionRegExp = QRegExp("SPAdes.* v(\\d+.\\d+.\\d+)");
+    versionRegExp = QRegularExpression("SPAdes.* v(\\d+.\\d+.\\d+)");
     toolKitName = "SPAdes";
 
     toolRunnerProgram = Python3Support::ET_PYTHON_ID;

--- a/src/plugins/external_tool_support/src/stringtie/StringTieSupport.cpp
+++ b/src/plugins/external_tool_support/src/stringtie/StringTieSupport.cpp
@@ -42,7 +42,7 @@ StringTieSupport::StringTieSupport()
                      "but also alignments longer sequences that have been assembled "
                      "from those reads.");
 
-    versionRegExp = QRegExp("StringTie v(\\d+.\\d+.\\d+[a-zA-Z]?)");
+    versionRegExp = QRegularExpression("StringTie v(\\d+.\\d+.\\d+[a-zA-Z]?)");
     validationArguments << "-h";
     toolKitName = "StringTie";
 }

--- a/src/plugins/external_tool_support/src/tophat/TopHatSupport.cpp
+++ b/src/plugins/external_tool_support/src/tophat/TopHatSupport.cpp
@@ -55,7 +55,7 @@ TopHatSupport::TopHatSupport()
                   "<br>TopHat is not officially supported today and is not compatible with the latest Bowtie versions."
                   "<br>The old and compatible versions of Bowtie1 and Bowtie2 must be placed "
                   "into the 'bowtie1' and 'bowtie2' sub-folders of the TopHat to be used by default.";
-    versionRegExp = QRegExp("(\\d+.\\d+.\\d+\\w?)");
+    versionRegExp = QRegularExpression("(\\d+.\\d+.\\d+\\w?)");
     toolKitName = "TopHat";
 
     muted = true;

--- a/src/plugins/external_tool_support/src/utils/ExternalToolValidateTask.cpp
+++ b/src/plugins/external_tool_support/src/utils/ExternalToolValidateTask.cpp
@@ -257,22 +257,23 @@ bool ExternalToolJustValidateTask::parseLog(const ExternalToolValidation& valida
 }
 
 void ExternalToolJustValidateTask::checkVersion(const QString& partOfLog) {
-    if (checkVersionRegExp.isEmpty()) {
+    if (checkVersionRegExp.pattern().isEmpty()) {
         version = tool->getVersionFromToolPath(toolPath);
         if (version.isEmpty()) {
             version = tool->getPredefinedVersion();
         }
     } else {
-        QStringList lastPartOfLog = partOfLog.split(QRegExp("(\n|\r)"));
-        foreach (QString buf, lastPartOfLog) {
-            if (buf.contains(checkVersionRegExp)) {
-                checkVersionRegExp.indexIn(buf);
-                version = checkVersionRegExp.cap(1);
+        QStringList lastPartOfLog = partOfLog.split(QRegularExpression("[\n\r]"));
+        for (const QString& buf : lastPartOfLog) {
+            QRegularExpressionMatch match = checkVersionRegExp.match(buf);
+            if (match.hasMatch()) {
+                version = match.captured(1);
                 return;
             }
         }
     }
 }
+
 
 void ExternalToolJustValidateTask::checkArchitecture(const QString& toolPath) {
     Q_UNUSED(toolPath);

--- a/src/plugins/external_tool_support/src/utils/ExternalToolValidateTask.h
+++ b/src/plugins/external_tool_support/src/utils/ExternalToolValidateTask.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <QProcess>
+#include <QRegularExpression>
 
 #include <U2Core/MultiTask.h>
 #include <U2Core/Task.h>
@@ -90,7 +91,7 @@ private:
 
     QList<ExternalToolValidation> validations;  // original tool validation is the last one
 
-    QRegExp checkVersionRegExp;
+    QRegularExpression checkVersionRegExp;
 
     QString lastErrLine;
     QString lastOutLine;


### PR DESCRIPTION
Рефакторинг в рамках перехода на Qt6. Чтобы не создавать один громадный PR, как это было с dark mode, буду делать маленькими кусочками. В данном PR предсталена замена устаревшего `QRegExp`, который окончательно вырезан в Qt6, на современный `QRegularExpression` в corelib'ах