### PR TITLE
"Document is empty" on opening a "FASTA" file with merged header and sequence #1917

### DIFF
--- a/src/corelibs/U2Formats/src/FastaFormat.cpp
+++ b/src/corelibs/U2Formats/src/FastaFormat.cpp
@@ -276,9 +276,9 @@ static void load(IOAdapterReader& reader, const U2DbiRef& dbiRef, const QVariant
 
     CHECK_OP_EXT(os, qDeleteAll(objects); objects.clear(), );
     bool isEmptyFileAllowed = hints.value(DocumentReadingMode_AllowEmptyFile).toBool();
-    CHECK_EXT(headerFound && (!objects.isEmpty() || mergeIntoSingleSequence || isEmptyFileAllowed), 
-                               os.setError(FastaFormat::tr("FASTA header is found in the file, but no sequence data are provided.")), );
-    CHECK_EXT(!objects.isEmpty() || mergeIntoSingleSequence || isEmptyFileAllowed, os.setError(Document::tr("Document is empty.")), );
+    CHECK_EXT(!objects.isEmpty() || mergeIntoSingleSequence || isEmptyFileAllowed, headerFound ?
+                os.setError(FastaFormat::tr("FASTA header is found in the file, but no sequence data are provided.")) :
+                os.setError(Document::tr("Document is empty.")), );
     SAFE_POINT(headers.size() == mergedMapping.size(), "headers <-> regions mapping failed!", );
     ioLog.trace("All sequences are processed");
 

--- a/src/corelibs/U2Formats/src/FastaFormat.cpp
+++ b/src/corelibs/U2Formats/src/FastaFormat.cpp
@@ -174,11 +174,13 @@ static void load(IOAdapterReader& reader, const U2DbiRef& dbiRef, const QVariant
 
     int objectsCountLimit = hints.contains(DocumentReadingMode_MaxObjectsInDoc) ? hints[DocumentReadingMode_MaxObjectsInDoc].toInt() : INT_MAX;
     bool makeUniqueSequenceNames = !hints.value(DocumentReadingMode_DontMakeUniqueNames, false).toBool();
+    bool headerFound = false;
     while (!os.isCoR() && !reader.atEnd()) {
         skipLeadingWhitesAndComments(reader, os);
         CHECK_OP(os, );
 
         QString header = readHeader(reader, os).trimmed();
+        headerFound = headerFound || !header.isEmpty();
         CHECK_OP(os, );
 
         // Construct sequence name.
@@ -274,6 +276,8 @@ static void load(IOAdapterReader& reader, const U2DbiRef& dbiRef, const QVariant
 
     CHECK_OP_EXT(os, qDeleteAll(objects); objects.clear(), );
     bool isEmptyFileAllowed = hints.value(DocumentReadingMode_AllowEmptyFile).toBool();
+    CHECK_EXT(headerFound && (!objects.isEmpty() || mergeIntoSingleSequence || isEmptyFileAllowed), 
+                               os.setError(FastaFormat::tr("FASTA header is found in the file, but no sequence data are provided.")), );
     CHECK_EXT(!objects.isEmpty() || mergeIntoSingleSequence || isEmptyFileAllowed, os.setError(Document::tr("Document is empty.")), );
     SAFE_POINT(headers.size() == mergedMapping.size(), "headers <-> regions mapping failed!", );
     ioLog.trace("All sequences are processed");

--- a/src/corelibs/U2Formats/transl/russian.ts
+++ b/src/corelibs/U2Formats/transl/russian.ts
@@ -1158,6 +1158,11 @@
         <translation>The file format is invalid.</translation>
     </message>
     <message>
+        <location filename="../src/FastaFormat.cpp" line="280"/>
+        <source>FASTA header is found in the file, but no sequence data are provided.</source>
+        <translation>FASTA заголовок найден файле, но последовательность отсутствует.</translation>
+    </message>
+    <message>
         <location filename="../src/FastaFormat.cpp" line="283"/>
         <source>Loaded sequences: %1. 
 </source>

--- a/tests/cmdline/common/custom/1998/test_0001.xml
+++ b/tests/cmdline/common/custom/1998/test_0001.xml
@@ -2,6 +2,6 @@
     <run-cmdline task="!common_data_dir!cmdline/custom/1998/1998.uws"
                  names="!common_data_dir!cmdline/custom/1998/names.txt"
                  in="!common_data_dir!cmdline/custom/1998/empty.fa"
-                 message="Document is empty"/>
+                 message="FASTA header is found in the file, but no sequence data are provided."/>
 
 </multi-test>

--- a/tests/doc_format/fasta/negative/test_0005.xml
+++ b/tests/doc_format/fasta/negative/test_0005.xml
@@ -1,5 +1,6 @@
 <multi-test>
 
-    <load-broken-document index="doc" url="fasta/broken/headers_only.fa" io="local_file" format="fasta"/>
+    <load-broken-document index="doc" url="fasta/broken/headers_only.fa" io="local_file" format="fasta" 
+                          message="FASTA header is found in the file, but no sequence data are provided."/>
 
 </multi-test>


### PR DESCRIPTION
Немного поменял исходное сообщение, так как имя файла уже есть в составном сообщении от родительской таски.