### PR TITLE
Replace QMutex with QRecursiveMutex in U2Core

### DIFF
--- a/src/corelibs/U2Core/src/datatype/UdrSchemaRegistry.cpp
+++ b/src/corelibs/U2Core/src/datatype/UdrSchemaRegistry.cpp
@@ -28,10 +28,6 @@
 
 namespace U2 {
 
-UdrSchemaRegistry::UdrSchemaRegistry()
-    : mutex(QMutex::Recursive) {
-}
-
 UdrSchemaRegistry::~UdrSchemaRegistry() {
     qDeleteAll(schemas.values());
 }

--- a/src/corelibs/U2Core/src/datatype/UdrSchemaRegistry.h
+++ b/src/corelibs/U2Core/src/datatype/UdrSchemaRegistry.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include <U2Core/UdrSchema.h>
 
@@ -30,7 +30,7 @@ namespace U2 {
 class U2CORE_EXPORT UdrSchemaRegistry {
     Q_DISABLE_COPY(UdrSchemaRegistry)
 public:
-    UdrSchemaRegistry();
+    UdrSchemaRegistry() = default;
     ~UdrSchemaRegistry();
 
     void registerSchema(const UdrSchema* schema, U2OpStatus& os);
@@ -44,7 +44,7 @@ public:
     static bool isCorrectName(const QByteArray& name);
 
 private:
-    mutable QMutex mutex;
+    mutable QRecursiveMutex mutex;
     QHash<UdrSchemaId, const UdrSchema*> schemas;
 };
 

--- a/src/corelibs/U2Core/src/dbi/U2Dbi.cpp
+++ b/src/corelibs/U2Core/src/dbi/U2Dbi.cpp
@@ -76,7 +76,7 @@ void U2Dbi::startOperationsBlock(U2OpStatus&) {
 void U2Dbi::stopOperationBlock(U2OpStatus&) {
 }
 
-QMutex* U2Dbi::getDbMutex() const {
+QRecursiveMutex* U2Dbi::getDbMutex() const {
     return nullptr;
 }
 

--- a/src/corelibs/U2Core/src/dbi/U2Dbi.h
+++ b/src/corelibs/U2Core/src/dbi/U2Dbi.h
@@ -23,6 +23,7 @@
 
 #include <QHash>
 #include <QSet>
+#include <QRecursiveMutex>
 
 #include <U2Core/GUrl.h>
 #include <U2Core/U2Assembly.h>
@@ -352,7 +353,7 @@ public:
     /** Returns a mutex that synchronizes access to internal database handler.
         This method is supposed to be used by caching DBIs
         in order to prevent cache inconsistency. */
-    virtual QMutex* getDbMutex() const;
+    virtual QRecursiveMutex* getDbMutex() const;
 
     virtual bool isReadOnly() const = 0;
 

--- a/src/corelibs/U2Core/src/dbi/U2DbiRegistry.cpp
+++ b/src/corelibs/U2Core/src/dbi/U2DbiRegistry.cpp
@@ -42,7 +42,7 @@ namespace U2 {
 static const QString SESSION_TMP_DBI_ALIAS("session");
 
 U2DbiRegistry::U2DbiRegistry(QObject* parent)
-    : QObject(parent), lock(QMutex::Recursive) {
+    : QObject(parent) {
     pool = new U2DbiPool(this);
     sessionDbiConnection = nullptr;
     sessionDbiInitDone = false;

--- a/src/corelibs/U2Core/src/dbi/U2DbiRegistry.h
+++ b/src/corelibs/U2Core/src/dbi/U2DbiRegistry.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <QHash>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QTimer>
 
 #include <U2Core/U2Dbi.h>
@@ -104,7 +104,7 @@ private:
     QHash<U2DbiFactoryId, U2DbiFactory*> factories;
     U2DbiPool* pool;
     QList<TmpDbiRef> tmpDbis;
-    QMutex lock;
+    QRecursiveMutex lock;
 
     /** this connection is opened during the whole ugene session*/
     DbiConnection* sessionDbiConnection;

--- a/src/corelibs/U2Core/src/dbi/U2SqlHelpers.h
+++ b/src/corelibs/U2Core/src/dbi/U2SqlHelpers.h
@@ -22,8 +22,8 @@
 #pragma once
 
 #include <QHash>
-#include <QMutex>
 #include <QReadWriteLock>
+#include <QRecursiveMutex>
 #include <QSharedPointer>
 #include <QStringList>
 #include <QThread>
@@ -44,11 +44,11 @@ class SQLiteTransaction;
 class U2CORE_EXPORT DbRef {
 public:
     DbRef(sqlite3* db = nullptr)
-        : handle(db), lock(QMutex::Recursive), useTransaction(true) {
+        : handle(db), useTransaction(true) {
     }
 
     sqlite3* handle;
-    QMutex lock;
+    QRecursiveMutex lock;
     QReadWriteLock rwLock;
     bool useTransaction;
     bool useCache;

--- a/src/corelibs/U2Core/src/globals/Log.cpp
+++ b/src/corelibs/U2Core/src/globals/Log.cpp
@@ -29,8 +29,7 @@
 
 namespace U2 {
 
-LogServer::LogServer()
-    : listenerMutex(QMutex::Recursive) {
+LogServer::LogServer() {
     qRegisterMetaType<LogMessage>("LogMessage");
 }
 

--- a/src/corelibs/U2Core/src/globals/Log.h
+++ b/src/corelibs/U2Core/src/globals/Log.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <QMetaType>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QStringList>
 #include <QTime>
 
@@ -120,7 +120,7 @@ private:
 
     QList<Logger*> loggers;
     QList<LogListener*> listeners;
-    QMutex listenerMutex;
+    QRecursiveMutex listenerMutex;
 };
 
 // TODO: support log category translation + use log category ids instead of the names in code

--- a/src/corelibs/U2Formats/src/sqlite_dbi/SQLiteDbi.cpp
+++ b/src/corelibs/U2Formats/src/sqlite_dbi/SQLiteDbi.cpp
@@ -200,7 +200,7 @@ void SQLiteDbi::stopOperationBlock(U2OpStatus& os) {
     }
 }
 
-QMutex* SQLiteDbi::getDbMutex() const {
+QRecursiveMutex* SQLiteDbi::getDbMutex() const {
     return &db->lock;
 }
 

--- a/src/corelibs/U2Formats/src/sqlite_dbi/SQLiteDbi.h
+++ b/src/corelibs/U2Formats/src/sqlite_dbi/SQLiteDbi.h
@@ -151,7 +151,7 @@ public:
 
     void stopOperationBlock(U2OpStatus& os) override;
 
-    QMutex* getDbMutex() const override;
+    QRecursiveMutex* getDbMutex() const override;
 
     bool isReadOnly() const override;
 

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyModel.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyModel.cpp
@@ -659,7 +659,7 @@ U2SequenceObject* AssemblyModel::getRefObj() const {
 }
 
 bool AssemblyModel::isDbLocked(int timeout) const {
-    QMutex* mutex = dbiHandle.dbi->getDbMutex();
+    QRecursiveMutex* mutex = dbiHandle.dbi->getDbMutex();
     CHECK(mutex != nullptr, false);
     if (mutex->tryLock(timeout)) {
         mutex->unlock();


### PR DESCRIPTION
Все еще грежу идеей перехода на qt6, буду делать понемногу какие-то маленькие изменения, не позволяющие сделать переход и совместимые с обоими версиями Qt. 

Я не знаю, как тебе будет удобнее смотреть - один большой, но не очень связный коммит, или много маленьких, каждый посвященный какой-то конкретной проблеме. Сейчас предлагаю вариант с много маленьких, т.к. с одним большим мне было самому не очень удобно по определенным причинам. 

Здесь замена `QMutex` с флагом `QMutex::Recursive` на `QRecursiveMutex`. Технически это одно и то же, но этот флаг был удален в Qt6.