### PR TITLE
Make possible to extract Assembly Browser as a separate widget

### DIFF
--- a/src/corelibs/U2Gui/src/ObjectViewModel.cpp
+++ b/src/corelibs/U2Gui/src/ObjectViewModel.cpp
@@ -473,7 +473,10 @@ void GObjectViewWindow::setupViewMenu(QMenu* m) {
 /// Utils
 
 GObjectViewWindow* GObjectViewUtils::findViewByName(const QString& name) {
-    QList<MWMDIWindow*> mdiWindows = AppContext::getMainWindow()->getMDIManager()->getWindows();
+    auto mdiManager = AppContext::getMainWindow()->getMDIManager();
+    CHECK(mdiManager != nullptr, nullptr);
+
+    QList<MWMDIWindow*> mdiWindows = mdiManager->getWindows();
     for (MWMDIWindow* mdiWindow : qAsConst(mdiWindows)) {
         if (mdiWindow->windowTitle() == name) {
             auto objectViewWindow = qobject_cast<GObjectViewWindow*>(mdiWindow);
@@ -549,7 +552,10 @@ GObjectViewState* GObjectViewUtils::findStateInList(const QString& viewName, con
 }
 
 QList<GObjectViewWindow*> GObjectViewUtils::getAllActiveViews() {
-    QList<MWMDIWindow*> mdiWindows = AppContext::getMainWindow()->getMDIManager()->getWindows();
+    auto mdiManager = AppContext::getMainWindow()->getMDIManager();
+    CHECK(mdiManager != nullptr, {});
+
+    QList<MWMDIWindow*> mdiWindows = mdiManager->getWindows();
     QList<GObjectViewWindow*> objectViewWindows;
     for (MWMDIWindow* mdiWindow : qAsConst(mdiWindows)) {
         auto objectViewWindow = qobject_cast<GObjectViewWindow*>(mdiWindow);

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyBrowser.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyBrowser.cpp
@@ -610,6 +610,8 @@ void AssemblyBrowser::adjustOffsets(qint64 dx, qint64 dy) {
 }
 
 void AssemblyBrowser::setFocusToPosSelector() {
+    CHECK(posSelector != nullptr, );
+
     posSelector->getPosEdit()->setFocus();
 }
 

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyBrowser.h
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyBrowser.h
@@ -45,7 +45,7 @@ class PositionSelector;
 class AssemblyCellRendererFactoryRegistry;
 class OptionsPanelController;
 
-class AssemblyBrowser : public GObjectViewController {
+class U2VIEW_EXPORT AssemblyBrowser : public GObjectViewController {
     Q_OBJECT
 public:
     AssemblyBrowser(const QString& viewName, AssemblyObject* o);
@@ -164,6 +164,8 @@ public:
 
     bool onCloseEvent() override;
 
+    static constexpr const char* ONLY_ASSEMBLY_BROWSER = "only-assembly-browser";
+
 public slots:
     void sl_zoomIn(const QPoint& pos = QPoint());
     void sl_zoomOut(const QPoint& pos = QPoint());
@@ -219,6 +221,11 @@ private:
     QString chooseReferenceUrl() const;
     void loadReferenceFromFile();
     void showReferenceLoadingError(const QList<GObject*>& sequenceObjects, const QString& url) const;
+
+public:
+    // Set sequence from the @doc reference to the current Assembly Browser instance.
+    // @doc pointer to the Documetn. If there are several sequences in this document,
+    //  the first one will be added as a reference.
     void setReference(const Document* doc);
 
 private:

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyBrowserTasks.h
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyBrowserTasks.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <U2Core/GObjectReference.h>
+#include <U2Core/global.h>
 
 #include <U2Gui/ObjectViewTasks.h>
 

--- a/src/corelibs/U2View/src/ov_assembly/AssemblyReferenceArea.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/AssemblyReferenceArea.cpp
@@ -195,6 +195,11 @@ QByteArray AssemblyReferenceArea::getSequenceRegion(U2OpStatus& os) {
 }
 
 void AssemblyReferenceArea::mousePressEvent(QMouseEvent* e) {
+    if (qEnvironmentVariableIsSet(AssemblyBrowser::ONLY_ASSEMBLY_BROWSER)) {
+        AssemblySequenceArea::mousePressEvent(e);
+        return;
+    }
+
     if (e->button() == Qt::RightButton) {
         referenceAreaMenu->exec(QCursor::pos());
     }

--- a/src/corelibs/U2View/src/ov_assembly/ExportConsensusDialog.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/ExportConsensusDialog.cpp
@@ -21,6 +21,7 @@
 
 #include "ExportConsensusDialog.h"
 
+#include <QtGlobal>
 #include <QMessageBox>
 #include <QPushButton>
 
@@ -33,6 +34,8 @@
 #include <U2Gui/HelpButton.h>
 #include <U2Gui/RegionSelector.h>
 #include <U2Gui/SaveDocumentController.h>
+
+#include "AssemblyBrowser.h"
 
 namespace U2 {
 
@@ -61,6 +64,11 @@ ExportConsensusDialog::ExportConsensusDialog(QWidget* p, const ExportConsensusTa
     addToProjectCheckBox->setChecked(settings.addToProject);
     regionSelector->setCustomRegion(settings.region);
     keepGapsCheckBox->setChecked(settings.keepGaps);
+
+    if (qEnvironmentVariableIsSet(AssemblyBrowser::ONLY_ASSEMBLY_BROWSER)) {
+        addToProjectCheckBox->setChecked(false);
+        addToProjectCheckBox->hide();
+    }
 
     QList<QString> algos = AppContext::getAssemblyConsensusAlgorithmRegistry()->getAlgorithmIds();
     algorithmComboBox->addItems(algos);

--- a/src/corelibs/U2View/src/ov_assembly/ExportConsensusVariationsDialog.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/ExportConsensusVariationsDialog.cpp
@@ -34,6 +34,8 @@
 #include <U2Gui/RegionSelector.h>
 #include <U2Gui/SaveDocumentController.h>
 
+#include "AssemblyBrowser.h"
+
 namespace U2 {
 
 ExportConsensusVariationsDialog::ExportConsensusVariationsDialog(QWidget* p, const ExportConsensusVariationsTaskSettings& settings_, const U2Region& visibleRegion)
@@ -61,6 +63,11 @@ ExportConsensusVariationsDialog::ExportConsensusVariationsDialog(QWidget* p, con
     addToProjectCheckBox->setChecked(settings.addToProject);
     regionSelector->setCustomRegion(settings.region);
     keepGapsCheckBox->setChecked(settings.keepGaps);
+
+    if (qEnvironmentVariableIsSet(AssemblyBrowser::ONLY_ASSEMBLY_BROWSER)) {
+        addToProjectCheckBox->setChecked(false);
+        addToProjectCheckBox->hide();
+    }
 
     QList<QString> algos = AppContext::getAssemblyConsensusAlgorithmRegistry()->getAlgorithmIds();
     algorithmComboBox->addItems(algos);

--- a/src/corelibs/U2View/src/ov_assembly/ExportReadsDialog.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/ExportReadsDialog.cpp
@@ -33,6 +33,8 @@
 #include <U2Gui/LastUsedDirHelper.h>
 #include <U2Gui/SaveDocumentController.h>
 
+#include "AssemblyBrowser.h"
+
 namespace U2 {
 
 ExportReadsDialog::ExportReadsDialog(QWidget* p, const QList<DocumentFormatId>& formats)
@@ -58,6 +60,11 @@ ExportReadsDialog::ExportReadsDialog(QWidget* p, const QList<DocumentFormatId>& 
 
     saveController = new SaveDocumentController(conf, formats, this);
     setMaximumHeight(layout()->minimumSize().height());
+
+    if (qEnvironmentVariableIsSet(AssemblyBrowser::ONLY_ASSEMBLY_BROWSER)) {
+        addToProjectCheckBox->setChecked(false);
+        addToProjectCheckBox->hide();
+    }
 }
 
 void ExportReadsDialog::accept() {

--- a/src/corelibs/U2View/src/ov_assembly/ExtractAssemblyRegionDialog.cpp
+++ b/src/corelibs/U2View/src/ov_assembly/ExtractAssemblyRegionDialog.cpp
@@ -29,6 +29,8 @@
 #include <U2Gui/RegionSelector.h>
 #include <U2Gui/SaveDocumentController.h>
 
+#include "AssemblyBrowser.h"
+
 namespace U2 {
 
 ExtractAssemblyRegionDialog::ExtractAssemblyRegionDialog(QWidget* p, ExtractAssemblyRegionTaskSettings* settings)
@@ -50,6 +52,11 @@ ExtractAssemblyRegionDialog::ExtractAssemblyRegionDialog(QWidget* p, ExtractAsse
 
     setMaximumHeight(layout()->minimumSize().height());
     connect(regionSelector, SIGNAL(si_regionChanged(const U2Region&)), SLOT(sl_regionChanged(const U2Region&)));
+
+    if (qEnvironmentVariableIsSet(AssemblyBrowser::ONLY_ASSEMBLY_BROWSER)) {
+        addToProjectCheckBox->setChecked(false);
+        addToProjectCheckBox->hide();
+    }
 }
 
 void ExtractAssemblyRegionDialog::sl_regionChanged(const U2Region& newRegion) {


### PR DESCRIPTION
В рамках одного из проектов, нам понадобится возможность вытащить Assembly Browser в качестве отдельного виджета. Мне удалось это сделать, но ядро UGENE потребует следующих доработок:

- AB находится внутри `MDIWidget`, если нет `MDIWidget`, то не нужен и `MDIManager`, а в некоторых местах нет проверки `MDIManager` на `nullptr`.
- Класс `AssemblyBrowser` должен заиметь `U2VIEW_EXPORT`, т.к. к нему потребуется доступ "снаружи".
- Функцию `setReference()` перенес в `public`, т.к. она оказалась нужна.
- `posSelector` находится на тулбаре, за пределами AB. Нет тулбара -> нет `posSelector`, а проверки на `nullptr` тоже не было.
- Диалоги экспорта содержат чекбокс "Add to project", а проекта, в привычном понимании, у отдельного AB нет. Добавил переменную окружения, на которую этот чекбокс скрывается.