### PR TITLE
UGENE падает с установленной Aspera

### DIFF
--- a/src/corelibs/U2Gui/src/util/U2FileDialog.cpp
+++ b/src/corelibs/U2Gui/src/util/U2FileDialog.cpp
@@ -41,14 +41,18 @@ namespace U2 {
 class FileDialogCrashGuard {
 public:
     FileDialogCrashGuard() {
+        // The guard is not needed if non-native dialogs are used, as they are implemented in Qt and should not cause crashes.
         CHECK(!U2FileDialog::FORCE_USE_NON_NATIVE_DIALOG, );
 
+        // Set the flag to detect crashes caused by QFileDialog. The flag will be reset in the destructor.
         AppContext::getSettings()->setValue(U2FileDialog::CRASH_DETECTING_SETTINGS_ROOT, true);
     }
 
     ~FileDialogCrashGuard() {
+        // The guard is not needed if non-native dialogs are used, as they are implemented in Qt and should not cause crashes.
         CHECK(!U2FileDialog::FORCE_USE_NON_NATIVE_DIALOG, );
 
+        // Reset the flag after the dialog is closed.
         AppContext::getSettings()->setValue(U2FileDialog::CRASH_DETECTING_SETTINGS_ROOT, false);
     }
 };

--- a/src/corelibs/U2Gui/src/util/U2FileDialog.cpp
+++ b/src/corelibs/U2Gui/src/util/U2FileDialog.cpp
@@ -41,10 +41,14 @@ namespace U2 {
 class FileDialogCrashGuard {
 public:
     FileDialogCrashGuard() {
+        CHECK(!U2FileDialog::FORCE_USE_NON_NATIVE_DIALOG, );
+
         AppContext::getSettings()->setValue(U2FileDialog::CRASH_DETECTING_SETTINGS_ROOT, true);
     }
 
     ~FileDialogCrashGuard() {
+        CHECK(!U2FileDialog::FORCE_USE_NON_NATIVE_DIALOG, );
+
         AppContext::getSettings()->setValue(U2FileDialog::CRASH_DETECTING_SETTINGS_ROOT, false);
     }
 };

--- a/src/corelibs/U2Gui/src/util/U2FileDialogPolicy.cpp
+++ b/src/corelibs/U2Gui/src/util/U2FileDialogPolicy.cpp
@@ -53,9 +53,10 @@ void U2FileDialogPolicy::checkIfShouldUseNonNativeDialog() {
         // This is the highest Aspera Connect version this problem reproduces
         // Increase this value if crash report with higher Aspera Connect verion recieved
         static const QString MIN_MALICIOUS_ASPERA_VERSION = "4.2.12.780";
+        bool doNotCheckMaliciousEnv = qgetenv(UGENE_DO_NOT_CHECK_MALICIOUS) == "1";
         bool isMalicious = versionLessThan(version, MIN_MALICIOUS_ASPERA_VERSION);
         bool crashedPreviously = settings->getValue(U2FileDialog::CRASH_DETECTING_SETTINGS_ROOT, false).toBool();
-        if (isMalicious) {
+        if (isMalicious && !doNotCheckMaliciousEnv) {
             coreLog.details(QObject::tr("Aspera Connect malicious version detected, switching to non-native dialog..."));
             U2FileDialog::FORCE_USE_NON_NATIVE_DIALOG = true;
         } else if (crashedPreviously) {

--- a/src/corelibs/U2Gui/src/util/U2FileDialogPolicy.cpp
+++ b/src/corelibs/U2Gui/src/util/U2FileDialogPolicy.cpp
@@ -53,10 +53,10 @@ void U2FileDialogPolicy::checkIfShouldUseNonNativeDialog() {
         // This is the highest Aspera Connect version this problem reproduces
         // Increase this value if crash report with higher Aspera Connect verion recieved
         static const QString MIN_MALICIOUS_ASPERA_VERSION = "4.2.12.780";
-        bool doNotCheckMaliciousEnv = qgetenv(UGENE_DO_NOT_CHECK_MALICIOUS) == "1";
+        bool skipFileDialogCompatibilityCheck = qgetenv(UGENE_SKIP_FILE_DIALOG_COMPATIBILITY_CHECK) == "1";
         bool isMalicious = versionLessThan(version, MIN_MALICIOUS_ASPERA_VERSION);
         bool crashedPreviously = settings->getValue(U2FileDialog::CRASH_DETECTING_SETTINGS_ROOT, false).toBool();
-        if (isMalicious && !doNotCheckMaliciousEnv) {
+        if (isMalicious && !skipFileDialogCompatibilityCheck) {
             coreLog.details(QObject::tr("Aspera Connect malicious version detected, switching to non-native dialog..."));
             U2FileDialog::FORCE_USE_NON_NATIVE_DIALOG = true;
         } else if (crashedPreviously) {

--- a/src/corelibs/U2Gui/src/util/U2FileDialogPolicy.h
+++ b/src/corelibs/U2Gui/src/util/U2FileDialogPolicy.h
@@ -54,12 +54,12 @@ private:
     // @return true if Aspera Connect library is found and version is detected, false otherwise.
     static bool detectAsperaVersion(QString& outVersion);
 
-    // Environment variable name to disable malicious software check.
-    // Disabling malicious software check may be require for testing purposes.
+    // Environment variable name to skip file dialog compatibility check.
+    // Disabling file dialog compatibility check may be require for testing purposes.
     // If this variable is set to "1", the check will be desabled and native dialogs will be used even if malicious software is detected.
     // But, if UGENE.ini file contains the information that UGENE crashed previously with native dialog,
     // the non-native dialog will be used anyway to avoid possible crashes in this case, even if the environment variable is set.
-    static constexpr const char* UGENE_DO_NOT_CHECK_MALICIOUS = "UGENE_DO_NOT_CHECK_MALICIOUS";
+    static constexpr const char* UGENE_SKIP_FILE_DIALOG_COMPATIBILITY_CHECK = "UGENE_SKIP_FILE_DIALOG_COMPATIBILITY_CHECK";
 
 };
 

--- a/src/corelibs/U2Gui/src/util/U2FileDialogPolicy.h
+++ b/src/corelibs/U2Gui/src/util/U2FileDialogPolicy.h
@@ -54,6 +54,13 @@ private:
     // @return true if Aspera Connect library is found and version is detected, false otherwise.
     static bool detectAsperaVersion(QString& outVersion);
 
+    // Environment variable name to disable malicious software check.
+    // Disabling malicious software check may be require for testing purposes.
+    // If this variable is set to "1", the check will be desabled and native dialogs will be used even if malicious software is detected.
+    // But, if UGENE.ini file contains the information that UGENE crashed previously with native dialog,
+    // the non-native dialog will be used anyway to avoid possible crashes in this case, even if the environment variable is set.
+    static constexpr const char* UGENE_DO_NOT_CHECK_MALICIOUS = "UGENE_DO_NOT_CHECK_MALICIOUS";
+
 };
 
 }  // namespace U2


### PR DESCRIPTION
Был заведен флаг `file_dialog/dialog_opened`, который добавляется в `UGENE.ini` перед каждым открытием диалога `QDileDialog` и удаляется после закрытия. Если при запуске UGENE этот флаг есть в ini-файле, значит UGENE крешнулся во время диалога и диалог надо заменить на не-нативный. Открытие не-нативного диалога во время второго запуска так же обрамляется добавлением и удалением соответствующего флага. Из-за этого, при третьем запуске флага уже не будет, UGENE снова попытается нарисовать нативный диалог и крешнется.

Сценарий (только на релизе):
1. Установить Aspera Connect из задачи https://github.com/ugeneunipro/ugene/issues/1874
2. Выставить переменную окружения `UGENE_SKIP_FILE_DIALOG_COMPATIBILITY_CHECK=1`. Не нативный диалог больше не будет рисоваться из-за версии Aspera Connect.
3. Запустить UGENE, нажать "Открыть файл", кликнуть правой кнопкой мыши по любому файлу.
Ожидание: UGENE упал.
4. Перезапустить UGENE, нажать "Открыть файл"
Ожидание: появился не-нативный диалог.
6. Закрыть диалог, перезапустить UGENE, нажать "Открыть файл".
Ожидание: снова появился не-нативный диалог.