### PR TITLE
1835 some layout shift on macos

### DIFF
--- a/etc/script/mac/dmg/Info.plist
+++ b/etc/script/mac/dmg/Info.plist
@@ -51,6 +51,9 @@
     <key>NSRequiresAquaSystemAppearance</key>
     <true/>
     
+    <key>UIDesignRequiresCompatibility</key>
+    <true/>
+
     <key>CFBundleDocumentTypes</key>
     <array>
         <!-- Project -->

--- a/etc/script/mac/release.sh
+++ b/etc/script/mac/release.sh
@@ -168,7 +168,7 @@ echo "##teamcity[blockClosed name='Notarize']"
 echo "##teamcity[blockOpened name='Check Notarization']"
 END_TIME=$((SECONDS+1200))  # 1200 seconds = 20 minutes
 while [ $SECONDS -lt $END_TIME ]; do
-    NOTARYTOOL_JOB_INFO_OUTPUT=$(xcrun notarytool info "${NOTARYTOOL_JOB_UUID}" --keychain-profile "UGENE")
+    NOTARYTOOL_JOB_INFO_OUTPUT=$(xcrun notarytool info "${NOTARYTOOL_JOB_UUID}" --keychain-profile "UGENE" 2>&1)
     echo "Notary tool job info output: ${NOTARYTOOL_JOB_INFO_OUTPUT}"
     if echo "${NOTARYTOOL_JOB_INFO_OUTPUT}" | grep -q "status: Accepted"; then
         echo "Notarization successful!"

--- a/src/plugins/enzymes/src/enzymes_dialog/EnzymesSelectorWidget.cpp
+++ b/src/plugins/enzymes/src/enzymes_dialog/EnzymesSelectorWidget.cpp
@@ -57,6 +57,9 @@ EnzymesSelectorWidget::EnzymesSelectorWidget(QWidget* parent)
     : QWidget(parent) {
     setupUi(this);
 
+    selectEnzymeInfoLabel->setMinimumHeight(loadSelectionButton->height());
+    checkedEnzymesLabel->setMinimumHeight(loadSelectionButton->height());
+
     filterComboBox->addItem(tr("name"), FILTER_BY_NAME);
     filterComboBox->addItem(tr("sequence"), FILTER_BY_SEQUENCE);
 

--- a/src/plugins/enzymes/src/enzymes_dialog/EnzymesSelectorWidget.cpp
+++ b/src/plugins/enzymes/src/enzymes_dialog/EnzymesSelectorWidget.cpp
@@ -57,9 +57,6 @@ EnzymesSelectorWidget::EnzymesSelectorWidget(QWidget* parent)
     : QWidget(parent) {
     setupUi(this);
 
-    selectEnzymeInfoLabel->setMinimumHeight(loadSelectionButton->height());
-    checkedEnzymesLabel->setMinimumHeight(loadSelectionButton->height());
-
     filterComboBox->addItem(tr("name"), FILTER_BY_NAME);
     filterComboBox->addItem(tr("sequence"), FILTER_BY_SEQUENCE);
 

--- a/src/plugins/enzymes/src/enzymes_dialog/EnzymesSelectorWidget.ui
+++ b/src/plugins/enzymes/src/enzymes_dialog/EnzymesSelectorWidget.ui
@@ -194,7 +194,7 @@
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_3">
           <item>
-           <widget class="QLabel" name="label">
+           <widget class="QLabel" name="checkedEnzymesLabel">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -270,7 +270,7 @@
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_6">
           <item>
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="selectEnzymeInfoLabel">
             <property name="text">
              <string>Selected enzyme info</string>
             </property>

--- a/src/plugins/enzymes/src/enzymes_dialog/EnzymesSelectorWidget.ui
+++ b/src/plugins/enzymes/src/enzymes_dialog/EnzymesSelectorWidget.ui
@@ -194,7 +194,7 @@
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_3">
           <item>
-           <widget class="QLabel" name="checkedEnzymesLabel">
+           <widget class="QLabel" name="label">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -270,7 +270,7 @@
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_6">
           <item>
-           <widget class="QLabel" name="selectEnzymeInfoLabel">
+           <widget class="QLabel" name="label_3">
             <property name="text">
              <string>Selected enzyme info</string>
             </property>

--- a/src/plugins/enzymes/src/enzymes_dialog/EnzymesSelectorWidget.ui
+++ b/src/plugins/enzymes/src/enzymes_dialog/EnzymesSelectorWidget.ui
@@ -209,7 +209,7 @@
           <item>
            <widget class="QPushButton" name="saveSelectionButton">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>


### PR DESCRIPTION
Из-за того, что мы используем устаревшее Qt, некоторые элементы интерфейса смотрятся так себе на маке - например, вылезают за границы и обрезаются, как с кнопками Save и Load в диалоге сайтов рестрикции. Правильное решение проблемы - переход на Qt6.5+. Т.к. пока что это не планируется, добавляю флаг `UIDesignRequiresCompatibility`, который фиксит эту проблему, отображая виджеты в режиме совместимости. Собрал релизный билд и проверил - визуально действительно проблема исправилось.
Недоработку с разной высотой `Text edit`'ов исправить легким движением руки не получится. Проблема в том, что шапка левого `Text edit`'а содержит кнопки, которые увеличивают высоту шапки, тем самым уменьшая высоту `Text edit`. Если поместить их в `GridLayout`, то потеряется сплиттер между левой и правой колонкой, а он бывает удобен, например, если в левом `Text edit`'е информации мало, в а правом - много (или наоборот), то их ширины можно сдвинуть. А оно еще и на разных системах по разному отображается, поэтому, захардкодить какие-то значения сложно, нужно писать какой-то eventFilter, который будет отслеживать resize - короче, слишком сложно получается для такой маленькой проблемы, решил оставить как есть.
Дополнительно подправил скрипт, т.к. информация "The request timed out" писалась в stderr, а проверялся только sdtout, а фикс объединил их.