### PR TITLE
Qt5 to Qt6

### DIFF
--- a/src/corelibs/U2Core/src/datatype/Annotation.cpp
+++ b/src/corelibs/U2Core/src/datatype/Annotation.cpp
@@ -22,6 +22,7 @@
 #include "Annotation.h"
 
 #include <QTextDocument>
+#include <QRegExp>
 
 #include <U2Core/AnnotationModification.h>
 #include <U2Core/AnnotationTableObject.h>

--- a/src/corelibs/U2Core/src/datatype/Annotation.cpp
+++ b/src/corelibs/U2Core/src/datatype/Annotation.cpp
@@ -555,7 +555,7 @@ QString Annotation::getQualifiersTip(const SharedAnnotationData& data, int maxRo
         U2OpStatus2Log os;
         QByteArray seqVal = U2SequenceUtils::extractRegions(sequenceRef, tooltipRegions, effectiveComplTT, nullptr, data->isJoin(), os).join("^");
         QByteArray aminoVal = os.hasError() || aminoTT == nullptr
-                                  ? ""
+                                  ? QByteArray()
                                   : U2SequenceUtils::extractRegions(sequenceRef, tooltipRegions, effectiveComplTT, aminoTT, data->isJoin(), os).join("^");
         if (!os.hasError() && seqVal.length() > 0) {
             if (!tip.isEmpty()) {

--- a/src/corelibs/U2Core/src/datatype/Annotation.cpp
+++ b/src/corelibs/U2Core/src/datatype/Annotation.cpp
@@ -462,10 +462,10 @@ static QString getAlignmentTip(const QString& ref, const QList<U2CigarToken>& to
     QList<int> mismatchPositions;
     for (const U2CigarToken& t : qAsConst(tokens)) {
         if (t.op == U2CigarOp_M) {
-            alignmentTip += ref.midRef(cigarPos, t.count);
+            alignmentTip += ref.mid(cigarPos, t.count);
             cigarPos += t.count;
         } else if (t.op == U2CigarOp_X) {
-            alignmentTip += ref.midRef(cigarPos, t.count);
+            alignmentTip += ref.mid(cigarPos, t.count);
             mismatchPositions.append(cigarPos);
             cigarPos += t.count;
         } else if (t.op == U2CigarOp_I) {

--- a/src/corelibs/U2Core/src/datatype/PFMatrix.cpp
+++ b/src/corelibs/U2Core/src/datatype/PFMatrix.cpp
@@ -26,6 +26,8 @@
 
 #include "DIProperties.h"
 
+#include <QRegularExpression>
+
 namespace U2 {
 
 JasparInfo::JasparInfo()
@@ -39,7 +41,7 @@ JasparInfo::JasparInfo(const QMap<QString, QString>& props)
 JasparInfo::JasparInfo(const QString& line) {
     QStringList parsedData = line.split(";");
     QString idData = parsedData.first();
-    QStringList base = idData.split(QRegExp("\\s"));
+    QStringList base = idData.split(QRegularExpression("\\s"));
     QString id = base[0];
     properties.insert(QString("id"), id);
     QString name = base[2];

--- a/src/corelibs/U2Core/src/datatype/UdrSchemaRegistry.cpp
+++ b/src/corelibs/U2Core/src/datatype/UdrSchemaRegistry.cpp
@@ -28,10 +28,6 @@
 
 namespace U2 {
 
-UdrSchemaRegistry::UdrSchemaRegistry()
-    : mutex(QMutex::Recursive) {
-}
-
 UdrSchemaRegistry::~UdrSchemaRegistry() {
     qDeleteAll(schemas.values());
 }

--- a/src/corelibs/U2Core/src/datatype/UdrSchemaRegistry.h
+++ b/src/corelibs/U2Core/src/datatype/UdrSchemaRegistry.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <QMutex>
+#include <QRecursiveMutex>
 
 #include <U2Core/UdrSchema.h>
 
@@ -30,7 +30,7 @@ namespace U2 {
 class U2CORE_EXPORT UdrSchemaRegistry {
     Q_DISABLE_COPY(UdrSchemaRegistry)
 public:
-    UdrSchemaRegistry();
+    UdrSchemaRegistry() = default;
     ~UdrSchemaRegistry();
 
     void registerSchema(const UdrSchema* schema, U2OpStatus& os);
@@ -44,7 +44,7 @@ public:
     static bool isCorrectName(const QByteArray& name);
 
 private:
-    mutable QMutex mutex;
+    mutable QRecursiveMutex mutex;
     QHash<UdrSchemaId, const UdrSchema*> schemas;
 };
 

--- a/src/corelibs/U2Core/src/datatype/primers/PrimerStatistics.cpp
+++ b/src/corelibs/U2Core/src/datatype/primers/PrimerStatistics.cpp
@@ -74,7 +74,7 @@ bool PrimerStatistics::validatePrimerLength(const QByteArray& primer) {
 
 QString PrimerStatistics::getDoubleStringValue(double value) {
     QString result = QString::number(value, 'f', 2);
-    result.remove(QRegExp("\\.?0+$"));
+    result.remove(QRegularExpression("\\.?0+$"));
     return result;
 }
 
@@ -351,7 +351,7 @@ void PrimersPairStatistics::addDimersToReport(QString& report) const {
 
 QString PrimersPairStatistics::toString(double value) {
     QString result = QString::number(value, 'f', 2);
-    result.remove(QRegExp("\\.?0+$"));
+    result.remove(QRegularExpression("\\.?0+$"));
     return result;
 }
 

--- a/src/corelibs/U2Core/src/datatype/primers/PrimerValidator.cpp
+++ b/src/corelibs/U2Core/src/datatype/primers/PrimerValidator.cpp
@@ -27,20 +27,20 @@
 namespace U2 {
 
 PrimerValidator::PrimerValidator(QObject* parent, bool allowExtended)
-    : QRegExpValidator(parent) {
+    : QRegularExpressionValidator(parent) {
     const DNAAlphabet* alphabet = AppContext::getDNAAlphabetRegistry()->findById(
         allowExtended ? BaseDNAAlphabetIds::NUCL_DNA_EXTENDED() : BaseDNAAlphabetIds::NUCL_DNA_DEFAULT());
     QByteArray alphabetChars = alphabet->getAlphabetChars(true);
     // Gaps are not allowed
     alphabetChars.remove(alphabetChars.indexOf('-'), 1);
-    setRegExp(QRegExp(QString("[%1]+").arg(alphabetChars.constData())));
+    setRegularExpression(QRegularExpression(QString("[%1]+").arg(alphabetChars.constData())));
 }
 
 QValidator::State PrimerValidator::validate(QString& input, int& pos) const {
     input = input.simplified();
     input = input.toUpper();
     input.remove(" ");
-    return QRegExpValidator::validate(input, pos);
+    return QRegularExpressionValidator::validate(input, pos);
 }
 
 }  // namespace U2

--- a/src/corelibs/U2Core/src/datatype/primers/PrimerValidator.h
+++ b/src/corelibs/U2Core/src/datatype/primers/PrimerValidator.h
@@ -21,16 +21,16 @@
 
 #pragma once
 
-#include <QValidator>
+#include <QRegularExpressionValidator>
 
 #include <U2Core/global.h>
 
 namespace U2 {
 /**
  * @PrimerValidator
- * QRegExpValidator improving for primers. Make possible to type nucleotide or nucleotide-extended characters.
+ * QRegularExpressionValidator improving for primers. Make possible to type nucleotide or nucleotide-extended characters.
  */
-class U2CORE_EXPORT PrimerValidator : public QRegExpValidator {
+class U2CORE_EXPORT PrimerValidator : public QRegularExpressionValidator {
 public:
     PrimerValidator(QObject* parent, bool allowExtended = true);
 

--- a/src/corelibs/U2Core/src/dbi/U2Dbi.cpp
+++ b/src/corelibs/U2Core/src/dbi/U2Dbi.cpp
@@ -76,7 +76,7 @@ void U2Dbi::startOperationsBlock(U2OpStatus&) {
 void U2Dbi::stopOperationBlock(U2OpStatus&) {
 }
 
-QMutex* U2Dbi::getDbMutex() const {
+QRecursiveMutex* U2Dbi::getDbMutex() const {
     return nullptr;
 }
 

--- a/src/corelibs/U2Core/src/dbi/U2Dbi.h
+++ b/src/corelibs/U2Core/src/dbi/U2Dbi.h
@@ -23,6 +23,7 @@
 
 #include <QHash>
 #include <QSet>
+#include <QRecursiveMutex>
 
 #include <U2Core/GUrl.h>
 #include <U2Core/U2Assembly.h>
@@ -352,7 +353,7 @@ public:
     /** Returns a mutex that synchronizes access to internal database handler.
         This method is supposed to be used by caching DBIs
         in order to prevent cache inconsistency. */
-    virtual QMutex* getDbMutex() const;
+    virtual QRecursiveMutex* getDbMutex() const;
 
     virtual bool isReadOnly() const = 0;
 

--- a/src/corelibs/U2Core/src/dbi/U2DbiRegistry.cpp
+++ b/src/corelibs/U2Core/src/dbi/U2DbiRegistry.cpp
@@ -42,7 +42,7 @@ namespace U2 {
 static const QString SESSION_TMP_DBI_ALIAS("session");
 
 U2DbiRegistry::U2DbiRegistry(QObject* parent)
-    : QObject(parent), lock(QMutex::Recursive) {
+    : QObject(parent) {
     pool = new U2DbiPool(this);
     sessionDbiConnection = nullptr;
     sessionDbiInitDone = false;

--- a/src/corelibs/U2Core/src/dbi/U2DbiRegistry.h
+++ b/src/corelibs/U2Core/src/dbi/U2DbiRegistry.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <QHash>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QTimer>
 
 #include <U2Core/U2Dbi.h>
@@ -104,7 +104,7 @@ private:
     QHash<U2DbiFactoryId, U2DbiFactory*> factories;
     U2DbiPool* pool;
     QList<TmpDbiRef> tmpDbis;
-    QMutex lock;
+    QRecursiveMutex lock;
 
     /** this connection is opened during the whole ugene session*/
     DbiConnection* sessionDbiConnection;

--- a/src/corelibs/U2Core/src/dbi/U2DbiUtils.cpp
+++ b/src/corelibs/U2Core/src/dbi/U2DbiUtils.cpp
@@ -22,6 +22,7 @@
 #include "U2DbiUtils.h"
 
 #include <QBitArray>
+#include <QRegularExpression>
 #include <QFile>
 
 #include <U2Core/AppContext.h>
@@ -176,7 +177,7 @@ QString U2DbiUtils::makeFolderCanonical(const QString& folder) {
     }
 
     QString result = folder.startsWith(U2ObjectDbi::ROOT_FOLDER + U2ObjectDbi::PATH_SEP) ? folder : U2ObjectDbi::ROOT_FOLDER + U2ObjectDbi::PATH_SEP + folder;
-    result.replace(QRegExp(U2ObjectDbi::PATH_SEP + "+"), U2ObjectDbi::PATH_SEP);
+    result.replace(QRegularExpression(U2ObjectDbi::PATH_SEP + "+"), U2ObjectDbi::PATH_SEP);
 
     if (U2ObjectDbi::ROOT_FOLDER != result &&
         result.endsWith(U2ObjectDbi::ROOT_FOLDER)) {

--- a/src/corelibs/U2Core/src/dbi/U2SqlHelpers.h
+++ b/src/corelibs/U2Core/src/dbi/U2SqlHelpers.h
@@ -22,8 +22,8 @@
 #pragma once
 
 #include <QHash>
-#include <QMutex>
 #include <QReadWriteLock>
+#include <QRecursiveMutex>
 #include <QSharedPointer>
 #include <QStringList>
 #include <QThread>
@@ -44,11 +44,11 @@ class SQLiteTransaction;
 class U2CORE_EXPORT DbRef {
 public:
     DbRef(sqlite3* db = nullptr)
-        : handle(db), lock(QMutex::Recursive), useTransaction(true) {
+        : handle(db), useTransaction(true) {
     }
 
     sqlite3* handle;
-    QMutex lock;
+    QRecursiveMutex lock;
     QReadWriteLock rwLock;
     bool useTransaction;
     bool useCache;

--- a/src/corelibs/U2Core/src/globals/ExternalToolRegistry.h
+++ b/src/corelibs/U2Core/src/globals/ExternalToolRegistry.h
@@ -24,6 +24,7 @@
 #include <QIcon>
 #include <QList>
 #include <QMap>
+#include <QRegExp>
 #include <QString>
 #include <QStringList>
 #include <QVariant>

--- a/src/corelibs/U2Core/src/globals/GUrl.cpp
+++ b/src/corelibs/U2Core/src/globals/GUrl.cpp
@@ -23,6 +23,7 @@
 
 #include <QDataStream>
 #include <QDir>
+#include <QRegularExpression>
 
 #include "U2SafePoints.h"
 
@@ -110,7 +111,7 @@ GUrlType GUrl::getURLType(const QString& rawUrl) {
         result = GUrl_Http;
     } else if (rawUrl.startsWith("ftp://")) {
         result = GUrl_Ftp;
-    } else if (!rawUrl.startsWith("file://") && rawUrl.contains(QRegExp("^([\\.\\w-]+@)?[\\.\\w-]+:\\d*(/[\\w-]*)?$"))) {
+    } else if (!rawUrl.startsWith("file://") && rawUrl.contains(QRegularExpression("^([\\.\\w-]+@)?[\\.\\w-]+:\\d*(/[\\w-]*)?$"))) {
         return GUrl_Network;
     } else if (rawUrl.startsWith(U2_VFS_URL_PREFIX)) {
         result = GUrl_VFSFile;

--- a/src/corelibs/U2Core/src/globals/Log.cpp
+++ b/src/corelibs/U2Core/src/globals/Log.cpp
@@ -29,8 +29,7 @@
 
 namespace U2 {
 
-LogServer::LogServer()
-    : listenerMutex(QMutex::Recursive) {
+LogServer::LogServer() {
     qRegisterMetaType<LogMessage>("LogMessage");
 }
 

--- a/src/corelibs/U2Core/src/globals/Log.h
+++ b/src/corelibs/U2Core/src/globals/Log.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <QMetaType>
-#include <QMutex>
+#include <QRecursiveMutex>
 #include <QStringList>
 #include <QTime>
 
@@ -120,7 +120,7 @@ private:
 
     QList<Logger*> loggers;
     QList<LogListener*> listeners;
-    QMutex listenerMutex;
+    QRecursiveMutex listenerMutex;
 };
 
 // TODO: support log category translation + use log category ids instead of the names in code

--- a/src/corelibs/U2Core/src/io/IOAdapterTextStream.cpp
+++ b/src/corelibs/U2Core/src/io/IOAdapterTextStream.cpp
@@ -181,7 +181,7 @@ QChar IOAdapterReader::readChar(U2OpStatus& os) {
     if (unreadCharsBuffer.isEmpty()) {
         stream >> ch;
     } else {
-        SAFE_POINT_EXT(unreadCharsBufferPos < unreadCharsBuffer.size(), os.setError(L10N::internalError()), 0);
+        SAFE_POINT_EXT(unreadCharsBufferPos < unreadCharsBuffer.size(), os.setError(L10N::internalError()), '0');
         ch = unreadCharsBuffer[unreadCharsBufferPos];
         unreadCharsBufferPos++;
         if (unreadCharsBufferPos == unreadCharsBuffer.length()) {

--- a/src/corelibs/U2Core/src/io/IOAdapterTextStream.h
+++ b/src/corelibs/U2Core/src/io/IOAdapterTextStream.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <QBitArray>
+#include <QIODevice>
 #include <QObject>
 #include <QTextStream>
 

--- a/src/corelibs/U2Core/src/tasks/CmdlineTaskRunner.cpp
+++ b/src/corelibs/U2Core/src/tasks/CmdlineTaskRunner.cpp
@@ -19,6 +19,7 @@
  * MA 02110-1301, USA.
  */
 
+#include <QRegularExpression>
 #include <QTextCodec>
 #include <QTimer>
 
@@ -380,7 +381,7 @@ void CmdlineTaskRunner::sl_onReadStandardOutput() {
     }
 
     for (const QString& line : qAsConst(lines)) {
-        QStringList words = line.split(QRegExp("\\s+"), Qt::SkipEmptyParts);
+        QStringList words = line.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
         for (const QString& word : qAsConst(words)) {
             if (word.startsWith(OUTPUT_PROGRESS_TAG)) {
                 QString numStr = word.mid(OUTPUT_PROGRESS_TAG.size());

--- a/src/corelibs/U2Core/src/util/DatatypeSerializeUtils.cpp
+++ b/src/corelibs/U2Core/src/util/DatatypeSerializeUtils.cpp
@@ -22,6 +22,7 @@
 #include "DatatypeSerializeUtils.h"
 
 #include <QBitArray>
+#include <QRegularExpression>
 #include <QStack>
 #include <QtEndian>
 
@@ -227,7 +228,7 @@ static void packTreeNode(QString& resultText, const PhyNode* node, U2OpStatus& o
             resultText.append(QString::number(childBranch->distance));
         }
         resultText.append(")");
-    } else if (node->name.contains(QRegExp("\\s|[(]|[)]|[:]|[;]|[,]"))) {
+    } else if (node->name.contains(QRegularExpression("\\s|[(]|[)]|[:]|[;]|[,]"))) {
         resultText.append(QString("\'%1\'").arg(node->name));
     } else {
         resultText.append(node->name);

--- a/src/corelibs/U2Core/src/util/FilesIterator.h
+++ b/src/corelibs/U2Core/src/util/FilesIterator.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <QDir>
+#include <QRegExp>
 
 #include <U2Core/global.h>
 

--- a/src/corelibs/U2Core/src/util/GUrlUtils.cpp
+++ b/src/corelibs/U2Core/src/util/GUrlUtils.cpp
@@ -22,6 +22,7 @@
 #include "GUrlUtils.h"
 
 #include <QDir>
+#include <QRegularExpression>
 
 #include <U2Core/AppContext.h>
 #include <U2Core/AppSettings.h>
@@ -71,7 +72,7 @@ GUrl GUrlUtils::ensureFileExt(const GUrl& url, const QStringList& typeExt) {
 }
 
 bool GUrlUtils::containSpaces(const QString& string) {
-    return string.contains(QRegExp("\\s"));
+    return string.contains(QRegularExpression("\\s"));
 }
 
 GUrl GUrlUtils::changeFileExt(const GUrl& url, const DocumentFormatId& newFormatId) {
@@ -351,7 +352,7 @@ QString GUrlUtils::getDefaultDataPath() {
 }
 
 QString GUrlUtils::getQuotedString(const QString& inString) {
-    if (inString.contains(QRegExp("\\s"))) {
+    if (inString.contains(QRegularExpression("\\s"))) {
         return "\"" + inString + "\"";
     }
     return inString;
@@ -454,8 +455,8 @@ QString GUrlUtils::getPairedFastqFilesBaseName(const QString& sourceFileUrl, boo
 
 QString GUrlUtils::fixFileName(const QString& fileName) {
     QString result = fileName;
-    result.replace(QRegExp("[^0-9a-zA-Z._\\-]"), "_");
-    result.replace(QRegExp("_+"), "_");
+    result.replace(QRegularExpression("[^0-9a-zA-Z._\\-]"), "_");
+    result.replace(QRegularExpression("_+"), "_");
 
     // Truncate long file names a bit more to allow suffix adjustments (rolling) later.
     result.truncate(MAX_OS_FILE_NAME_LENGTH - 50);

--- a/src/corelibs/U2Core/src/util/StrPackUtils.cpp
+++ b/src/corelibs/U2Core/src/util/StrPackUtils.cpp
@@ -21,6 +21,8 @@
 
 #include <math.h>
 
+#include <QRegularExpression>
+
 #include <U2Core/U2SafePoints.h>
 
 #include "StrPackUtils.h"
@@ -33,16 +35,16 @@ const QString StrPackUtils::MAP_SEPARATOR = ";";
 const QString StrPackUtils::PAIR_CONNECTOR = "=";
 
 const QString StrPackUtils::listSeparatorPattern = QString("^\\%2|(?!\\\\)\\%2%1\\%2|\\%2$").arg(LIST_SEPARATOR);
-const QRegExp StrPackUtils::listSingleQuoteSeparatorRegExp(listSeparatorPattern.arg("\'"));
-const QRegExp StrPackUtils::listDoubleQuoteSeparatorRegExp(listSeparatorPattern.arg("\""));
+const QRegularExpression StrPackUtils::listSingleQuoteSeparatorRegExp(listSeparatorPattern.arg("\'"));
+const QRegularExpression StrPackUtils::listDoubleQuoteSeparatorRegExp(listSeparatorPattern.arg("\""));
 
 const QString StrPackUtils::mapSeparatorPattern = QString("(?!\\\\)\\%2%1\\%2").arg(MAP_SEPARATOR);
-const QRegExp StrPackUtils::mapSingleQuoteSeparatorRegExp(mapSeparatorPattern.arg("\'"));
-const QRegExp StrPackUtils::mapDoubleQuoteSeparatorRegExp(mapSeparatorPattern.arg("\""));
+const QRegularExpression StrPackUtils::mapSingleQuoteSeparatorRegExp(mapSeparatorPattern.arg("\'"));
+const QRegularExpression StrPackUtils::mapDoubleQuoteSeparatorRegExp(mapSeparatorPattern.arg("\""));
 
 const QString StrPackUtils::pairSeparatorPattern = QString("^\\%2|(?!\\\\)\\%2%1\\%2|\\%2$").arg(PAIR_CONNECTOR);
-const QRegExp StrPackUtils::pairSingleQuoteSeparatorRegExp(pairSeparatorPattern.arg("\'"));
-const QRegExp StrPackUtils::pairDoubleQuoteSeparatorRegExp(pairSeparatorPattern.arg("\""));
+const QRegularExpression StrPackUtils::pairSingleQuoteSeparatorRegExp(pairSeparatorPattern.arg("\'"));
+const QRegularExpression StrPackUtils::pairDoubleQuoteSeparatorRegExp(pairSeparatorPattern.arg("\""));
 
 static bool registerMetaTypes() {
     qRegisterMetaType<StrStrMap>("StrStrMap");
@@ -69,7 +71,7 @@ QString StrPackUtils::packStringList(const QStringList& list, Options options) {
 
 QStringList StrPackUtils::unpackStringList(const QString& string, Options options) {
     QStringList unpackedList;
-    const QRegExp separator = (options == SingleQuotes ? listSingleQuoteSeparatorRegExp : listDoubleQuoteSeparatorRegExp);
+    const auto separator = (options == SingleQuotes ? listSingleQuoteSeparatorRegExp : listDoubleQuoteSeparatorRegExp);
     foreach (const QString& escapedString, string.split(separator, Qt::SkipEmptyParts)) {
         unpackedList << unescapeCharacters(escapedString);
     }
@@ -101,9 +103,9 @@ QString StrPackUtils::packMap(const StrStrMap& map, Options options) {
 
 StrStrMap StrPackUtils::unpackMap(const QString& string, Options options) {
     StrStrMap map;
-    QRegExp elementsSeparator = options == SingleQuotes ? mapSingleQuoteSeparatorRegExp : mapDoubleQuoteSeparatorRegExp;
+    auto elementsSeparator = options == SingleQuotes ? mapSingleQuoteSeparatorRegExp : mapDoubleQuoteSeparatorRegExp;
     foreach (const QString& pair, string.split(elementsSeparator, Qt::SkipEmptyParts)) {
-        QRegExp keyValueSeparator = options == SingleQuotes ? pairSingleQuoteSeparatorRegExp : pairDoubleQuoteSeparatorRegExp;
+        auto keyValueSeparator = options == SingleQuotes ? pairSingleQuoteSeparatorRegExp : pairDoubleQuoteSeparatorRegExp;
         QStringList splitPair = pair.split(keyValueSeparator, Qt::SkipEmptyParts);
         Q_ASSERT(splitPair.size() <= 2);
         if (!splitPair.empty()) {  // splitPair can be empty if both key and value are empty strings.

--- a/src/corelibs/U2Core/src/util/StrPackUtils.h
+++ b/src/corelibs/U2Core/src/util/StrPackUtils.h
@@ -24,7 +24,7 @@
 #include <QBitArray>
 #include <QCoreApplication>
 #include <QMap>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QStringList>
 #include <QVariant>
 
@@ -64,16 +64,16 @@ private:
     static const QString PAIR_CONNECTOR;
 
     static const QString listSeparatorPattern;
-    static const QRegExp listSingleQuoteSeparatorRegExp;
-    static const QRegExp listDoubleQuoteSeparatorRegExp;
+    static const QRegularExpression listSingleQuoteSeparatorRegExp;
+    static const QRegularExpression listDoubleQuoteSeparatorRegExp;
 
     static const QString mapSeparatorPattern;
-    static const QRegExp mapSingleQuoteSeparatorRegExp;
-    static const QRegExp mapDoubleQuoteSeparatorRegExp;
+    static const QRegularExpression mapSingleQuoteSeparatorRegExp;
+    static const QRegularExpression mapDoubleQuoteSeparatorRegExp;
 
     static const QString pairSeparatorPattern;
-    static const QRegExp pairSingleQuoteSeparatorRegExp;
-    static const QRegExp pairDoubleQuoteSeparatorRegExp;
+    static const QRegularExpression pairSingleQuoteSeparatorRegExp;
+    static const QRegularExpression pairDoubleQuoteSeparatorRegExp;
 
     static const bool isMetaTypesRegistered;
 };

--- a/src/corelibs/U2Core/src/util/U1AnnotationUtils.cpp
+++ b/src/corelibs/U2Core/src/util/U1AnnotationUtils.cpp
@@ -22,6 +22,7 @@
 #include "U1AnnotationUtils.h"
 
 #include <QStringBuilder>
+#include <QRegExp>
 
 #include <U2Core/AnnotationTableObject.h>
 #include <U2Core/AppContext.h>

--- a/src/corelibs/U2Formats/src/sqlite_dbi/SQLiteDbi.cpp
+++ b/src/corelibs/U2Formats/src/sqlite_dbi/SQLiteDbi.cpp
@@ -200,7 +200,7 @@ void SQLiteDbi::stopOperationBlock(U2OpStatus& os) {
     }
 }
 
-QMutex* SQLiteDbi::getDbMutex() const {
+QRecursiveMutex* SQLiteDbi::getDbMutex() const {
     return &db->lock;
 }
 

--- a/src/corelibs/U2Formats/src/sqlite_dbi/SQLiteDbi.h
+++ b/src/corelibs/U2Formats/src/sqlite_dbi/SQLiteDbi.h
@@ -151,7 +151,7 @@ public:
 
     void stopOperationBlock(U2OpStatus& os) override;
 
-    QMutex* getDbMutex() const override;
+    QRecursiveMutex* getDbMutex() const override;
 
     bool isReadOnly() const override;
 

--- a/src/corelibs/U2Gui/src/MainWindow.h
+++ b/src/corelibs/U2Gui/src/MainWindow.h
@@ -139,9 +139,9 @@ public:
 
     virtual void setNewStyle(const QString& style, int colorThemeIndex) = 0;
 
-    static constexpr char* ICON_PATH_PROPERTY_NAME = "icon-path";
-    static constexpr char* MOVIE_PATH_PROPERTY_NAME = "icon-path-movie";
-    static constexpr char* WINDOWS_ICON_PATH_PROPERTY_NAME = "icon-path-movie";
+    static constexpr const char* ICON_PATH_PROPERTY_NAME = "icon-path";
+    static constexpr const char* MOVIE_PATH_PROPERTY_NAME = "icon-path-movie";
+    static constexpr const char* WINDOWS_ICON_PATH_PROPERTY_NAME = "icon-path-movie";
     static constexpr int PIXMAP_SIZE = 16;
 
 signals:

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyModel.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyModel.cpp
@@ -659,7 +659,7 @@ U2SequenceObject* AssemblyModel::getRefObj() const {
 }
 
 bool AssemblyModel::isDbLocked(int timeout) const {
-    QMutex* mutex = dbiHandle.dbi->getDbMutex();
+    QRecursiveMutex* mutex = dbiHandle.dbi->getDbMutex();
     CHECK(mutex != nullptr, false);
     if (mutex->tryLock(timeout)) {
         mutex->unlock();


### PR DESCRIPTION
Пересоздаю PR, немного не удачно получилось с тем. Еще раз, изменения:
- Замена QMutex с флагом QMutex::Recursive на QRecursiveMutex. Технически это одно и то же, но этот флаг был удален в Qt6
- Добавление хедеров в места, где в Qt6 были потеряны определения
- Исправление неявных преобразований, которые стали некорректными
- Замена QString::midRef который: 1. удален в Qt6, 2. вообще здесь не в тему, на QString::mid
- Сам по себе QRegExp можно сохранить, используя Qt5 compatibility, но QString больше не содержит QRegExp в качестве аргументов своих функций
- QRegExpr доступен через Qt5 compatibility module, а вот QRegExpValidator - нет, поэтому его надо заменить на QRegularExpressionValidator. Работают они одинакого