### PR TITLE
Replace QRegExp with QRegularExpression in U2Core

### DIFF
--- a/src/corelibs/U2Core/src/datatype/PFMatrix.cpp
+++ b/src/corelibs/U2Core/src/datatype/PFMatrix.cpp
@@ -26,6 +26,8 @@
 
 #include "DIProperties.h"
 
+#include <QRegularExpression>
+
 namespace U2 {
 
 JasparInfo::JasparInfo()
@@ -39,7 +41,7 @@ JasparInfo::JasparInfo(const QMap<QString, QString>& props)
 JasparInfo::JasparInfo(const QString& line) {
     QStringList parsedData = line.split(";");
     QString idData = parsedData.first();
-    QStringList base = idData.split(QRegExp("\\s"));
+    QStringList base = idData.split(QRegularExpression("\\s"));
     QString id = base[0];
     properties.insert(QString("id"), id);
     QString name = base[2];

--- a/src/corelibs/U2Core/src/datatype/primers/PrimerStatistics.cpp
+++ b/src/corelibs/U2Core/src/datatype/primers/PrimerStatistics.cpp
@@ -74,7 +74,7 @@ bool PrimerStatistics::validatePrimerLength(const QByteArray& primer) {
 
 QString PrimerStatistics::getDoubleStringValue(double value) {
     QString result = QString::number(value, 'f', 2);
-    result.remove(QRegExp("\\.?0+$"));
+    result.remove(QRegularExpression("\\.?0+$"));
     return result;
 }
 
@@ -351,7 +351,7 @@ void PrimersPairStatistics::addDimersToReport(QString& report) const {
 
 QString PrimersPairStatistics::toString(double value) {
     QString result = QString::number(value, 'f', 2);
-    result.remove(QRegExp("\\.?0+$"));
+    result.remove(QRegularExpression("\\.?0+$"));
     return result;
 }
 

--- a/src/corelibs/U2Core/src/dbi/U2DbiUtils.cpp
+++ b/src/corelibs/U2Core/src/dbi/U2DbiUtils.cpp
@@ -22,6 +22,7 @@
 #include "U2DbiUtils.h"
 
 #include <QBitArray>
+#include <QRegularExpression>
 #include <QFile>
 
 #include <U2Core/AppContext.h>
@@ -176,7 +177,7 @@ QString U2DbiUtils::makeFolderCanonical(const QString& folder) {
     }
 
     QString result = folder.startsWith(U2ObjectDbi::ROOT_FOLDER + U2ObjectDbi::PATH_SEP) ? folder : U2ObjectDbi::ROOT_FOLDER + U2ObjectDbi::PATH_SEP + folder;
-    result.replace(QRegExp(U2ObjectDbi::PATH_SEP + "+"), U2ObjectDbi::PATH_SEP);
+    result.replace(QRegularExpression(U2ObjectDbi::PATH_SEP + "+"), U2ObjectDbi::PATH_SEP);
 
     if (U2ObjectDbi::ROOT_FOLDER != result &&
         result.endsWith(U2ObjectDbi::ROOT_FOLDER)) {

--- a/src/corelibs/U2Core/src/globals/GUrl.cpp
+++ b/src/corelibs/U2Core/src/globals/GUrl.cpp
@@ -23,6 +23,7 @@
 
 #include <QDataStream>
 #include <QDir>
+#include <QRegularExpression>
 
 #include "U2SafePoints.h"
 
@@ -110,7 +111,7 @@ GUrlType GUrl::getURLType(const QString& rawUrl) {
         result = GUrl_Http;
     } else if (rawUrl.startsWith("ftp://")) {
         result = GUrl_Ftp;
-    } else if (!rawUrl.startsWith("file://") && rawUrl.contains(QRegExp("^([\\.\\w-]+@)?[\\.\\w-]+:\\d*(/[\\w-]*)?$"))) {
+    } else if (!rawUrl.startsWith("file://") && rawUrl.contains(QRegularExpression("^([\\.\\w-]+@)?[\\.\\w-]+:\\d*(/[\\w-]*)?$"))) {
         return GUrl_Network;
     } else if (rawUrl.startsWith(U2_VFS_URL_PREFIX)) {
         result = GUrl_VFSFile;

--- a/src/corelibs/U2Core/src/tasks/CmdlineTaskRunner.cpp
+++ b/src/corelibs/U2Core/src/tasks/CmdlineTaskRunner.cpp
@@ -19,6 +19,7 @@
  * MA 02110-1301, USA.
  */
 
+#include <QRegularExpression>
 #include <QTextCodec>
 #include <QTimer>
 
@@ -380,7 +381,7 @@ void CmdlineTaskRunner::sl_onReadStandardOutput() {
     }
 
     for (const QString& line : qAsConst(lines)) {
-        QStringList words = line.split(QRegExp("\\s+"), Qt::SkipEmptyParts);
+        QStringList words = line.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
         for (const QString& word : qAsConst(words)) {
             if (word.startsWith(OUTPUT_PROGRESS_TAG)) {
                 QString numStr = word.mid(OUTPUT_PROGRESS_TAG.size());

--- a/src/corelibs/U2Core/src/util/DatatypeSerializeUtils.cpp
+++ b/src/corelibs/U2Core/src/util/DatatypeSerializeUtils.cpp
@@ -22,6 +22,7 @@
 #include "DatatypeSerializeUtils.h"
 
 #include <QBitArray>
+#include <QRegularExpression>
 #include <QStack>
 #include <QtEndian>
 
@@ -227,7 +228,7 @@ static void packTreeNode(QString& resultText, const PhyNode* node, U2OpStatus& o
             resultText.append(QString::number(childBranch->distance));
         }
         resultText.append(")");
-    } else if (node->name.contains(QRegExp("\\s|[(]|[)]|[:]|[;]|[,]"))) {
+    } else if (node->name.contains(QRegularExpression("\\s|[(]|[)]|[:]|[;]|[,]"))) {
         resultText.append(QString("\'%1\'").arg(node->name));
     } else {
         resultText.append(node->name);

--- a/src/corelibs/U2Core/src/util/GUrlUtils.cpp
+++ b/src/corelibs/U2Core/src/util/GUrlUtils.cpp
@@ -22,6 +22,7 @@
 #include "GUrlUtils.h"
 
 #include <QDir>
+#include <QRegularExpression>
 
 #include <U2Core/AppContext.h>
 #include <U2Core/AppSettings.h>
@@ -71,7 +72,7 @@ GUrl GUrlUtils::ensureFileExt(const GUrl& url, const QStringList& typeExt) {
 }
 
 bool GUrlUtils::containSpaces(const QString& string) {
-    return string.contains(QRegExp("\\s"));
+    return string.contains(QRegularExpression("\\s"));
 }
 
 GUrl GUrlUtils::changeFileExt(const GUrl& url, const DocumentFormatId& newFormatId) {
@@ -351,7 +352,7 @@ QString GUrlUtils::getDefaultDataPath() {
 }
 
 QString GUrlUtils::getQuotedString(const QString& inString) {
-    if (inString.contains(QRegExp("\\s"))) {
+    if (inString.contains(QRegularExpression("\\s"))) {
         return "\"" + inString + "\"";
     }
     return inString;
@@ -454,8 +455,8 @@ QString GUrlUtils::getPairedFastqFilesBaseName(const QString& sourceFileUrl, boo
 
 QString GUrlUtils::fixFileName(const QString& fileName) {
     QString result = fileName;
-    result.replace(QRegExp("[^0-9a-zA-Z._\\-]"), "_");
-    result.replace(QRegExp("_+"), "_");
+    result.replace(QRegularExpression("[^0-9a-zA-Z._\\-]"), "_");
+    result.replace(QRegularExpression("_+"), "_");
 
     // Truncate long file names a bit more to allow suffix adjustments (rolling) later.
     result.truncate(MAX_OS_FILE_NAME_LENGTH - 50);

--- a/src/corelibs/U2Core/src/util/StrPackUtils.cpp
+++ b/src/corelibs/U2Core/src/util/StrPackUtils.cpp
@@ -21,6 +21,8 @@
 
 #include <math.h>
 
+#include <QRegularExpression>
+
 #include <U2Core/U2SafePoints.h>
 
 #include "StrPackUtils.h"
@@ -33,16 +35,16 @@ const QString StrPackUtils::MAP_SEPARATOR = ";";
 const QString StrPackUtils::PAIR_CONNECTOR = "=";
 
 const QString StrPackUtils::listSeparatorPattern = QString("^\\%2|(?!\\\\)\\%2%1\\%2|\\%2$").arg(LIST_SEPARATOR);
-const QRegExp StrPackUtils::listSingleQuoteSeparatorRegExp(listSeparatorPattern.arg("\'"));
-const QRegExp StrPackUtils::listDoubleQuoteSeparatorRegExp(listSeparatorPattern.arg("\""));
+const QRegularExpression StrPackUtils::listSingleQuoteSeparatorRegExp(listSeparatorPattern.arg("\'"));
+const QRegularExpression StrPackUtils::listDoubleQuoteSeparatorRegExp(listSeparatorPattern.arg("\""));
 
 const QString StrPackUtils::mapSeparatorPattern = QString("(?!\\\\)\\%2%1\\%2").arg(MAP_SEPARATOR);
-const QRegExp StrPackUtils::mapSingleQuoteSeparatorRegExp(mapSeparatorPattern.arg("\'"));
-const QRegExp StrPackUtils::mapDoubleQuoteSeparatorRegExp(mapSeparatorPattern.arg("\""));
+const QRegularExpression StrPackUtils::mapSingleQuoteSeparatorRegExp(mapSeparatorPattern.arg("\'"));
+const QRegularExpression StrPackUtils::mapDoubleQuoteSeparatorRegExp(mapSeparatorPattern.arg("\""));
 
 const QString StrPackUtils::pairSeparatorPattern = QString("^\\%2|(?!\\\\)\\%2%1\\%2|\\%2$").arg(PAIR_CONNECTOR);
-const QRegExp StrPackUtils::pairSingleQuoteSeparatorRegExp(pairSeparatorPattern.arg("\'"));
-const QRegExp StrPackUtils::pairDoubleQuoteSeparatorRegExp(pairSeparatorPattern.arg("\""));
+const QRegularExpression StrPackUtils::pairSingleQuoteSeparatorRegExp(pairSeparatorPattern.arg("\'"));
+const QRegularExpression StrPackUtils::pairDoubleQuoteSeparatorRegExp(pairSeparatorPattern.arg("\""));
 
 static bool registerMetaTypes() {
     qRegisterMetaType<StrStrMap>("StrStrMap");
@@ -69,7 +71,7 @@ QString StrPackUtils::packStringList(const QStringList& list, Options options) {
 
 QStringList StrPackUtils::unpackStringList(const QString& string, Options options) {
     QStringList unpackedList;
-    const QRegExp separator = (options == SingleQuotes ? listSingleQuoteSeparatorRegExp : listDoubleQuoteSeparatorRegExp);
+    const auto separator = (options == SingleQuotes ? listSingleQuoteSeparatorRegExp : listDoubleQuoteSeparatorRegExp);
     foreach (const QString& escapedString, string.split(separator, Qt::SkipEmptyParts)) {
         unpackedList << unescapeCharacters(escapedString);
     }
@@ -101,9 +103,9 @@ QString StrPackUtils::packMap(const StrStrMap& map, Options options) {
 
 StrStrMap StrPackUtils::unpackMap(const QString& string, Options options) {
     StrStrMap map;
-    QRegExp elementsSeparator = options == SingleQuotes ? mapSingleQuoteSeparatorRegExp : mapDoubleQuoteSeparatorRegExp;
+    auto elementsSeparator = options == SingleQuotes ? mapSingleQuoteSeparatorRegExp : mapDoubleQuoteSeparatorRegExp;
     foreach (const QString& pair, string.split(elementsSeparator, Qt::SkipEmptyParts)) {
-        QRegExp keyValueSeparator = options == SingleQuotes ? pairSingleQuoteSeparatorRegExp : pairDoubleQuoteSeparatorRegExp;
+        auto keyValueSeparator = options == SingleQuotes ? pairSingleQuoteSeparatorRegExp : pairDoubleQuoteSeparatorRegExp;
         QStringList splitPair = pair.split(keyValueSeparator, Qt::SkipEmptyParts);
         Q_ASSERT(splitPair.size() <= 2);
         if (!splitPair.empty()) {  // splitPair can be empty if both key and value are empty strings.

--- a/src/corelibs/U2Core/src/util/StrPackUtils.h
+++ b/src/corelibs/U2Core/src/util/StrPackUtils.h
@@ -24,7 +24,7 @@
 #include <QBitArray>
 #include <QCoreApplication>
 #include <QMap>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QStringList>
 #include <QVariant>
 
@@ -64,16 +64,16 @@ private:
     static const QString PAIR_CONNECTOR;
 
     static const QString listSeparatorPattern;
-    static const QRegExp listSingleQuoteSeparatorRegExp;
-    static const QRegExp listDoubleQuoteSeparatorRegExp;
+    static const QRegularExpression listSingleQuoteSeparatorRegExp;
+    static const QRegularExpression listDoubleQuoteSeparatorRegExp;
 
     static const QString mapSeparatorPattern;
-    static const QRegExp mapSingleQuoteSeparatorRegExp;
-    static const QRegExp mapDoubleQuoteSeparatorRegExp;
+    static const QRegularExpression mapSingleQuoteSeparatorRegExp;
+    static const QRegularExpression mapDoubleQuoteSeparatorRegExp;
 
     static const QString pairSeparatorPattern;
-    static const QRegExp pairSingleQuoteSeparatorRegExp;
-    static const QRegExp pairDoubleQuoteSeparatorRegExp;
+    static const QRegularExpression pairSingleQuoteSeparatorRegExp;
+    static const QRegularExpression pairDoubleQuoteSeparatorRegExp;
 
     static const bool isMetaTypesRegistered;
 };


### PR DESCRIPTION
Сам по себе `QRegExp` можно сохранить, используя Qt5 compatibility, но `QString` больше не содержит `QRegExp` в качестве аргументов своих функций 