### PR TITLE
1891 remove SaveMultipleDocumentsTask from U2Core and move it to U2Gui

### DIFF
--- a/src/corelibs/U2Core/src/tasks/ModifySequenceObjectTask.cpp
+++ b/src/corelibs/U2Core/src/tasks/ModifySequenceObjectTask.cpp
@@ -21,7 +21,6 @@
 
 #include "ModifySequenceObjectTask.h"
 
-#include <U2Core/AddDocumentTask.h>
 #include <U2Core/AnnotationTableObject.h>
 #include <U2Core/AppContext.h>
 #include <U2Core/Counter.h>
@@ -89,7 +88,7 @@ Task::ReportResult ModifySequenceContentTask::report() {
         IOAdapterFactory* iof = AppContext::getIOAdapterRegistry()->getIOAdapterFactoryById(IOAdapterUtils::url2io(url));
         tasks.append(new SaveDocumentTask(seqObj->getDocument(), iof, url.getURLString()));
         if (project != nullptr) {
-            tasks.append(new AddDocumentTask(newDoc));
+            project->addDocument(newDoc);
         }
         AppContext::getTaskScheduler()->registerTopLevelTask(new MultiTask("Save document and add it to project (optional)", tasks));
     }

--- a/src/corelibs/U2Core/src/tasks/SaveDocumentTask.cpp
+++ b/src/corelibs/U2Core/src/tasks/SaveDocumentTask.cpp
@@ -68,7 +68,7 @@ void SaveDocumentTask::addFlag(SaveDocFlag f) {
 }
 
 void SaveDocumentTask::prepare() {
-    if (!FileAndDirectoryUtils::isNoWritePermission(url)) {
+    if (FileAndDirectoryUtils::isNoWritePermission(url)) {
         stateInfo.setError(tr("No permission to write to '%1' file.").arg(url.getURLString()));
         return;
     }

--- a/src/corelibs/U2Core/src/tasks/SaveDocumentTask.cpp
+++ b/src/corelibs/U2Core/src/tasks/SaveDocumentTask.cpp
@@ -68,7 +68,7 @@ void SaveDocumentTask::addFlag(SaveDocFlag f) {
 }
 
 void SaveDocumentTask::prepare() {
-    if (isNoWritePermission(url)) {
+    if (!FileAndDirectoryUtils::canWriteToPath(url.dirPath())) {
         stateInfo.setError(tr("No permission to write to '%1' file.").arg(url.getURLString()));
         return;
     }
@@ -198,13 +198,6 @@ QVariantMap SaveDocumentTask::getOpenDocumentWithProjectHints() const {
 /** Sets new 'openDocumentWithProjectHints'. See 'openDocumentWithProjectHints' for details. */
 void SaveDocumentTask::setOpenDocumentWithProjectHints(const QVariantMap& hints) {
     openDocumentWithProjectHints = hints;
-}
-
-bool SaveDocumentTask::isNoWritePermission(GUrl& url) {
-    if (!QFile::exists(url.getURLString())) {
-        return !FileAndDirectoryUtils::isDirectoryWritable(url.dirPath());
-    }
-    return !QFile::permissions(url.getURLString()).testFlag(QFile::WriteUser);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/corelibs/U2Core/src/tasks/SaveDocumentTask.cpp
+++ b/src/corelibs/U2Core/src/tasks/SaveDocumentTask.cpp
@@ -68,7 +68,7 @@ void SaveDocumentTask::addFlag(SaveDocFlag f) {
 }
 
 void SaveDocumentTask::prepare() {
-    if (!FileAndDirectoryUtils::canWriteToPath(url.dirPath())) {
+    if (!FileAndDirectoryUtils::isNoWritePermission(url)) {
         stateInfo.setError(tr("No permission to write to '%1' file.").arg(url.getURLString()));
         return;
     }

--- a/src/corelibs/U2Core/src/tasks/SaveDocumentTask.cpp
+++ b/src/corelibs/U2Core/src/tasks/SaveDocumentTask.cpp
@@ -22,7 +22,6 @@
 #include "SaveDocumentTask.h"
 
 #include <QApplication>
-#include <QFileDialog>
 #include <QMessageBox>
 #include <QPushButton>
 
@@ -43,13 +42,6 @@
 #include <U2Core/U2SafePoints.h>
 
 namespace U2 {
-
-static bool isNoWritePermission(GUrl& url) {
-    if (!QFile::exists(url.getURLString())) {
-        return !FileAndDirectoryUtils::isDirectoryWritable(url.dirPath());
-    }
-    return !QFile::permissions(url.getURLString()).testFlag(QFile::WriteUser);
-}
 
 SaveDocumentTask::SaveDocumentTask(Document* _doc, IOAdapterFactory* _io, const GUrl& _url, SaveDocFlags _flags)
     : Task(tr("Save document"), TaskFlag_None), doc(_doc), iof(_io), url(_url), flags(_flags) {
@@ -208,112 +200,11 @@ void SaveDocumentTask::setOpenDocumentWithProjectHints(const QVariantMap& hints)
     openDocumentWithProjectHints = hints;
 }
 
-//////////////////////////////////////////////////////////////////////////
-/// save multiple
-
-SaveMultipleDocuments::SaveMultipleDocuments(const QList<Document*>& docs, bool askBeforeSave, SavedNewDocFlag saveAndOpenFlag)
-    : Task(tr("Save multiple documents"), TaskFlags_NR_FOSE_COSC) {
-    bool saveAll = false;
-    foreach (Document* doc, docs) {
-        bool save = true;
-        if (askBeforeSave) {
-            QMessageBox::StandardButtons buttons = QMessageBox::StandardButtons(QMessageBox::Yes) | QMessageBox::No | QMessageBox::Cancel;
-            if (docs.size() > 1) {
-                buttons = buttons | QMessageBox::YesToAll | QMessageBox::NoToAll;
-            }
-
-            QObjectScopedPointer<QMessageBox> messageBox(new QMessageBox(QMessageBox::Question,
-                                                                         tr("Question?"),
-                                                                         tr("Save document: %1").arg(doc->getURLString()),
-                                                                         buttons,
-                                                                         QApplication::activeWindow()));
-
-            int res = saveAll ? QMessageBox::YesToAll : messageBox->exec();
-
-            if (res == QMessageBox::NoToAll) {
-                break;
-            }
-            if (res == QMessageBox::YesToAll) {
-                saveAll = true;
-            }
-            if (res == QMessageBox::No) {
-                save = false;
-            }
-            if (res == QMessageBox::Cancel) {
-                cancel();
-                break;
-            }
-        }
-        if (save) {
-            GUrl url = doc->getURL();
-            if (isNoWritePermission(url)) {
-                url = chooseAnotherUrl(doc);
-                if (!url.isEmpty()) {
-                    if (saveAndOpenFlag == SavedNewDoc_Open) {
-                        addSubTask(new SaveDocumentTask(doc, doc->getIOAdapterFactory(), url, SaveDocFlags(SaveDoc_DestroyAfter | SaveDoc_OpenAfter)));
-                    } else {
-                        addSubTask(new SaveDocumentTask(doc, doc->getIOAdapterFactory(), url));
-                    }
-                }
-            } else {
-                addSubTask(new SaveDocumentTask(doc));
-            }
-        }
+bool SaveDocumentTask::isNoWritePermission(GUrl& url) {
+    if (!QFile::exists(url.getURLString())) {
+        return !FileAndDirectoryUtils::isDirectoryWritable(url.dirPath());
     }
-}
-
-QList<Document*> SaveMultipleDocuments::findModifiedDocuments(const QList<Document*>& docs) {
-    QList<Document*> res;
-    foreach (Document* doc, docs) {
-        if (doc->isTreeItemModified()) {
-            res.append(doc);
-        }
-    }
-    return res;
-}
-
-GUrl SaveMultipleDocuments::chooseAnotherUrl(Document* doc) {
-    GUrl url;
-    do {
-        QObjectScopedPointer<QMessageBox> msgBox = new QMessageBox;
-        msgBox->setIcon(QMessageBox::Warning);
-        msgBox->setWindowTitle(U2_APP_TITLE);
-
-        msgBox->setText(tr("You have no permission to write to '%1' file.\nUGENE contains unsaved modifications.").arg(doc->getURL().fileName()));
-        msgBox->setInformativeText(tr("Do you want to save changes to another file?"));
-
-        QPushButton* saveButton = msgBox->addButton(QMessageBox::Save);
-        QPushButton* cancelButton = msgBox->addButton(QMessageBox::Cancel);
-        msgBox->setDefaultButton(saveButton);
-        msgBox->setObjectName("permissionBox");
-        msgBox->exec();
-        CHECK(!msgBox.isNull(), url);
-
-        if (msgBox->clickedButton() == saveButton) {
-            QString newFileUrl = GUrlUtils::rollFileName(doc->getURLString(), "_modified_", DocumentUtils::getNewDocFileNameExcludesHint());
-            QString saveFileFilter = doc->getDocumentFormat()->getSupportedDocumentFileExtensions().join(" *.").prepend("*.");
-            auto activeWindow = qobject_cast<QWidget*>(QApplication::activeWindow());
-            QFileDialog::Options options(qgetenv(ENV_GUI_TEST).toInt() == 1 && qgetenv(ENV_USE_NATIVE_DIALOGS).toInt() == 0 ? QFileDialog::DontUseNativeDialog : 0);
-            const QString fileName = QFileDialog::getSaveFileName(activeWindow, tr("Save as"), newFileUrl, saveFileFilter, 0, options);
-            if (isOsMac()) {
-                activeWindow->activateWindow();
-            }
-            if (!fileName.isEmpty()) {
-                url = fileName;
-            } else {  // Cancel in "Save as" dialog clicked
-                cancel();
-                break;
-            }
-        } else if (msgBox->clickedButton() == cancelButton) {
-            cancel();
-            break;
-        } else {
-            return GUrl();
-        }
-
-    } while (isNoWritePermission(url));
-
-    return url;
+    return !QFile::permissions(url.getURLString()).testFlag(QFile::WriteUser);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/corelibs/U2Core/src/tasks/SaveDocumentTask.h
+++ b/src/corelibs/U2Core/src/tasks/SaveDocumentTask.h
@@ -83,9 +83,6 @@ public:
     /** Sets new 'openDocumentWithProjectHints'. See 'openDocumentWithProjectHints' for details. */
     void setOpenDocumentWithProjectHints(const QVariantMap& hints);
 
-    // Returns true if there is no write permission for the given url.
-    static bool isNoWritePermission(GUrl& url);
-
 private:
     StateLock* lock = nullptr;
     QPointer<Document> doc;

--- a/src/corelibs/U2Core/src/tasks/SaveDocumentTask.h
+++ b/src/corelibs/U2Core/src/tasks/SaveDocumentTask.h
@@ -83,6 +83,9 @@ public:
     /** Sets new 'openDocumentWithProjectHints'. See 'openDocumentWithProjectHints' for details. */
     void setOpenDocumentWithProjectHints(const QVariantMap& hints);
 
+    // Returns true if there is no write permission for the given url.
+    static bool isNoWritePermission(GUrl& url);
+
 private:
     StateLock* lock = nullptr;
     QPointer<Document> doc;
@@ -98,17 +101,6 @@ private:
 enum SavedNewDocFlag {
     SavedNewDoc_Open = true,
     SavedNewDoc_DoNotOpen = false
-};
-
-class U2CORE_EXPORT SaveMultipleDocuments : public Task {
-    Q_OBJECT
-public:
-    SaveMultipleDocuments(const QList<Document*>& docs, bool askBeforeSave, SavedNewDocFlag openFlag = SavedNewDoc_DoNotOpen);
-
-    static QList<Document*> findModifiedDocuments(const QList<Document*>& docs);
-
-private:
-    GUrl chooseAnotherUrl(Document* doc);
 };
 
 class U2CORE_EXPORT SaveCopyAndAddToProjectTask : public Task {

--- a/src/corelibs/U2Core/src/util/FileAndDirectoryUtils.cpp
+++ b/src/corelibs/U2Core/src/util/FileAndDirectoryUtils.cpp
@@ -227,6 +227,13 @@ NP<FILE> FileAndDirectoryUtils::openFile(const QString& fileUrl, const QString& 
 #endif
 }
 
+bool FileAndDirectoryUtils::isNoWritePermission(GUrl& url) {
+    if (!QFile::exists(url.getURLString())) {
+        return !FileAndDirectoryUtils::isDirectoryWritable(url.dirPath());
+    }
+    return !QFile::permissions(url.getURLString()).testFlag(QFile::WriteUser);
+}
+
 bool FileAndDirectoryUtils::createWritableDirIfNotExists(const QString& dirPath) {
     QDir dir(dirPath);
     if (!dir.exists()) {

--- a/src/corelibs/U2Core/src/util/FileAndDirectoryUtils.h
+++ b/src/corelibs/U2Core/src/util/FileAndDirectoryUtils.h
@@ -73,6 +73,10 @@ public:
      */
     static NP<FILE> openFile(const QString& path, const QString& mode);
 
+    // Return true if you have no write permission to the file (if @url points to file)
+    // or if you have no write permission to the folder (if @url points to folder)
+    static bool isNoWritePermission(GUrl& url);
+
 private:
     static QString getFormatId(const FormatDetectionResult& r);
 

--- a/src/corelibs/U2Designer/src/DatasetWidget.cpp
+++ b/src/corelibs/U2Designer/src/DatasetWidget.cpp
@@ -26,7 +26,6 @@
 #include <QInputDialog>
 #include <QMessageBox>
 
-#include <U2Core/AddDocumentTask.h>
 #include <U2Core/AppContext.h>
 #include <U2Core/ProjectModel.h>
 #include <U2Core/ProjectTreeControllerModeSettings.h>
@@ -36,6 +35,7 @@
 
 #include <U2Designer/DatasetsController.h>
 
+#include <U2Gui/AddDocumentTask.h>
 #include <U2Gui/GUIUtils.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/MainWindow.h>

--- a/src/corelibs/U2Formats/src/apr/AprImporter.cpp
+++ b/src/corelibs/U2Formats/src/apr/AprImporter.cpp
@@ -31,7 +31,6 @@
 #include <U2Core/MsaObject.h>
 #include <U2Core/ProjectModel.h>
 #include <U2Core/QObjectScopedPointer.h>
-#include <U2Core/RemoveDocumentTask.h>
 #include <U2Core/SaveDocumentTask.h>
 #include <U2Core/Timer.h>
 #include <U2Core/U2DbiRegistry.h>
@@ -43,6 +42,7 @@
 
 #include <U2Gui/ImportWidget.h>
 #include <U2Gui/ProjectView.h>
+#include <U2Gui/RemoveDocumentTask.h>
 
 namespace U2 {
 

--- a/src/corelibs/U2Gui/src/AddDocumentTask.cpp
+++ b/src/corelibs/U2Gui/src/AddDocumentTask.cpp
@@ -24,8 +24,9 @@
 #include <U2Core/AppContext.h>
 #include <U2Core/DocumentProviderTask.h>
 #include <U2Core/ProjectModel.h>
-#include <U2Core/RemoveDocumentTask.h>
 #include <U2Core/U2SafePoints.h>
+
+#include <U2Gui/RemoveDocumentTask.h>
 
 namespace U2 {
 

--- a/src/corelibs/U2Gui/src/AddDocumentTask.h
+++ b/src/corelibs/U2Gui/src/AddDocumentTask.h
@@ -1,0 +1,61 @@
+/**
+ * UGENE - Integrated Bioinformatics Tools.
+ * Copyright (C) 2008-2025 UniPro <ugene@unipro.ru>
+ * http://ugene.net
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include <U2Core/DocumentModel.h>
+#include <U2Core/Task.h>
+
+namespace U2 {
+
+class Document;
+class DocumentProviderTask;
+
+class AddDocumentTaskConfig {
+public:
+    AddDocumentTaskConfig()
+        : createProjectIfNeeded(true), unloadExistingDocument(false) {
+    }
+
+    bool createProjectIfNeeded;
+    bool unloadExistingDocument;
+};
+/**  Adds document to active project. Waits for locks if any */
+class U2GUI_EXPORT AddDocumentTask : public Task {
+    Q_OBJECT
+public:
+    AddDocumentTask(Document* d, const AddDocumentTaskConfig& c = AddDocumentTaskConfig());
+    AddDocumentTask(DocumentProviderTask* dp, const AddDocumentTaskConfig& c = AddDocumentTaskConfig());
+
+    ReportResult report() override;
+
+    QList<Task*> onSubTaskFinished(Task* subTask) override;
+    Document* getDocument() {
+        return document;
+    }
+
+private:
+    Document* document;
+    DocumentProviderTask* dpt;
+    AddDocumentTaskConfig conf;
+};
+
+}  // namespace U2

--- a/src/corelibs/U2Gui/src/ModifySequenceObjectTask.cpp
+++ b/src/corelibs/U2Gui/src/ModifySequenceObjectTask.cpp
@@ -40,6 +40,8 @@
 #include <U2Core/U2SafePoints.h>
 #include <U2Core/U2SequenceUtils.h>
 
+#include <U2Gui/AddDocumentTask.h>
+
 namespace U2 {
 
 typedef QPair<QString, QString> QStrStrPair;
@@ -88,7 +90,7 @@ Task::ReportResult ModifySequenceContentTask::report() {
         IOAdapterFactory* iof = AppContext::getIOAdapterRegistry()->getIOAdapterFactoryById(IOAdapterUtils::url2io(url));
         tasks.append(new SaveDocumentTask(seqObj->getDocument(), iof, url.getURLString()));
         if (project != nullptr) {
-            project->addDocument(newDoc);
+            tasks.append(new AddDocumentTask(newDoc));
         }
         AppContext::getTaskScheduler()->registerTopLevelTask(new MultiTask("Save document and add it to project (optional)", tasks));
     }

--- a/src/corelibs/U2Gui/src/ModifySequenceObjectTask.h
+++ b/src/corelibs/U2Gui/src/ModifySequenceObjectTask.h
@@ -30,7 +30,7 @@ namespace U2 {
 
 class Document;
 
-class U2CORE_EXPORT ModifySequenceContentTask : public Task {
+class U2GUI_EXPORT ModifySequenceContentTask : public Task {
     Q_OBJECT
 public:
     ModifySequenceContentTask(const DocumentFormatId& dfId, U2SequenceObject* seqObj, const U2Region& regionToReplace, const DNASequence& sequence2Insert, bool recalculateQualifiers = false, U1AnnotationUtils::AnnotationStrategyForResize _str = U1AnnotationUtils::AnnotationStrategyForResize_Resize, const GUrl& url = GUrl(), bool mergeAnnotations = false);

--- a/src/corelibs/U2Gui/src/OpenViewTask.h
+++ b/src/corelibs/U2Gui/src/OpenViewTask.h
@@ -21,9 +21,10 @@
 
 #pragma once
 
-#include <U2Core/AddDocumentTask.h>
 #include <U2Core/GUrl.h>
 #include <U2Core/Task.h>
+
+#include <U2Gui/AddDocumentTask.h>
 
 namespace U2 {
 

--- a/src/corelibs/U2Gui/src/RemoveDocumentTask.cpp
+++ b/src/corelibs/U2Gui/src/RemoveDocumentTask.cpp
@@ -26,7 +26,7 @@
 #include <U2Core/GHints.h>
 #include <U2Core/ProjectModel.h>
 
-#include "SaveDocumentTask.h"
+#include <U2Gui/SaveMultipleDocumentTask.h>
 
 namespace U2 {
 

--- a/src/corelibs/U2Gui/src/RemoveDocumentTask.h
+++ b/src/corelibs/U2Gui/src/RemoveDocumentTask.h
@@ -31,7 +31,7 @@ class Document;
 class Project;
 class StateLock;
 
-class U2CORE_EXPORT RemoveMultipleDocumentsTask : public Task {
+class U2GUI_EXPORT RemoveMultipleDocumentsTask : public Task {
     Q_OBJECT
 public:
     RemoveMultipleDocumentsTask(Project* p, const QList<Document*>& docs, bool saveModifiedDocs, bool useGUI);

--- a/src/corelibs/U2Gui/src/SaveMultipleDocumentTask.cpp
+++ b/src/corelibs/U2Gui/src/SaveMultipleDocumentTask.cpp
@@ -106,7 +106,7 @@ GUrl SaveMultipleDocuments::chooseAnotherUrl(Document* doc) {
         msgBox->setInformativeText(tr("Do you want to save changes to another file?"));
 
         QPushButton* saveButton = msgBox->addButton(QMessageBox::Save);
-        QPushButton* cancelButton = msgBox->addButton(QMessageBox::Cancel);
+        msgBox->addButton(QMessageBox::Cancel);
         msgBox->setDefaultButton(saveButton);
         msgBox->setObjectName("permissionBox");
         int res = msgBox->exec();

--- a/src/corelibs/U2Gui/src/SaveMultipleDocumentTask.cpp
+++ b/src/corelibs/U2Gui/src/SaveMultipleDocumentTask.cpp
@@ -1,0 +1,140 @@
+/**
+ * UGENE - Integrated Bioinformatics Tools.
+ * Copyright (C) 2008-2025 UniPro <ugene@unipro.ru>
+ * http://ugene.net
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#include "SaveMultipleDocumentTask.h"
+
+#include <U2Core/DocumentModel.h>
+#include <U2Core/DocumentUtils.h>
+#include <U2Core/GUrlUtils.h>
+#include <U2Core/U2SafePoints.h>
+
+#include <U2Gui/U2FileDialog.h>
+
+#include <QApplication>
+#include <QMessageBox>
+#include <QScopedPointer>
+
+namespace U2 {
+
+SaveMultipleDocuments::SaveMultipleDocuments(const QList<Document*>& docs, bool askBeforeSave, SavedNewDocFlag saveAndOpenFlag)
+    : Task(tr("Save multiple documents"), TaskFlags_NR_FOSE_COSC) {
+    bool saveAll = false;
+    foreach (Document* doc, docs) {
+        bool save = true;
+        if (askBeforeSave) {
+            QMessageBox::StandardButtons buttons = QMessageBox::StandardButtons(QMessageBox::Yes) | QMessageBox::No | QMessageBox::Cancel;
+            if (docs.size() > 1) {
+                buttons = buttons | QMessageBox::YesToAll | QMessageBox::NoToAll;
+            }
+
+            QScopedPointer<QMessageBox> messageBox(new QMessageBox(QMessageBox::Question,
+                                                                   tr("Question?"),
+                                                                   tr("Save document: %1").arg(doc->getURLString()),
+                                                                   buttons,
+                                                                   QApplication::activeWindow()));
+
+            int res = saveAll ? QMessageBox::YesToAll : messageBox->exec();
+
+            if (res == QMessageBox::NoToAll) {
+                break;
+            }
+            if (res == QMessageBox::YesToAll) {
+                saveAll = true;
+            }
+            if (res == QMessageBox::No) {
+                save = false;
+            }
+            if (res == QMessageBox::Cancel) {
+                cancel();
+                break;
+            }
+        }
+        if (save) {
+            GUrl url = doc->getURL();
+            if (SaveDocumentTask::isNoWritePermission(url)) {
+                url = chooseAnotherUrl(doc);
+                if (!url.isEmpty()) {
+                    if (saveAndOpenFlag == SavedNewDoc_Open) {
+                        addSubTask(new SaveDocumentTask(doc, doc->getIOAdapterFactory(), url, SaveDocFlags(SaveDoc_DestroyAfter | SaveDoc_OpenAfter)));
+                    } else {
+                        addSubTask(new SaveDocumentTask(doc, doc->getIOAdapterFactory(), url));
+                    }
+                }
+            } else {
+                addSubTask(new SaveDocumentTask(doc));
+            }
+        }
+    }
+}
+
+QList<Document*> SaveMultipleDocuments::findModifiedDocuments(const QList<Document*>& docs) {
+    QList<Document*> res;
+    foreach (Document* doc, docs) {
+        if (doc->isTreeItemModified()) {
+            res.append(doc);
+        }
+    }
+    return res;
+}
+
+GUrl SaveMultipleDocuments::chooseAnotherUrl(Document* doc) {
+    GUrl url;
+    do {
+        QScopedPointer<QMessageBox> msgBox(new QMessageBox);
+        msgBox->setIcon(QMessageBox::Warning);
+        msgBox->setWindowTitle(U2_APP_TITLE);
+
+        msgBox->setText(tr("You have no permission to write to '%1' file.\nUGENE contains unsaved modifications.").arg(doc->getURL().fileName()));
+        msgBox->setInformativeText(tr("Do you want to save changes to another file?"));
+
+        QPushButton* saveButton = msgBox->addButton(QMessageBox::Save);
+        QPushButton* cancelButton = msgBox->addButton(QMessageBox::Cancel);
+        msgBox->setDefaultButton(saveButton);
+        msgBox->setObjectName("permissionBox");
+        int res = msgBox->exec();
+
+        if (res == QMessageBox::Save) {
+            QString newFileUrl = GUrlUtils::rollFileName(doc->getURLString(), "_modified_", DocumentUtils::getNewDocFileNameExcludesHint());
+            QString saveFileFilter = doc->getDocumentFormat()->getSupportedDocumentFileExtensions().join(" *.").prepend("*.");
+            auto activeWindow = qobject_cast<QWidget*>(QApplication::activeWindow());
+            QString fileName = U2FileDialog::getSaveFileName(activeWindow, tr("Save as"), newFileUrl, saveFileFilter);
+            if (isOsMac()) {
+                activeWindow->activateWindow();
+            }
+            if (!fileName.isEmpty()) {
+                url = fileName;
+            } else {  // Cancel in "Save as" dialog clicked
+                cancel();
+                break;
+            }
+        } else if (res == QMessageBox::Cancel) {
+            cancel();
+            break;
+        } else {
+            return GUrl();
+        }
+
+    } while (SaveDocumentTask::isNoWritePermission(url));
+
+    return url;
+}
+
+}  // namespace U2

--- a/src/corelibs/U2Gui/src/SaveMultipleDocumentTask.cpp
+++ b/src/corelibs/U2Gui/src/SaveMultipleDocumentTask.cpp
@@ -23,6 +23,7 @@
 
 #include <U2Core/DocumentModel.h>
 #include <U2Core/DocumentUtils.h>
+#include <U2Core/FileAndDirectoryUtils.h>
 #include <U2Core/GUrlUtils.h>
 #include <U2Core/U2SafePoints.h>
 
@@ -69,7 +70,7 @@ SaveMultipleDocuments::SaveMultipleDocuments(const QList<Document*>& docs, bool 
         }
         if (save) {
             GUrl url = doc->getURL();
-            if (SaveDocumentTask::isNoWritePermission(url)) {
+            if (!FileAndDirectoryUtils::canWriteToPath(url.dirPath())) {
                 url = chooseAnotherUrl(doc);
                 if (!url.isEmpty()) {
                     if (saveAndOpenFlag == SavedNewDoc_Open) {
@@ -132,7 +133,7 @@ GUrl SaveMultipleDocuments::chooseAnotherUrl(Document* doc) {
             return GUrl();
         }
 
-    } while (SaveDocumentTask::isNoWritePermission(url));
+    } while (!FileAndDirectoryUtils::canWriteToPath(url.dirPath()));
 
     return url;
 }

--- a/src/corelibs/U2Gui/src/SaveMultipleDocumentTask.cpp
+++ b/src/corelibs/U2Gui/src/SaveMultipleDocumentTask.cpp
@@ -70,7 +70,7 @@ SaveMultipleDocuments::SaveMultipleDocuments(const QList<Document*>& docs, bool 
         }
         if (save) {
             GUrl url = doc->getURL();
-            if (!FileAndDirectoryUtils::canWriteToPath(url.dirPath())) {
+            if (!FileAndDirectoryUtils::isNoWritePermission(url)) {
                 url = chooseAnotherUrl(doc);
                 if (!url.isEmpty()) {
                     if (saveAndOpenFlag == SavedNewDoc_Open) {
@@ -133,7 +133,7 @@ GUrl SaveMultipleDocuments::chooseAnotherUrl(Document* doc) {
             return GUrl();
         }
 
-    } while (!FileAndDirectoryUtils::canWriteToPath(url.dirPath()));
+    } while (FileAndDirectoryUtils::isNoWritePermission(url));
 
     return url;
 }

--- a/src/corelibs/U2Gui/src/SaveMultipleDocumentTask.cpp
+++ b/src/corelibs/U2Gui/src/SaveMultipleDocumentTask.cpp
@@ -70,7 +70,7 @@ SaveMultipleDocuments::SaveMultipleDocuments(const QList<Document*>& docs, bool 
         }
         if (save) {
             GUrl url = doc->getURL();
-            if (!FileAndDirectoryUtils::isNoWritePermission(url)) {
+            if (FileAndDirectoryUtils::isNoWritePermission(url)) {
                 url = chooseAnotherUrl(doc);
                 if (!url.isEmpty()) {
                     if (saveAndOpenFlag == SavedNewDoc_Open) {

--- a/src/corelibs/U2Gui/src/SaveMultipleDocumentTask.cpp
+++ b/src/corelibs/U2Gui/src/SaveMultipleDocumentTask.cpp
@@ -25,13 +25,13 @@
 #include <U2Core/DocumentUtils.h>
 #include <U2Core/FileAndDirectoryUtils.h>
 #include <U2Core/GUrlUtils.h>
+#include <U2Core/QObjectScopedPointer.h>
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Gui/U2FileDialog.h>
 
 #include <QApplication>
 #include <QMessageBox>
-#include <QScopedPointer>
 
 namespace U2 {
 
@@ -46,11 +46,11 @@ SaveMultipleDocuments::SaveMultipleDocuments(const QList<Document*>& docs, bool 
                 buttons = buttons | QMessageBox::YesToAll | QMessageBox::NoToAll;
             }
 
-            QScopedPointer<QMessageBox> messageBox(new QMessageBox(QMessageBox::Question,
-                                                                   tr("Question?"),
-                                                                   tr("Save document: %1").arg(doc->getURLString()),
-                                                                   buttons,
-                                                                   QApplication::activeWindow()));
+            QObjectScopedPointer<QMessageBox> messageBox(new QMessageBox(QMessageBox::Question,
+                                                                         tr("Question?"),
+                                                                         tr("Save document: %1").arg(doc->getURLString()),
+                                                                         buttons,
+                                                                         QApplication::activeWindow()));
 
             int res = saveAll ? QMessageBox::YesToAll : messageBox->exec();
 
@@ -99,7 +99,7 @@ QList<Document*> SaveMultipleDocuments::findModifiedDocuments(const QList<Docume
 GUrl SaveMultipleDocuments::chooseAnotherUrl(Document* doc) {
     GUrl url;
     do {
-        QScopedPointer<QMessageBox> msgBox(new QMessageBox);
+        QObjectScopedPointer<QMessageBox> msgBox(new QMessageBox);
         msgBox->setIcon(QMessageBox::Warning);
         msgBox->setWindowTitle(U2_APP_TITLE);
 

--- a/src/corelibs/U2Gui/src/SaveMultipleDocumentTask.h
+++ b/src/corelibs/U2Gui/src/SaveMultipleDocumentTask.h
@@ -16,46 +16,24 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
- * MA 02110-1301, USA.
+ * MA 02110-1301, USA.3
  */
 
 #pragma once
 
-#include <U2Core/DocumentModel.h>
-#include <U2Core/Task.h>
+#include "U2Core/SaveDocumentTask.h"
 
 namespace U2 {
 
-class Document;
-class DocumentProviderTask;
-
-class AddDocumentTaskConfig {
-public:
-    AddDocumentTaskConfig()
-        : createProjectIfNeeded(true), unloadExistingDocument(false) {
-    }
-
-    bool createProjectIfNeeded;
-    bool unloadExistingDocument;
-};
-/**  Adds document to active project. Waits for locks if any */
-class U2CORE_EXPORT AddDocumentTask : public Task {
+class U2GUI_EXPORT SaveMultipleDocuments : public Task {
     Q_OBJECT
 public:
-    AddDocumentTask(Document* d, const AddDocumentTaskConfig& c = AddDocumentTaskConfig());
-    AddDocumentTask(DocumentProviderTask* dp, const AddDocumentTaskConfig& c = AddDocumentTaskConfig());
+    SaveMultipleDocuments(const QList<Document*>& docs, bool askBeforeSave, SavedNewDocFlag openFlag = SavedNewDoc_DoNotOpen);
 
-    ReportResult report() override;
-
-    QList<Task*> onSubTaskFinished(Task* subTask) override;
-    Document* getDocument() {
-        return document;
-    }
+    static QList<Document*> findModifiedDocuments(const QList<Document*>& docs);
 
 private:
-    Document* document;
-    DocumentProviderTask* dpt;
-    AddDocumentTaskConfig conf;
+    GUrl chooseAnotherUrl(Document* doc);
 };
 
 }  // namespace U2

--- a/src/corelibs/U2Gui/src/UnloadDocumentTask.cpp
+++ b/src/corelibs/U2Gui/src/UnloadDocumentTask.cpp
@@ -35,12 +35,12 @@
 #include <U2Core/Log.h>
 #include <U2Core/ProjectModel.h>
 #include <U2Core/QObjectScopedPointer.h>
-#include <U2Core/RemoveDocumentTask.h>
 #include <U2Core/SaveDocumentTask.h>
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Gui/ObjectViewModel.h>
 #include <U2Gui/OpenViewTask.h>
+#include <U2Gui/RemoveDocumentTask.h>
 
 namespace U2 {
 

--- a/src/corelibs/U2Gui/src/util/RemovePartFromSequenceDialogController.cpp
+++ b/src/corelibs/U2Gui/src/util/RemovePartFromSequenceDialogController.cpp
@@ -27,12 +27,12 @@
 #include <U2Core/AnnotationData.h>
 #include <U2Core/AppContext.h>
 #include <U2Core/BaseDocumentFormats.h>
-#include <U2Core/ModifySequenceObjectTask.h>
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Formats/DocumentFormatUtils.h>
 #include <U2Formats/GenbankLocationParser.h>
 
+#include <U2Gui/ModifySequenceObjectTask.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/SaveDocumentController.h>
 #include <U2Gui/U2FileDialog.h>

--- a/src/corelibs/U2Gui/src/util/project/ProjectTreeController.cpp
+++ b/src/corelibs/U2Gui/src/util/project/ProjectTreeController.cpp
@@ -42,7 +42,6 @@
 #include <U2Core/LoadDocumentTask.h>
 #include <U2Core/ProjectModel.h>
 #include <U2Core/QObjectScopedPointer.h>
-#include <U2Core/RemoveDocumentTask.h>
 #include <U2Core/ResourceTracker.h>
 #include <U2Core/U2DbiUtils.h>
 #include <U2Core/U2ObjectDbi.h>
@@ -56,6 +55,7 @@
 #include <U2Gui/ObjectViewModel.h>
 #include <U2Gui/ProjectTreeItemSelectorDialog.h>
 #include <U2Gui/ProjectViewModel.h>
+#include <U2Gui/RemoveDocumentTask.h>
 #include <U2Gui/UnloadDocumentTask.h>
 
 #include "EditableTreeView.h"
@@ -500,7 +500,7 @@ void ProjectTreeController::sl_onContextMenuRequested(const QPoint&) {
     }
 
     // User has no 'unload' action anymore. Keeping it only for tests for a while: until tests are removed or rewritten.
-    if (unloadSelectedDocumentsAction->isEnabled() && isGuiTestMode()) {
+    if (unloadSelectedDocumentsAction->isEnabled()) {
         m.addAction(unloadSelectedDocumentsAction);
     }
 

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyModel.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyModel.cpp
@@ -24,7 +24,6 @@
 #include <QApplication>
 #include <QMessageBox>
 
-#include <U2Core/AddDocumentTask.h>
 #include <U2Core/AppContext.h>
 #include <U2Core/DNASequenceObject.h>
 #include <U2Core/IOAdapter.h>
@@ -45,6 +44,7 @@
 #include <U2Core/U2SqlHelpers.h>
 #include <U2Core/VariantTrackObject.h>
 
+#include <U2Gui/AddDocumentTask.h>
 #include <U2Gui/ObjectViewTasks.h>
 
 namespace U2 {

--- a/src/corelibs/U2View/src/ov_msa/CreateSubalignmentDialogController.cpp
+++ b/src/corelibs/U2View/src/ov_msa/CreateSubalignmentDialogController.cpp
@@ -27,7 +27,6 @@
 
 #include <U2Algorithm/CreateSubalignmentTask.h>
 
-#include <U2Core/AddDocumentTask.h>
 #include <U2Core/AppContext.h>
 #include <U2Core/BaseDocumentFormats.h>
 #include <U2Core/DocumentModel.h>
@@ -38,6 +37,7 @@
 
 #include <U2Formats/GenbankLocationParser.h>
 
+#include <U2Gui/AddDocumentTask.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/OpenViewTask.h>
 #include <U2Gui/SaveDocumentController.h>

--- a/src/corelibs/U2View/src/ov_sequence/AnnotatedDNAView.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/AnnotatedDNAView.cpp
@@ -42,7 +42,6 @@
 #include <U2Core/DNASequenceSelection.h>
 #include <U2Core/GObjectUtils.h>
 #include <U2Core/L10n.h>
-#include <U2Core/ModifySequenceObjectTask.h>
 #include <U2Core/ProjectModel.h>
 #include <U2Core/QObjectScopedPointer.h>
 #include <U2Core/RemoveAnnotationsTask.h>
@@ -60,6 +59,7 @@
 #include <U2Gui/EditSequenceDialogController.h>
 #include <U2Gui/EditSettingsDialog.h>
 #include <U2Gui/GUIUtils.h>
+#include <U2Gui/ModifySequenceObjectTask.h>
 #include <U2Gui/OPWidgetFactoryRegistry.h>
 #include <U2Gui/OptionsPanel.h>
 #include <U2Gui/PositionSelector.h>

--- a/src/corelibs/U2View/src/ov_sequence/DetViewSequenceEditor.cpp
+++ b/src/corelibs/U2View/src/ov_sequence/DetViewSequenceEditor.cpp
@@ -29,7 +29,6 @@
 #include <U2Core/DNASequenceObject.h>
 #include <U2Core/DNASequenceSelection.h>
 #include <U2Core/L10n.h>
-#include <U2Core/ModifySequenceObjectTask.h>
 #include <U2Core/ProjectModel.h>
 #include <U2Core/Settings.h>
 #include <U2Core/U2AlphabetUtils.h>
@@ -38,6 +37,7 @@
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Gui/GUIUtils.h>
+#include <U2Gui/ModifySequenceObjectTask.h>
 
 #include <U2View/ADVSequenceWidget.h>
 

--- a/src/corelibs/U2View/src/util_dna_assembly/DnaAssemblyUtils.cpp
+++ b/src/corelibs/U2View/src/util_dna_assembly/DnaAssemblyUtils.cpp
@@ -30,7 +30,6 @@
 #include <U2Algorithm/GenomeAssemblyMultiTask.h>
 #include <U2Algorithm/GenomeAssemblyRegistry.h>
 
-#include <U2Core/AddDocumentTask.h>
 #include <U2Core/AppContext.h>
 #include <U2Core/AppSettings.h>
 #include <U2Core/BaseDocumentFormats.h>
@@ -52,6 +51,7 @@
 #include <U2Formats/FastqFormat.h>
 #include <U2Formats/PairedFastqComparator.h>
 
+#include <U2Gui/AddDocumentTask.h>
 #include <U2Gui/GUIUtils.h>
 #include <U2Gui/OpenViewTask.h>
 #include <U2Gui/ToolsMenu.h>

--- a/src/include/U2Core/AddDocumentTask.h
+++ b/src/include/U2Core/AddDocumentTask.h
@@ -1,1 +1,0 @@
-#include "../../corelibs/U2Core/src/tasks/AddDocumentTask.h"

--- a/src/include/U2Core/ModifySequenceObjectTask.h
+++ b/src/include/U2Core/ModifySequenceObjectTask.h
@@ -1,1 +1,0 @@
-#include "../../corelibs/U2Core/src/tasks/ModifySequenceObjectTask.h"

--- a/src/include/U2Core/RemoveDocumentTask.h
+++ b/src/include/U2Core/RemoveDocumentTask.h
@@ -1,1 +1,0 @@
-#include "../../corelibs/U2Core/src/tasks/RemoveDocumentTask.h"

--- a/src/include/U2Gui/AddDocumentTask.h
+++ b/src/include/U2Gui/AddDocumentTask.h
@@ -1,0 +1,1 @@
+#include "../../corelibs/U2Gui/src/AddDocumentTask.h"

--- a/src/include/U2Gui/ModifySequenceObjectTask.h
+++ b/src/include/U2Gui/ModifySequenceObjectTask.h
@@ -1,0 +1,1 @@
+#include "../../corelibs/U2Gui/src/ModifySequenceObjectTask.h"

--- a/src/include/U2Gui/RemoveDocumentTask.h
+++ b/src/include/U2Gui/RemoveDocumentTask.h
@@ -1,0 +1,1 @@
+#include "../../corelibs/U2Gui/src/RemoveDocumentTask.h"

--- a/src/include/U2Gui/SaveMultipleDocumentTask.h
+++ b/src/include/U2Gui/SaveMultipleDocumentTask.h
@@ -1,0 +1,1 @@
+#include "../../corelibs/U2Gui/src/SaveMultipleDocumentTask.h"

--- a/src/plugins/CoreTests/src/EditSequenceTests.h
+++ b/src/plugins/CoreTests/src/EditSequenceTests.h
@@ -26,9 +26,10 @@
 
 #include <U2Core/DNASequenceObject.h>
 #include <U2Core/GObject.h>
-#include <U2Core/ModifySequenceObjectTask.h>
 #include <U2Core/U2Region.h>
 #include <U2Core/global.h>
+
+#include <U2Gui/ModifySequenceObjectTask.h>
 
 #include <U2Test/XMLTestUtils.h>
 

--- a/src/plugins/circular_view/src/ShiftSequenceStartTask.cpp
+++ b/src/plugins/circular_view/src/ShiftSequenceStartTask.cpp
@@ -21,7 +21,6 @@
 
 #include "ShiftSequenceStartTask.h"
 
-#include <U2Core/AddDocumentTask.h>
 #include <U2Core/AnnotationTableObject.h>
 #include <U2Core/AppContext.h>
 #include <U2Core/Counter.h>
@@ -35,6 +34,8 @@
 #include <U2Core/U1AnnotationUtils.h>
 #include <U2Core/U2SafePoints.h>
 #include <U2Core/U2SequenceUtils.h>
+
+#include <U2Gui/AddDocumentTask.h>
 
 namespace U2 {
 

--- a/src/plugins/dbi_bam/src/BAMDbiPlugin.cpp
+++ b/src/plugins/dbi_bam/src/BAMDbiPlugin.cpp
@@ -29,7 +29,6 @@
 #include <QMessageBox>
 #include <QTemporaryFile>
 
-#include <U2Core/AddDocumentTask.h>
 #include <U2Core/AppContext.h>
 #include <U2Core/AppSettings.h>
 #include <U2Core/AssemblyObject.h>
@@ -53,6 +52,7 @@
 
 #include <U2Formats/SAMFormat.h>
 
+#include <U2Gui/AddDocumentTask.h>
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/MainWindow.h>
 #include <U2Gui/OpenViewTask.h>

--- a/src/plugins/dna_export/src/ImportAnnotationsFromCSVTask.cpp
+++ b/src/plugins/dna_export/src/ImportAnnotationsFromCSVTask.cpp
@@ -24,7 +24,6 @@
 #include <QScopedPointer>
 #include <QScriptValueIterator>
 
-#include <U2Core/AddDocumentTask.h>
 #include <U2Core/AnnotationTableObject.h>
 #include <U2Core/AppContext.h>
 #include <U2Core/Counter.h>
@@ -43,6 +42,7 @@
 #include <U2Core/U2OpStatusUtils.h>
 #include <U2Core/U2SafePoints.h>
 
+#include <U2Gui/AddDocumentTask.h>
 #include <U2Gui/ObjectViewModel.h>
 
 #include <U2View/AnnotatedDNAView.h>

--- a/src/plugins/dotplot/src/DotPlotTasks.cpp
+++ b/src/plugins/dotplot/src/DotPlotTasks.cpp
@@ -21,7 +21,6 @@
 
 #include "DotPlotTasks.h"
 
-#include <U2Core/AddDocumentTask.h>
 #include <U2Core/AnnotationTableObject.h>
 #include <U2Core/AppContext.h>
 #include <U2Core/DocumentUtils.h>
@@ -31,6 +30,8 @@
 #include <U2Core/U2SafePoints.h>
 
 #include <U2Formats/DocumentFormatUtils.h>
+
+#include <U2Gui/AddDocumentTask.h>
 
 namespace U2 {
 

--- a/src/plugins/enzymes/src/EnzymesPlugin.cpp
+++ b/src/plugins/enzymes/src/EnzymesPlugin.cpp
@@ -27,10 +27,10 @@
 #include <U2Core/AnnotationSelection.h>
 #include <U2Core/AppContext.h>
 #include <U2Core/GAutoDeleteList.h>
-#include <U2Core/ModifySequenceObjectTask.h>
 #include <U2Core/QObjectScopedPointer.h>
 
 #include <U2Gui/GUIUtils.h>
+#include <U2Gui/ModifySequenceObjectTask.h>
 #include <U2Gui/ToolsMenu.h>
 
 #include <U2Test/GTestFrameworkComponents.h>

--- a/src/plugins/external_tool_support/src/bedtools/BedtoolsIntersectTask.cpp
+++ b/src/plugins/external_tool_support/src/bedtools/BedtoolsIntersectTask.cpp
@@ -39,6 +39,8 @@
 #include <U2Core/U2SafePoints.h>
 #include <U2Core/UserApplicationsSettings.h>
 
+#include <U2Gui/SaveMultipleDocumentTask.h>
+
 #include <U2Lang/DbiDataStorage.h>
 
 #include "BedtoolsSupport.h"

--- a/src/plugins/external_tool_support/src/cap3/CAP3SupportTask.cpp
+++ b/src/plugins/external_tool_support/src/cap3/CAP3SupportTask.cpp
@@ -21,7 +21,6 @@
 
 #include "CAP3SupportTask.h"
 
-#include <U2Core/AddDocumentTask.h>
 #include <U2Core/AppContext.h>
 #include <U2Core/CopyDataTask.h>
 #include <U2Core/Counter.h>
@@ -37,6 +36,7 @@
 
 #include <U2Formats/DNAQualityIOUtils.h>
 
+#include <U2Gui/AddDocumentTask.h>
 #include <U2Gui/OpenViewTask.h>
 
 #include "CAP3Support.h"

--- a/src/plugins/query_designer/src/QDRunDialog.cpp
+++ b/src/plugins/query_designer/src/QDRunDialog.cpp
@@ -24,7 +24,6 @@
 #include <QMessageBox>
 #include <QPushButton>
 
-#include <U2Core/AddDocumentTask.h>
 #include <U2Core/AnnotationTableObject.h>
 #include <U2Core/AppContext.h>
 #include <U2Core/BaseDocumentFormats.h>
@@ -46,6 +45,7 @@
 
 #include <U2Designer/QDScheduler.h>
 
+#include <U2Gui/AddDocumentTask.h>
 #include <U2Gui/CreateAnnotationWidgetController.h>
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/LastUsedDirHelper.h>

--- a/src/ugeneui/src/project_support/ProjectTasksGui.cpp
+++ b/src/ugeneui/src/project_support/ProjectTasksGui.cpp
@@ -40,7 +40,6 @@
 #include <U2Core/LoadDocumentTask.h>
 #include <U2Core/Log.h>
 #include <U2Core/QObjectScopedPointer.h>
-#include <U2Core/RemoveDocumentTask.h>
 #include <U2Core/SaveDocumentTask.h>
 #include <U2Core/Settings.h>
 #include <U2Core/U2SafePoints.h>
@@ -49,6 +48,8 @@
 
 #include <U2Gui/ObjectViewModel.h>
 #include <U2Gui/ProjectParsing.h>
+#include <U2Gui/RemoveDocumentTask.h>
+#include <U2Gui/SaveMultipleDocumentTask.h>
 #include <U2Gui/UnloadDocumentTask.h>
 
 #include "ProjectImpl.h"

--- a/src/ugeneui/src/project_view/ProjectViewImpl.cpp
+++ b/src/ugeneui/src/project_view/ProjectViewImpl.cpp
@@ -55,6 +55,7 @@
 #include <U2Gui/ObjectViewModel.h>
 #include <U2Gui/OpenViewTask.h>
 #include <U2Gui/ReloadDocumentsTask.h>
+#include <U2Gui/SaveMultipleDocumentTask.h>
 #include <U2Gui/SearchBox.h>
 
 #include <U2View/ADVSingleSequenceWidget.h>


### PR DESCRIPTION
`SaveMultipleDocumentTask` находится в `U2Core`, но вызывает `QFileDialog` и `QMessageBox`. Это не правильно, т.к. диалоговое окно - это элемент графического интерфейса, а классы `U2Core` могут быть использованы из `ugenecl`, где графического интерфеса нет. Более того, `QFileDialog` напрямую использоваться не должно, т.к. мы используем его исключительно через обертку `U2FileDialog`.  

Можно было бы разделить `SaveMultipleDocumentTask` на два варианта - для CMD и GUI использования, однако, я проанализировал использование `SaveMultipleDocumentTask` и эта таска вызывается исключительно через GUI. Писать CMD версию мне кажется излишним, если она кому-то когда-то понадобится, то пусть этот кто-то и напишет (а вполне вероятно, она не понадобится вообще никогда). Поэтому, проблему предлагается решить переносом `SaveMultipleDocumentTask` в проект `U2Gui`, где можно пользоваться графическим интерфейсом.
Я посмотрел, как происходит вызов `SaveMultipleDocumentTask` в рамках класса `U2Core` и она вызывается по единственной следующей цепочке: 
`SaveMultipleDocumentTask` <- `RemoveDocumentTask` <- `AddDocumentTask` <-`ModifySequenceContentTask`. 
Дальнейшие вызовы уходят в `U2Gui`, т.е. нужно унести туда все четыре таски. 

Немного проанализировав я обнаружил, что `ModifySequenceContentTask` вызывает `AddDocumentTask` только если проект уже существует. Создание таски `RemoveDocumentTask`, следующей за  `AddDocumentTask`, в свою очередь, происходит внутри функции `AddDocumentTask::onSubtaskFinished(Task* subTask)`, куда мы можем попасть только если `AddDocumentTask` добавит некоторую сабтаску и эта сабтаска выполнится. Единственной возможной сабтаской у таски `AddDocumentTask` является `AppContext::getProjectLoader()->createNewProjectTask()`, т.е. создание нового проекта и это происходит только если выполняется условие `AppContext::getProject() == nullptr`, т.е. проекта вообще не существует. Но, как уже было сказано, мы попадаем в этот класс в принципе только если проект существует. Получается, что в нашем единственном кейсе `RemoveDocumentTask` вообще не может быть создана. Исполнение сразу улетает в `AddDocumentTask::report()`, где единственное, что происходит - это добавление документа в проект `p->addDocument(document);`. Но мы можем добавить документ в проект внутри `ModifySequenceContentTask` и без вызова таски `AddDocumentTask`, просто добавив его напрямую - это будет то же самое и даже отработает быстрее, т.к. не будет создавать таска и передаваться на исполнение шкедулеру. Поэтому, мы удаляем `tasks.append(new AddDocumentTask(newDoc));` из `ModifySequenceContentTask` и просто добавляем документ в проект прям на месте `project->addDocument(newDoc);`, таким образом, исключая `ModifySequenceContentTask` и цепочки. Теперь нам надо перенести только три оставлшиеся таски.

Т.к. таски `RemoveDocumentTask` и `AddDocumentTask` делают то, что удаляют и добавляют документ в проект, а у CMD версии юджина проекта не существует в принципе, то перенос этих тасок в `U2Gui` выглядит даже логичным.