### PR TITLE
Update removed UniProt test accession

### DIFF
--- a/src/corelibs/U2Core/src/tasks/LoadRemoteDocumentTask.cpp
+++ b/src/corelibs/U2Core/src/tasks/LoadRemoteDocumentTask.cpp
@@ -689,7 +689,7 @@ RemoteDBRegistry::RemoteDBRegistry() {
     hints.insert(PDB, QObject::tr("Use PDB molecule four-letter identifier. For example: %1 or %2").arg(makeIDLink("3INS")).arg(makeIDLink("1CRN")));
     hints.insert(SWISS_PROT, QObject::tr("Use SWISS-PROT accession number. For example: %1 or %2").arg(makeIDLink("Q9IGQ6")).arg(makeIDLink("A0N8V2")));
     hints.insert(UNIPROTKB_SWISS_PROT, QObject::tr("Use UniProtKB/Swiss-Prot accession number. For example: %1").arg(makeIDLink("P16152")));
-    hints.insert(UNIPROTKB_TREMBL, QObject::tr("Use UniProtKB/TrEMBL accession number. For example: %1").arg(makeIDLink("D0VTW9")));
+    hints.insert(UNIPROTKB_TREMBL, QObject::tr("Use UniProtKB/TrEMBL accession number. For example: %1").arg(makeIDLink("B1ALH6")));
 }
 
 RemoteDBRegistry& RemoteDBRegistry::getRemoteDBRegistry() {

--- a/src/plugins/GUITestBase/src/tests/common_scenarios/project/remote_request/GTTestsProjectRemoteRequest.cpp
+++ b/src/plugins/GUITestBase/src/tests/common_scenarios/project/remote_request/GTTestsProjectRemoteRequest.cpp
@@ -355,19 +355,19 @@ GUI_TEST_CLASS_DEFINITION(test_0013) {
 GUI_TEST_CLASS_DEFINITION(test_0014) {
     //    1. Select {File -> Access remote database} menu item in the main menu.
     //    2. Fill the dialog:
-    //        Resource ID: D0VTW9
+    //        Resource ID: B1ALH6
     //        Database: UniProtKB/TrEMBL
     //        Save to folder: any valid path and accept it.
     //    Expected state: after the downloading task finish a new documents appears in the project
 
     QDir().mkpath(sandBoxDir + "remote_request/test_0014");
 
-    GTUtilsDialog::waitForDialog(new RemoteDBDialogFillerDeprecated("D0VTW9", 6, true, true, false, sandBoxDir));
+    GTUtilsDialog::waitForDialog(new RemoteDBDialogFillerDeprecated("B1ALH6", 6, true, true, false, sandBoxDir));
     GTMenu::clickMainMenuItem({"File", "Access remote database..."});
     GTUtilsTaskTreeView::waitTaskFinished();
 
-    GTUtilsDocument::isDocumentLoaded("D0VTW9.txt");
-    GTUtilsDocument::checkDocument("D0VTW9.txt", AnnotatedDNAViewFactory::ID);
+    GTUtilsDocument::isDocumentLoaded("B1ALH6.txt");
+    GTUtilsDocument::checkDocument("B1ALH6.txt", AnnotatedDNAViewFactory::ID);
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0015) {
@@ -486,14 +486,14 @@ GUI_TEST_CLASS_DEFINITION(test_0016_6) {
 GUI_TEST_CLASS_DEFINITION(test_0016_7) {
     QList<DownloadRemoteFileDialogFiller::Action> actions;
     actions << DownloadRemoteFileDialogFiller::Action(DownloadRemoteFileDialogFiller::SetDatabase, "UniProtKB/TrEMBL");
-    actions << DownloadRemoteFileDialogFiller::Action(DownloadRemoteFileDialogFiller::SetResourceIds, "D0VTW9");
+    actions << DownloadRemoteFileDialogFiller::Action(DownloadRemoteFileDialogFiller::SetResourceIds, "B1ALH6");
     actions << DownloadRemoteFileDialogFiller::Action(DownloadRemoteFileDialogFiller::EnterSaveToDirectoryPath, sandBoxDir);
     actions << DownloadRemoteFileDialogFiller::Action(DownloadRemoteFileDialogFiller::ClickOk, "");
 
     GTUtilsDialog::waitForDialog(new DownloadRemoteFileDialogFiller(actions));
     GTMenu::clickMainMenuItem({"File", "Access remote database..."}, GTGlobals::UseKey);
     GTUtilsTaskTreeView::waitTaskFinished();
-    GTUtilsNotifications::checkNotificationReportText("https://www.uniprot.org/uniprotkb/D0VTW9/entry");
+    GTUtilsNotifications::checkNotificationReportText("https://www.uniprot.org/uniprotkb/B1ALH6/entry");
 }
 
 GUI_TEST_CLASS_DEFINITION(test_0017) {

--- a/tests/cmdline/common/read_db/test_0009.xml
+++ b/tests/cmdline/common/read_db/test_0009.xml
@@ -2,11 +2,11 @@
     <run-cmdline
             task="!common_data_dir!cmdline/read-write/read_db_write_fa.uws"
             db="UniProtKB/TrEMBL"
-            id="D0VTW9"
+            id="B1ALH6"
             save="!tmp_data_dir!"
             out="!tmp_data_dir!test_0009.fa"/>
 
-    <load-document index="doc1" url="D0VTW9.txt" io="local_file" format="swiss-prot" dir="temp"/>
+    <load-document index="doc1" url="B1ALH6.txt" io="local_file" format="swiss-prot" dir="temp"/>
     <load-document index="doc2" url="test_0009.fa" io="local_file" format="fasta" dir="temp"/>
 
     <compare-sequences-in-two-objects doc="doc1" value="doc2"/>


### PR DESCRIPTION
Судя по логам тимсити, тесты проходили 2 апреля, а 11 июня стали падать. Между этим прогонов нет, т.к. тимсити не гонит тесты, если нет изменений. 10 июня Uniprot [сообщили о](https://www.uniprot.org/release-notes/2026-06-10-release) крупной реорганизации структуры своей БД. По видимости, именно после этого ресурс с ID `D0VTW9` перестал находиться. Решил проблему заменой на валидный ID'шник.