### PR TITLE
Set UGENE version to 53.1-dev for Windows XML tests

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -1,7 +1,7 @@
 # UGENE version definition
 
 set(UGENE_VER_MAJOR 53)
-set(UGENE_VER_MINOR 0)
+set(UGENE_VER_MINOR 1)
 set(UGENE_VER_SUFFIX "-dev") # optional, like "-dev" or ""
 
 set(UGENE_VERSION "${UGENE_VER_MAJOR}.${UGENE_VER_MINOR}${UGENE_VER_SUFFIX}")


### PR DESCRIPTION
XML тесты на винде валятся из-за того, что версия не дампнута