### PR TITLE
Replace QRegExpValidator with QRegularExpressionValidator

### DIFF
--- a/src/corelibs/U2Core/src/datatype/primers/PrimerValidator.cpp
+++ b/src/corelibs/U2Core/src/datatype/primers/PrimerValidator.cpp
@@ -27,20 +27,20 @@
 namespace U2 {
 
 PrimerValidator::PrimerValidator(QObject* parent, bool allowExtended)
-    : QRegExpValidator(parent) {
+    : QRegularExpressionValidator(parent) {
     const DNAAlphabet* alphabet = AppContext::getDNAAlphabetRegistry()->findById(
         allowExtended ? BaseDNAAlphabetIds::NUCL_DNA_EXTENDED() : BaseDNAAlphabetIds::NUCL_DNA_DEFAULT());
     QByteArray alphabetChars = alphabet->getAlphabetChars(true);
     // Gaps are not allowed
     alphabetChars.remove(alphabetChars.indexOf('-'), 1);
-    setRegExp(QRegExp(QString("[%1]+").arg(alphabetChars.constData())));
+    setRegularExpression(QRegularExpression(QString("[%1]+").arg(alphabetChars.constData())));
 }
 
 QValidator::State PrimerValidator::validate(QString& input, int& pos) const {
     input = input.simplified();
     input = input.toUpper();
     input.remove(" ");
-    return QRegExpValidator::validate(input, pos);
+    return QRegularExpressionValidator::validate(input, pos);
 }
 
 }  // namespace U2

--- a/src/corelibs/U2Core/src/datatype/primers/PrimerValidator.h
+++ b/src/corelibs/U2Core/src/datatype/primers/PrimerValidator.h
@@ -21,16 +21,16 @@
 
 #pragma once
 
-#include <QValidator>
+#include <QRegularExpressionValidator>
 
 #include <U2Core/global.h>
 
 namespace U2 {
 /**
  * @PrimerValidator
- * QRegExpValidator improving for primers. Make possible to type nucleotide or nucleotide-extended characters.
+ * QRegularExpressionValidator improving for primers. Make possible to type nucleotide or nucleotide-extended characters.
  */
-class U2CORE_EXPORT PrimerValidator : public QRegExpValidator {
+class U2CORE_EXPORT PrimerValidator : public QRegularExpressionValidator {
 public:
     PrimerValidator(QObject* parent, bool allowExtended = true);
 


### PR DESCRIPTION
`QRegExpr` доступен через Qt5 compatibility module, а вот `QRegExpValidator` - нет, поэтому его надо заменить на `QRegularExpressionValidator`. Работают они одинакого