### PR TITLE
Add timeout branch

### DIFF
--- a/etc/script/mac/release.sh
+++ b/etc/script/mac/release.sh
@@ -178,6 +178,8 @@ while [ $SECONDS -lt $END_TIME ]; do
         exit 1
     elif echo "${NOTARYTOOL_JOB_INFO_OUTPUT}" | grep -q "status: In Progress"; then
         echo "Notarization still in progress..."
+    elif echo "${NOTARYTOOL_JOB_INFO_OUTPUT}" | grep -q "The request timed out"; then
+        echo "Network timeout while checking notarization status. Retrying..."
     else
         echo "Unexpected output. Exiting."
         exit 1


### PR DESCRIPTION
При проверке нотаризации иногда пробивает такое сообщение:

```
Error: HTTPError(statusCode: nil, error: Error Domain=NSURLErrorDomain Code=-1001 "The request timed out." UserInfo={_kCFStreamErrorCodeKey=60, NSUnderlyingError=0x6000001794a0 {Error Domain=kCFErrorDomainCFNetwork Code=-1001 "(null)" UserInfo={_NSURLErrorNWPathKey=satisfied (Path is satisfied), interface: en0, ipv4, dns, _kCFStreamErrorCodeKey=60, _kCFStreamErrorDomainKey=1}}, _NSURLErrorFailingURLSessionTaskErrorKey=LocalDataTask <7456D6ED-57FE-4331-9518-8510ACCAAFF5>.<1>, _NSURLErrorRelatedURLSessionTaskErrorKey=(
[11:41:27 ](http://ugene-teamcity.unipro.ru:8111/ugene-teamcity/buildConfiguration/ReleaseMacIntelDmg/393171?expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildProblemsSection=true&showLog=393171_352_352&logView=flowAware)        "LocalDataTask <7456D6ED-57FE-4331-9518-8510ACCAAFF5>.<1>"
[11:41:27 ](http://ugene-teamcity.unipro.ru:8111/ugene-teamcity/buildConfiguration/ReleaseMacIntelDmg/393171?expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildProblemsSection=true&showLog=393171_353_353&logView=flowAware)    ), NSLocalizedDescription=The request timed out., NSErrorFailingURLStringKey=https://appstoreconnect.apple.com/notary/v2/asp?, NSErrorFailingURLKey=https://appstoreconnect.apple.com/notary/v2/asp?, _kCFStreamErrorDomainKey=1})
```

Я поисследовал - это не проблема нотаризации, иногда сервер Apple может не ответить на запрос, рекомендуют просто по таймауту повторить реквест. А у нас сейчас этот случай не обработан и нотаризация сразу падает, что создает неудобства. Предлагаю немного проапдейтить скрипт